### PR TITLE
Allow accounts to be created at different times

### DIFF
--- a/crates/interledger-api/Cargo.toml
+++ b/crates/interledger-api/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = "1.0.39"
 tower-web = "0.3.7"
 reqwest = "0.9.18"
 url = "2.1.0"
+tokio-executor = "0.1.7"
 tokio-retry = "0.2.0"
 
 [badges]

--- a/crates/interledger-api/Cargo.toml
+++ b/crates/interledger-api/Cargo.toml
@@ -27,7 +27,7 @@ tower-web = "0.3.7"
 reqwest = "0.9.18"
 url = "2.1.0"
 tokio-executor = "0.1.7"
-tokio-retry = "0.2.0"
+futures-retry = "0.3.3"
 
 [badges]
 circle-ci = { repository = "interledger-rs/interledger-rs" }

--- a/crates/interledger-api/Cargo.toml
+++ b/crates/interledger-api/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1.0.39"
 tower-web = "0.3.7"
 reqwest = "0.9.18"
 url = "2.1.0"
-tokio-executor = "0.1.7"
+tokio-retry = "0.2.0"
 futures-retry = "0.3.3"
 
 [badges]

--- a/crates/interledger-api/src/client.rs
+++ b/crates/interledger-api/src/client.rs
@@ -1,13 +1,13 @@
 // Adapted from the futures-retry example: https://gitlab.com/mexus/futures-retry/blob/master/examples/tcp-client-complex.rs
 use futures::future::Future;
 use futures_retry::{ErrorHandler, FutureRetry, RetryPolicy};
+use http::StatusCode;
 use log::trace;
 use reqwest::r#async::Client as HTTPClient;
 use serde_json::json;
 use std::fmt::Display;
 use std::time::Duration;
 use url::Url;
-use http::StatusCode;
 
 // The account creation endpoint set by the engines in [RFC536](https://github.com/interledger/rfcs/pull/536)
 static ACCOUNTS_ENDPOINT: &str = "accounts";

--- a/crates/interledger-api/src/client.rs
+++ b/crates/interledger-api/src/client.rs
@@ -1,0 +1,122 @@
+// Adapted from the futures-retry example: https://gitlab.com/mexus/futures-retry/blob/master/examples/tcp-client-complex.rs
+use futures::future::Future;
+use futures_retry::{ErrorHandler, FutureRetry, RetryPolicy};
+use log::{debug, error, trace};
+use reqwest::r#async::Client as HTTPClient;
+use serde_json::json;
+use std::fmt::Display;
+use std::time::Duration;
+use url::Url;
+
+// The account creation endpoint set by the engines in [RFC536](https://github.com/interledger/rfcs/pull/536)
+static ACCOUNTS_ENDPOINT: &str = "accounts";
+
+pub struct Client {
+    timeout_ms: Duration,
+    max_retries: usize,
+}
+
+impl Client {
+    /// Timeout duration is in millisecodns
+    pub fn new(timeout_ms: Duration, max_retries: usize) -> Self {
+        Client {
+            timeout_ms,
+            max_retries,
+        }
+    }
+
+    pub fn create_engine_account<T: Display + Copy>(
+        &self,
+        engine_url: Url,
+        id: T,
+    ) -> impl Future<Item = (), Error = reqwest::Error> {
+        let mut se_url = engine_url.clone();
+        let timeout = self.timeout_ms;
+        se_url
+            .path_segments_mut()
+            .expect("Invalid settlement engine URL")
+            .push(ACCOUNTS_ENDPOINT);
+        trace!(
+            "Sending account {} creation request to settlement engine: {:?}",
+            id,
+            se_url.clone()
+        );
+
+        // The actual HTTP request which gets made to the engine
+        let create_settlement_engine_account = move || {
+            let client = HTTPClient::builder().timeout(timeout).build().unwrap();
+            client
+                .post(se_url.as_ref())
+                .json(&json!({"id" : id.to_string()}))
+                .send()
+                .and_then(move |response| {
+                    trace!("Engine responded with status code: {}", response.status());
+                    // TODO: Do something with the success status code?
+                    Ok(())
+                })
+        };
+
+        FutureRetry::new(
+            create_settlement_engine_account,
+            IoHandler::new(
+                self.max_retries,
+                format!("[Engine: {}, Account: {}]", engine_url, id),
+            ),
+        )
+    }
+}
+
+/// An I/O handler that counts attempts.
+struct IoHandler<D> {
+    max_attempts: usize,
+    current_attempt: usize,
+    display_name: D,
+}
+
+impl<D> IoHandler<D> {
+    fn new(max_attempts: usize, display_name: D) -> Self {
+        IoHandler {
+            max_attempts,
+            current_attempt: 0,
+            display_name,
+        }
+    }
+}
+
+// The error handler trait implements the Retry logic based on the received
+// Error Status Code.
+impl<D> ErrorHandler<reqwest::Error> for IoHandler<D>
+where
+    D: ::std::fmt::Display,
+{
+    type OutError = reqwest::Error;
+
+    fn handle(&mut self, e: reqwest::Error) -> RetryPolicy<reqwest::Error> {
+        self.current_attempt += 1;
+        if self.current_attempt > self.max_attempts {
+            trace!(
+                "[{}] All attempts ({}) have been used",
+                self.display_name,
+                self.max_attempts
+            );
+            return RetryPolicy::ForwardError(e);
+        }
+        trace!(
+            "[{}] Attempt {}/{} has failed",
+            self.display_name,
+            self.current_attempt,
+            self.max_attempts
+        );
+
+        if e.is_client_error() {
+            // do not retry 4xx
+            RetryPolicy::ForwardError(e)
+        } else if e.is_timeout() || e.is_server_error() {
+            // Retry timeouts and 5xx every 5 seconds
+            RetryPolicy::WaitRetry(Duration::from_secs(5))
+        } else {
+            // Instantly retry other errors since they may be HTTP/redirect related
+            RetryPolicy::Repeat
+        }
+    }
+}

--- a/crates/interledger-api/src/client.rs
+++ b/crates/interledger-api/src/client.rs
@@ -9,7 +9,7 @@ use std::fmt::Display;
 use std::time::Duration;
 use url::Url;
 
-// The account creation endpoint set by the engines in [RFC536](https://github.com/interledger/rfcs/pull/536)
+// The account creation endpoint set by the engines in the [RFC](https://github.com/interledger/rfcs/pull/536)
 static ACCOUNTS_ENDPOINT: &str = "accounts";
 
 pub struct Client {

--- a/crates/interledger-api/src/lib.rs
+++ b/crates/interledger-api/src/lib.rs
@@ -18,6 +18,8 @@ use tower_web::{net::ConnectionStream, Extract, Response, ServiceBuilder};
 mod routes;
 use self::routes::*;
 
+pub(crate) mod client;
+
 pub(crate) const BEARER_TOKEN_START: usize = 7;
 
 pub trait NodeStore: Clone + Send + Sync + 'static {

--- a/crates/interledger-api/src/routes/accounts.rs
+++ b/crates/interledger-api/src/routes/accounts.rs
@@ -9,10 +9,10 @@ use interledger_http::{HttpAccount, HttpStore};
 use interledger_service::{Account, AuthToken, Username};
 use interledger_service_util::BalanceStore;
 use log::{debug, error, trace};
-use std::time::Duration;
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::str::FromStr;
+use std::time::Duration;
 use tower_web::{impl_web, Response};
 use url::Url;
 

--- a/crates/interledger-api/src/routes/accounts.rs
+++ b/crates/interledger-api/src/routes/accounts.rs
@@ -12,7 +12,8 @@ use reqwest::r#async::Client;
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::str::FromStr;
-use tokio_retry::{strategy::FixedInterval, Retry};
+use tokio_executor::spawn;
+use tokio_retry::{strategy::ExponentialBackoff, Retry};
 use tower_web::{impl_web, Response};
 use url::Url;
 
@@ -86,51 +87,44 @@ impl_web! {
             let se_url = body.settlement_engine_url.clone();
             self.validate_admin(authorization)
                 .and_then(move |store| store.insert_account(body)
-                .map_err(|_| Response::error(500))
                 .and_then(|account| {
                     // if the account had a SE associated with it, then register
                     // the account in the SE.
                     if let Some(se_url)  = se_url {
                         let id = account.id();
-                        Either::A(result(Url::parse(&se_url))
-                        .map_err(|_| Response::error(500))
-                        .and_then(move |mut se_url| {
-                            se_url
-                                .path_segments_mut()
-                                .expect("Invalid settlement engine URL")
-                                .push("accounts");
-                            trace!(
-                                "Sending account {} creation request to settlement engine: {:?}",
-                                id,
-                                se_url.clone()
-                            );
-                            let action = move || {
-                                Client::new().post(se_url.as_ref())
-                                .json(&json!({"id" : id.to_string()}))
-                                .send()
-                                .map_err(move |err| {
-                                    error!("Error sending account creation command to the settlement engine: {:?}", err)
-                                })
-                                .and_then(move |response| {
-                                    if response.status().is_success() {
-                                        trace!("Account {} created on the SE", id);
-                                        Ok(())
-                                    } else {
-                                        error!("Error creating account. Settlement engine responded with HTTP code: {}", response.status());
-                                        Err(())
-                                    }
-                                })
-                            };
-                            Retry::spawn(FixedInterval::from_millis(2000).take(MAX_RETRIES), action)
-                            .map_err(|_| Response::error(500))
-                            .and_then(move |_| {
-                                Ok(json!(account))
+                        let mut se_url = Url::parse(&se_url).map_err(|err| error!("Invalid URL: {:?}", err))?;
+                        se_url
+                            .path_segments_mut()
+                            .expect("Invalid settlement engine URL")
+                            .push("accounts");
+                        trace!(
+                            "Sending account {} creation request to settlement engine: {:?}",
+                            id,
+                            se_url.clone()
+                        );
+                        let action = move || {
+                            Client::new()
+                            .post(se_url.as_ref())
+                            .json(&json!({"id" : id.to_string()}))
+                            .send()
+                            .map_err(move |err| {
+                                error!("Error sending account creation command to the settlement engine: {:?}", err)
                             })
-                        }))
-                    } else {
-                        Either::B(ok(json!(account)))
+                            .and_then(move |response| {
+                                if response.status().is_success() {
+                                    trace!("Account {} created on the SE", id);
+                                    Ok(())
+                                } else {
+                                    error!("Error creating account. Settlement engine responded with HTTP code: {}", response.status());
+                                    Err(())
+                                }
+                            })
+                        };
+                        spawn(Retry::spawn(ExponentialBackoff::from_millis(10).take(MAX_RETRIES), action).map_err(|_| error!("Failed to keep retrying!")));
                     }
-                }))
+                    Ok(json!(account))
+                })
+                .map_err(|_| Response::builder().status(500).body(()).unwrap()))
         }
 
         #[get("/accounts")]

--- a/crates/interledger-settlement-engines/Cargo.toml
+++ b/crates/interledger-settlement-engines/Cargo.toml
@@ -39,6 +39,7 @@ num-traits = "0.2.8"
 lazy_static = "1.3.0"
 secrecy = { version = "0.4.0", features = ["serde", "bytes"] }
 zeroize = { version = "0.10.1", features = ["bytes"] }
+parking_lot = "0.9.0"
 
 [dev-dependencies]
 lazy_static = "1.3"

--- a/crates/interledger-settlement-engines/src/engines/ethereum_ledger/eth_engine.rs
+++ b/crates/interledger-settlement-engines/src/engines/ethereum_ledger/eth_engine.rs
@@ -790,7 +790,7 @@ where
         let store: S = self.store.clone();
         let account_id = account_id.id;
         let signer = self.signer.clone();
-        let address = self.address.clone();
+        let address = self.address;
 
         // We make a POST request to OUR connector's `messages`
         // endpoint. This will in turn send an outgoing

--- a/crates/interledger-settlement-engines/src/engines/ethereum_ledger/eth_engine.rs
+++ b/crates/interledger-settlement-engines/src/engines/ethereum_ledger/eth_engine.rs
@@ -55,13 +55,17 @@ impl PaymentDetailsRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct PaymentDetailsResponse {
     to: Addresses,
-    sig: Signature,
+    signature: Signature,
     challenge: Option<Vec<u8>>,
 }
 
 impl PaymentDetailsResponse {
-    fn new(to: Addresses, sig: Signature, challenge: Option<Vec<u8>>) -> Self {
-        PaymentDetailsResponse { to, sig, challenge }
+    fn new(to: Addresses, signature: Signature, challenge: Option<Vec<u8>>) -> Self {
+        PaymentDetailsResponse {
+            to,
+            signature,
+            challenge,
+        }
     }
 }
 
@@ -837,83 +841,82 @@ where
                 parse_body_into_payment_details(resp).and_then(move |payment_details| {
                     let data = prefixed_message(challenge_clone);
                     let challenge_hash = Sha3::digest(&data);
-                    let recovered_address = payment_details.sig.recover(&challenge_hash);
+                    let recovered_address = payment_details.signature.recover(&challenge_hash);
                     trace!("Received payment details {:?}", payment_details);
-                    result(recovered_address)
-                        .map_err(move |err| {
-                            let err = format!("Could not recover address {:?}", err);
-                            error!("{}", err);
-                            (StatusCode::from_u16(502).unwrap(), err)
-                        })
-                        .and_then({
-                            let payment_details = payment_details.clone();
-                            move |recovered_address| {
-                                if recovered_address.as_bytes()
-                                    == &payment_details.to.own_address.as_bytes()[..]
-                                {
-                                    ok(())
-                                } else {
-                                    let error_msg = format!(
-                                        "Recovered address did not match: {:?}. Expected {:?}",
-                                        recovered_address.to_string(),
-                                        payment_details.to
-                                    );
-                                    error!("{}", error_msg);
-                                    err((StatusCode::from_u16(502).unwrap(), error_msg))
-                                }
+                    match recovered_address {
+                        Ok(recovered_address) => {
+                            if recovered_address.as_bytes()
+                                != &payment_details.to.own_address.as_bytes()[..]
+                            {
+                                let error_msg = format!(
+                                    "Recovered address did not match: {:?}. Expected {:?}",
+                                    recovered_address.to_string(),
+                                    payment_details.to
+                                );
+                                error!("{}", error_msg);
+                                return Either::A(err((
+                                    StatusCode::from_u16(502).unwrap(),
+                                    error_msg,
+                                )));
                             }
-                        })
-                        .and_then({
-                            let payment_details = payment_details.clone();
-                            move |_| {
-                                // ACK BACK
-                                if let Some(challenge) = payment_details.challenge {
-                                    // if we were challenged, we must respond
-                                    let data = prefixed_message(challenge);
-                                    let signature = signer.sign_message(&data);
-                                    let resp = {
-                                        // Respond with our address, a signature,
-                                        // and no challenge, since we already sent
-                                        // them one earlier
-                                        let ret =
-                                            PaymentDetailsResponse::new(address, signature, None);
-                                        serde_json::to_string(&ret).unwrap()
-                                    };
-                                    let idempotency_uuid =
-                                        Uuid::new_v4().to_hyphenated().to_string();
-                                    let client = Client::new();
-                                    let action = move || {
-                                        client
-                                            .post(url_clone.as_ref())
-                                            .header("Content-Type", "application/octet-stream")
-                                            .header("Idempotency-Key", idempotency_uuid.clone())
-                                            .body(resp.clone())
-                                            .send()
-                                            .map_err(|err| error!("{}", err))
-                                            .and_then(move |_| Ok(()))
-                                    };
+                        }
+                        Err(error_msg) => {
+                            let error_msg = format!("Could not recover address {:?}", error_msg);
+                            error!("{}", error_msg);
+                            return Either::A(err((StatusCode::from_u16(400).unwrap(), error_msg)));
+                        }
+                    };
 
-                                    tokio::executor::spawn(
-                                        Retry::spawn(
-                                            ExponentialBackoff::from_millis(10).take(MAX_RETRIES),
-                                            action,
-                                        )
-                                        .map_err(|err| error!("{:?}", err)),
-                                    );
-                                }
+                    // ACK BACK
+                    if let Some(challenge) = payment_details.challenge {
+                        // if we were challenged, we must respond
+                        let data = prefixed_message(challenge);
+                        let signature = signer.sign_message(&data);
+                        let resp = {
+                            // Respond with our address, a signature,
+                            // and no challenge, since we already sent
+                            // them one earlier
+                            let ret = PaymentDetailsResponse::new(address, signature, None);
+                            serde_json::to_string(&ret).unwrap()
+                        };
+                        let idempotency_uuid = Uuid::new_v4().to_hyphenated().to_string();
+                        let client = Client::new();
+                        let action = move || {
+                            client
+                                .post(url_clone.as_ref())
+                                .header("Content-Type", "application/octet-stream")
+                                .header("Idempotency-Key", idempotency_uuid.clone())
+                                .body(resp.clone())
+                                .send()
+                                .map_err(|err| error!("{}", err))
+                                .and_then(move |_| Ok(()))
+                        };
 
-                                let data =
-                                    HashMap::from_iter(vec![(account_id, payment_details.to)]);
-                                store.save_account_addresses(data).map_err(move |err| {
-                                    let err = format!("Couldn't connect to store {:?}", err);
-                                    error!("{}", err);
-                                    (StatusCode::from_u16(500).unwrap(), err)
-                                })
-                            }
-                        })
+                        tokio::executor::spawn(
+                            Retry::spawn(
+                                ExponentialBackoff::from_millis(10).take(MAX_RETRIES),
+                                action,
+                            )
+                            .map_err(|err| error!("{:?}", err)),
+                        );
+                    }
+
+                    let data = HashMap::from_iter(vec![(account_id, payment_details.to)]);
+
+                    Either::B(
+                        store
+                            .save_account_addresses(data)
+                            .map_err(move |err| {
+                                let err = format!("Couldn't connect to store {:?}", err);
+                                error!("{}", err);
+                                (StatusCode::from_u16(500).unwrap(), err)
+                            })
+                            .and_then(move |_| {
+                                Ok((StatusCode::from_u16(201).unwrap(), "CREATED".to_owned()))
+                            }),
+                    )
                 })
-            })
-            .and_then(move |_| Ok((StatusCode::from_u16(201).unwrap(), "CREATED".to_owned()))),
+            }),
         )
     }
 
@@ -959,27 +962,29 @@ where
                 // save them in our store
                 let data = prefixed_message(challenge.to_vec());
                 let challenge_hash = Sha3::digest(&data);
-                let recovered_address = resp.sig.recover(&challenge_hash);
-                Either::A(
-                    result(recovered_address)
-                        .map_err(move |err| {
-                            let err = format!("Could not recover address {:?}", err);
-                            error!("{}", err);
-                            (StatusCode::from_u16(502).unwrap(), err)
-                        })
-                        .and_then(move |recovered_address| {
+                let recovered_address = resp.signature.recover(&challenge_hash);
+                match recovered_address {
+                    Ok(recovered_address) => {
+                        Either::A(
                             if recovered_address.as_bytes() != &resp.to.own_address.as_bytes()[..] {
-                                return Either::A(ok(()));
-                            }
-                            // save to the store
-                            let data = HashMap::from_iter(vec![(account_id, resp.to)]);
-                            Either::B(store.save_account_addresses(data).map_err(move |err| {
-                                let err = format!("Couldn't connect to store {:?}", err);
-                                error!("{}", err);
-                                (StatusCode::from_u16(500).unwrap(), err)
-                            }))
-                        }),
-                )
+                                Either::A(ok(()))
+                            } else {
+                                // save to the store
+                                let data = HashMap::from_iter(vec![(account_id, resp.to)]);
+                                Either::B(store.save_account_addresses(data).map_err(move |err| {
+                                    let err = format!("Couldn't connect to store {:?}", err);
+                                    error!("{}", err);
+                                    (StatusCode::from_u16(500).unwrap(), err)
+                                }))
+                            },
+                        )
+                    }
+                    Err(error_msg) => {
+                        let error_msg = format!("Could not recover address {:?}", error_msg);
+                        error!("{}", error_msg);
+                        Either::B(err((StatusCode::from_u16(400).unwrap(), error_msg)))
+                    }
+                }
             } else {
                 Either::B(ok(()))
             };
@@ -988,8 +993,9 @@ where
                 fut.and_then(move |_| Ok((StatusCode::from_u16(200).unwrap(), "OK".to_string()))),
             )
         } else {
+            error!("Ignoring message that was neither a PaymentDetailsRequest nor a PaymentDetailsResponse");
             Box::new(err((
-                StatusCode::from_u16(502).unwrap(),
+                StatusCode::from_u16(400).unwrap(),
                 "Invalid message type".to_owned(),
             )))
         }
@@ -1174,7 +1180,7 @@ mod tests {
                 own_address: bob.address,
                 token_address: None,
             },
-            sig: signature,
+            signature,
             challenge: None,
         })
         .unwrap();
@@ -1242,7 +1248,7 @@ mod tests {
         // The returned addresses must be Alice's
         assert_eq!(data.to, alice_addrs);
         // The returned signature must be Alice's sig.
-        assert_eq!(data.sig, signature);
+        assert_eq!(data.signature, signature);
         // The returned challenge is sent over to Bob, who will use it to send
         // his address back
         assert!(data.challenge.is_some());

--- a/crates/interledger-settlement-engines/tests/eth_ledger_settlement.rs
+++ b/crates/interledger-settlement-engines/tests/eth_ledger_settlement.rs
@@ -224,8 +224,10 @@ fn eth_ledger_settlement() {
                         let bob = node1_ids.get(&bob_addr2).unwrap().to_owned();
                         let alice = node2_ids.get(&alice_addr).unwrap().to_owned();
 
+                        // We can skip the creation of the account on the first
+                        // engine since the second call will create it on both
                         let create1 = create_account_on_engine(node1_engine, bob);
-                        let create2 = create_account_on_engine(node2_engine, alice);
+                        // let create2 = create_account_on_engine(node2_engine, alice);
 
                         // Make 4 subsequent payments (we could also do a 71 payment
                         // directly)
@@ -250,7 +252,7 @@ fn eth_ledger_settlement() {
                         };
 
                         create1
-                            .and_then(move |_| create2)
+                            // .and_then(move |_| create2)
                             .and_then(move |_| send1)
                             .and_then(move |_| get_balances())
                             .and_then(move |ret| {

--- a/crates/interledger-settlement-engines/tests/eth_xrp_interoperable.rs
+++ b/crates/interledger-settlement-engines/tests/eth_xrp_interoperable.rs
@@ -330,24 +330,20 @@ fn eth_xrp_interoperable() {
                     let bob_addr = Address::from_str("example.bob").unwrap();
                     let alice_addr = Address::from_str("example.alice").unwrap();
                     futures::future::join_all(vec![
-                        get_all_accounts(node1_http, "admin").map(accounts_to_ids),
                         get_all_accounts(node2_http, "admin").map(accounts_to_ids),
                         get_all_accounts(node3_http, "admin").map(accounts_to_ids),
                     ])
                     .and_then(move |ids| {
-                        let node1_ids = ids[0].clone();
-                        let node2_ids = ids[1].clone();
-                        let node3_ids = ids[2].clone();
+                        let node2_ids = ids[0].clone();
+                        let node3_ids = ids[1].clone();
 
-                        let bob_on_alice = node1_ids.get(&bob_addr).unwrap().to_owned();
                         let alice_on_bob = node2_ids.get(&alice_addr).unwrap().to_owned();
                         let charlie_on_bob = node2_ids.get(&charlie_addr).unwrap().to_owned();
                         let bob_on_charlie = node3_ids.get(&bob_addr).unwrap().to_owned();
 
                         // Insert accounts for the 3 nodes (4 total since node2 has
                         // eth & xrp)
-                        create_account_on_engine(node1_engine, bob_on_alice)
-                            .and_then(move |_| create_account_on_engine(node2_engine, alice_on_bob))
+                        create_account_on_engine(node2_engine, alice_on_bob)
                             .and_then(move |_| {
                                 create_account_on_engine(node2_xrp_engine_port, charlie_on_bob)
                             })

--- a/examples/eth-settlement/README.md
+++ b/examples/eth-settlement/README.md
@@ -256,7 +256,7 @@ curl \
     "routing_relation": "Peer",
     "send_routes": true,
     "receive_routes": true}' \
-    http://localhost:7770/accounts > logs/account-alice-bob.log 2>/dev/null &
+    http://localhost:7770/accounts > logs/account-alice-bob.log 2>/dev/null
 
 printf "Adding Alice's account on Bob's node...\n"
 curl \
@@ -278,7 +278,7 @@ curl \
     "routing_relation": "Peer",
     "send_routes": true,
     "receive_routes": true}' \
-    http://localhost:8770/accounts > logs/account-bob-alice.log 2>/dev/null &
+    http://localhost:8770/accounts > logs/account-bob-alice.log 2>/dev/null
 
 sleep 2
 ```

--- a/examples/eth_xrp_three_nodes/README.md
+++ b/examples/eth_xrp_three_nodes/README.md
@@ -211,8 +211,8 @@ cargo run --package interledger-settlement-engines -- ethereum-ledger \
 &> logs/node-bob-settlement-engine-eth.log &
 
 DEBUG="xrp-settlement-engine" \
-LEDGER_ADDRESS="r3GDnYaYCk2XKzEDNYj59yMqDZ7zGih94K" \
-LEDGER_SECRET="ssnYUDNeNQrNij2EVJG6dDw258jA6" \
+LEDGER_ADDRESS="rLna4iDTAn2vNs4CSBwhoz5HQ9M1Xm58F4" \
+LEDGER_SECRET="sn22GccSrAj4B2HtQN6YTk14Qwfnt" \
 CONNECTOR_URL="http://localhost:8771" \
 REDIS_PORT=6380 \
 ENGINE_PORT=3002 \
@@ -221,8 +221,8 @@ ilp-settlement-xrp \
 
 # Start Charlie's settlement engine (XRPL)
 DEBUG="xrp-settlement-engine" \
-LEDGER_ADDRESS="rGCUgMH4omQV1PUuYFoMAnA7esWFhE7ZEV" \
-LEDGER_SECRET="sahVoeg97nuitefnzL9GHjp2Z6kpj" \
+LEDGER_ADDRESS="r3FugEA5WpL4q3hmkUfo8a3pjdb214wsth" \
+LEDGER_SECRET="shRjP3WyN7TLsEAbw5hns4bNGZvRY" \
 CONNECTOR_URL="http://localhost:9771" \
 REDIS_PORT=6381 \
 ENGINE_PORT=3003 \
@@ -349,7 +349,7 @@ curl \
     "routing_relation": "Peer",
     "send_routes": true,
     "receive_routes": true}' \
-    http://localhost:7770/accounts > logs/account-alice-bob.log 2>/dev/null &
+    http://localhost:7770/accounts > logs/account-alice-bob.log 2>/dev/null
 
 printf "Adding Alice's account on Bob's node (ETH Peer relation)...\n"
 curl \
@@ -393,7 +393,7 @@ curl \
     "routing_relation": "Child",
     "send_routes": false,
     "receive_routes": true}' \
-    http://localhost:8770/accounts > logs/account-bob-charlie.log 2>/dev/null &
+    http://localhost:8770/accounts > logs/account-bob-charlie.log 2>/dev/null
 
 printf "Adding Bob's account on Charlie's node (XRP Parent relation)...\n"
 curl \

--- a/examples/xrp_ledger/README.md
+++ b/examples/xrp_ledger/README.md
@@ -44,8 +44,8 @@ This makes the `ilp-settlement-xrp` command available to your path.
 
 ```bash
 DEBUG="xrp-settlement-engine" \
-LEDGER_ADDRESS="rGCUgMH4omQV1PUuYFoMAnA7esWFhE7ZEV" \
-LEDGER_SECRET="sahVoeg97nuitefnzL9GHjp2Z6kpj" \
+LEDGER_ADDRESS="rLna4iDTAn2vNs4CSBwhoz5HQ9M1Xm58F4" \
+LEDGER_SECRET="sn22GccSrAj4B2HtQN6YTk14Qwfnt" \
 CONNECTOR_URL="http://localhost:7771" \
 REDIS_PORT=6379 \
 ENGINE_PORT=3000 \
@@ -97,8 +97,8 @@ running.
 
 ```bash
 DEBUG="xrp-settlement-engine" \
-LEDGER_ADDRESS="r3GDnYaYCk2XKzEDNYj59yMqDZ7zGih94K" \
-LEDGER_SECRET="ssnYUDNeNQrNij2EVJG6dDw258jA6" \
+LEDGER_ADDRESS="r3FugEA5WpL4q3hmkUfo8a3pjdb214wsth" \
+LEDGER_SECRET="shRjP3WyN7TLsEAbw5hns4bNGZvRY" \
 CONNECTOR_URL="http://localhost:8771" \
 REDIS_PORT=6380 \
 ENGINE_PORT=3001 \

--- a/examples/xrp_ledger/xrp_settlements_test.sh
+++ b/examples/xrp_ledger/xrp_settlements_test.sh
@@ -14,8 +14,8 @@ sleep 1
 
 echo "Initializing Alice SE"
 DEBUG="xrp-settlement-engine" \
-LEDGER_ADDRESS="rGCUgMH4omQV1PUuYFoMAnA7esWFhE7ZEV" \
-LEDGER_SECRET="sahVoeg97nuitefnzL9GHjp2Z6kpj" \
+LEDGER_ADDRESS="rLna4iDTAn2vNs4CSBwhoz5HQ9M1Xm58F4" \
+LEDGER_SECRET="sn22GccSrAj4B2HtQN6YTk14Qwfnt" \
 CONNECTOR_URL="http://localhost:7771" \
 REDIS_PORT=6379 \
 ENGINE_PORT=3000 \
@@ -23,8 +23,8 @@ ENGINE_PORT=3000 \
 
 echo "Initializing Bob SE"
 DEBUG="xrp-settlement-engine" \
-LEDGER_ADDRESS="r3GDnYaYCk2XKzEDNYj59yMqDZ7zGih94K" \
-LEDGER_SECRET="ssnYUDNeNQrNij2EVJG6dDw258jA6" \
+LEDGER_ADDRESS="r3FugEA5WpL4q3hmkUfo8a3pjdb214wsth" \
+LEDGER_SECRET="shRjP3WyN7TLsEAbw5hns4bNGZvRY" \
 CONNECTOR_URL="http://localhost:8771" \
 REDIS_PORT=6380 \
 ENGINE_PORT=3001 \


### PR DESCRIPTION
Closes https://github.com/interledger-rs/interledger-rs/issues/212

It always does exponential backoff now. 

@emschwartz described the following behavior:
> exp backoff, 10 retries ONLY on temporary errors, stops on final errors but returns 202 Accepted if the error was the equivalent of a 404 Not Found)

[RetryIf](https://docs.rs/tokio-retry/0.2.0/tokio_retry/struct.RetryIf.html) might be usable for the above, or although futures-retry probably has a better API: https://gitlab.com/mexus/futures-retry/blob/master/examples/tcp-client.rs. Which status codes do we want to retry and which not?