### PR TITLE
fix(service, examples): reject invalid usernames during account creation

### DIFF
--- a/crates/interledger-service/Cargo.toml
+++ b/crates/interledger-service/Cargo.toml
@@ -16,3 +16,6 @@ regex = "1.2.1"
 lazy_static = "1.3.0"
 unicase = "2.4.0"
 unicode-normalization = "0.1.8"
+
+[dev-dependencies]
+serde_json = "1.0.40"

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -7,7 +7,7 @@ This example sets up two local Interledger.rs nodes, peers them together, and se
 
 To run the full example, you can use [`run-md.sh`](../../scripts/run-md.sh) as described [here](../README.md). Otherwise, you can walk through each step below.
 
-Each of the services write their logs to files found under the `logs` directory. You can run `tail -f logs/node-a.log`, for example, to watch the logs of Node A.
+Each of the services write their logs to files found under the `logs` directory. You can run `tail -f logs/node_a.log`, for example, to watch the logs of Node A.
 
 ![overview](images/overview.svg)
 
@@ -88,7 +88,7 @@ export RUST_LOG=interledger=debug
 # Start both nodes
 # Note that the configuration options can be passed as environment variables
 # or saved to a YAML file and passed to the node with the `--config` or `-c` CLI argument
-ILP_ADDRESS=example.node-a \
+ILP_ADDRESS=example.node_a \
 ILP_SECRET_SEED=8852500887504328225458511465394229327394647958135038836332350604 \
 ILP_ADMIN_AUTH_TOKEN=admin-a \
 ILP_REDIS_CONNECTION=redis://127.0.0.1:6379/0 \
@@ -96,9 +96,9 @@ ILP_HTTP_ADDRESS=127.0.0.1:7770 \
 ILP_BTP_ADDRESS=127.0.0.1:7768 \
 ILP_SETTLEMENT_ADDRESS=127.0.0.1:7771 \
 ILP_DEFAULT_SPSP_ACCOUNT=0 \
-cargo run --package interledger -- node &> logs/node-a.log &
+cargo run --package interledger -- node &> logs/node_a.log &
 
-ILP_ADDRESS=example.node-b \
+ILP_ADDRESS=example.node_b \
 ILP_SECRET_SEED=1604966725982139900555208458637022875563691455429373719368053354 \
 ILP_ADMIN_AUTH_TOKEN=admin-b \
 ILP_REDIS_CONNECTION=redis://127.0.0.1:6379/1 \
@@ -106,7 +106,7 @@ ILP_HTTP_ADDRESS=127.0.0.1:8770 \
 ILP_BTP_ADDRESS=127.0.0.1:8768 \
 ILP_SETTLEMENT_ADDRESS=127.0.0.1:8771 \
 ILP_DEFAULT_SPSP_ACCOUNT=0 \
-cargo run --package interledger -- node &> logs/node-b.log &
+cargo run --package interledger -- node &> logs/node_b.log &
 ```
 
 <!--!
@@ -132,7 +132,7 @@ printf "The Interledger.rs nodes are up and running!\n\n"
 -->
 
 Now the Interledger.rs nodes are up and running!  
-You can also watch the logs with: `tail -f logs/node-a.log` or `tail -f logs/node-b.log`.
+You can also watch the logs with: `tail -f logs/node_a.log` or `tail -f logs/node_b.log`.
 
 ### 4. Configure the Nodes
 
@@ -151,7 +151,7 @@ curl \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer admin-a" \
     -d '{
-    "ilp_address": "example.node-a.alice",
+    "ilp_address": "example.node_a.alice",
     "username" : "alice",
     "asset_code": "ABC",
     "asset_scale": 9,
@@ -164,13 +164,13 @@ curl \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer admin-a" \
     -d '{
-    "ilp_address": "example.node-b",
-    "username" : "node-b",
+    "ilp_address": "example.node_b",
+    "username" : "node_b",
     "asset_code": "ABC",
     "asset_scale": 9,
     "max_packet_amount": 100,
-    "http_incoming_token": "node-b-password",
-    "http_outgoing_token": "node-a:node-a-password",
+    "http_incoming_token": "node_b-password",
+    "http_outgoing_token": "node_a:node_a-password",
     "http_endpoint": "http://localhost:8770/ilp",
     "min_balance": -100000,
     "routing_relation": "Peer",
@@ -186,7 +186,7 @@ curl \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer admin-b" \
     -d '{
-    "ilp_address": "example.node-b.bob",
+    "ilp_address": "example.node_b.bob",
     "username" : "bob",
     "asset_code": "ABC",
     "asset_scale": 9,
@@ -199,13 +199,13 @@ curl \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer admin-b" \
     -d '{
-    "ilp_address": "example.node-a",
-    "username" : "node-a",
+    "ilp_address": "example.node_a",
+    "username" : "node_a",
     "asset_code": "ABC",
     "asset_scale": 9,
     "max_packet_amount": 100,
-    "http_incoming_token": "node-a-password",
-    "http_outgoing_token": "node-b:node-b-password",
+    "http_incoming_token": "node_a-password",
+    "http_outgoing_token": "node_b:node_b-password",
     "http_endpoint": "http://localhost:7770/ilp",
     "min_balance": -100000,
     "routing_relation": "Peer",
@@ -229,12 +229,12 @@ http://localhost:7770/accounts/alice/balance
 printf "\nNode B's balance on Node A: "
 curl \
 -H "Authorization: Bearer admin-a" \
-http://localhost:7770/accounts/node-b/balance
+http://localhost:7770/accounts/node_b/balance
 
 printf "\nNode A's balance on Node B: "
 curl \
 -H "Authorization: Bearer admin-b" \
-http://localhost:8770/accounts/node-a/balance
+http://localhost:8770/accounts/node_a/balance
 
 printf "\nBob's balance: "
 curl \
@@ -274,12 +274,12 @@ http://localhost:7770/accounts/alice/balance
 printf "\nNode B's balance on Node A: "
 curl \
 -H "Authorization: Bearer admin-a" \
-http://localhost:7770/accounts/node-b/balance
+http://localhost:7770/accounts/node_b/balance
 
 printf "\nNode A's balance on Node B: "
 curl \
 -H "Authorization: Bearer admin-b" \
-http://localhost:8770/accounts/node-a/balance
+http://localhost:8770/accounts/node_a/balance
 
 printf "\nBob's balance: "
 curl \


### PR DESCRIPTION
The new username feature doesn't allow names to contain special
characters other than underscore, but the simple example had usernames
of the form "node-a". However, this was only being detected during
account lookup, whereas account creation was bypassing the validation
check. This occurred because the intended function by which to construct
a valid instance of Username, `Username::from_str`, was being explicitly
invoked during account lookup; for account creation, the instance of
Username was constructed directly via the Deserialize implementation
generated by Serde. Serde has an attribute hook that allows types to run
custom validation logic via the TryFrom trait; we implement TryFrom for
Username here in terms of the existing FromStr impl (in some future
version of Rust this may be unnecessary, as specialization should allow
TryFrom and FromStr to be defined in terms of each other within libstd).