### PR TITLE
Remove url serde

### DIFF
--- a/crates/interledger-store-redis/Cargo.toml
+++ b/crates/interledger-store-redis/Cargo.toml
@@ -37,7 +37,6 @@ tokio-timer = "0.2.10"
 url = { version = "2.1.0", features = ["serde"] }
 http = "0.1.17"
 uuid = { version = "0.7.4", features = ["serde"] }
-url_serde = { git = "https://github.com/interledger-rs/url_serde" }
 
 
 

--- a/crates/interledger-store-redis/src/account.rs
+++ b/crates/interledger-store-redis/src/account.rs
@@ -41,13 +41,11 @@ pub struct Account {
     pub(crate) asset_scale: u8,
     pub(crate) max_packet_amount: u64,
     pub(crate) min_balance: Option<i64>,
-    #[serde(with = "url_serde")]
     pub(crate) http_endpoint: Option<Url>,
     #[serde(serialize_with = "optional_bytes_to_utf8")]
     pub(crate) http_incoming_token: Option<Bytes>,
     #[serde(serialize_with = "optional_bytes_to_utf8")]
     pub(crate) http_outgoing_token: Option<Bytes>,
-    #[serde(with = "url_serde")]
     pub(crate) btp_uri: Option<Url>,
     #[serde(serialize_with = "optional_bytes_to_utf8")]
     pub(crate) btp_incoming_token: Option<Bytes>,
@@ -61,7 +59,6 @@ pub struct Account {
     pub(crate) round_trip_time: u32,
     pub(crate) packets_per_minute_limit: Option<u32>,
     pub(crate) amount_per_minute_limit: Option<u64>,
-    #[serde(with = "url_serde")]
     pub(crate) settlement_engine_url: Option<Url>,
 }
 


### PR DESCRIPTION
Turns out URLv2 with serde feature flag on is sufficient for any serialization, https://github.com/servo/rust-url/issues/545