### PR TITLE
chore(get_account_id.sh): get_account_id.sh is required for examples

### DIFF
--- a/scripts/get_account_id.sh
+++ b/scripts/get_account_id.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# this script could be more generalized but just for now
+cat $1 | node -e 'process.stdout.write(JSON.parse(require("fs").readFileSync("/dev/stdin", "utf8")).id);'


### PR DESCRIPTION
Though `get_account_id.sh` is required for examples, it seems that I forgot to add this file when I
was making the PR #232. I'm sorry.

Signed-off-by: Taiga Nakayama <dora@dora-gt.jp>