### PR TITLE
feat(eth se): port is deprecated, use http_address instead

### DIFF
--- a/crates/interledger-settlement-engines/src/engines/ethereum_ledger/eth_engine.rs
+++ b/crates/interledger-settlement-engines/src/engines/ethereum_ledger/eth_engine.rs
@@ -986,7 +986,7 @@ fn prefixed_mesage(challenge: Vec<u8>) -> Vec<u8> {
 pub fn run_ethereum_engine<R, Si>(
     redis_uri: R,
     ethereum_endpoint: String,
-    settlement_port: u16,
+    http_address: SocketAddr,
     private_key: Si,
     chain_id: u8,
     confirmations: u8,
@@ -1017,12 +1017,11 @@ where
                     .token_address(token_address)
                     .connect();
 
-            let addr = SocketAddr::from(([127, 0, 0, 1], settlement_port));
-            let listener =
-                TcpListener::bind(&addr).expect("Unable to bind to Settlement Engine address");
+            let listener = TcpListener::bind(&http_address)
+                .expect("Unable to bind to Settlement Engine address");
             let api = SettlementEngineApi::new(engine, ethereum_store);
             tokio::spawn(api.serve(listener.incoming()));
-            info!("Ethereum Settlement Engine listening on: {}", addr);
+            info!("Ethereum Settlement Engine listening on: {}", http_address);
             Ok(())
         })
 }

--- a/crates/interledger-settlement-engines/src/main.rs
+++ b/crates/interledger-settlement-engines/src/main.rs
@@ -25,11 +25,10 @@ pub fn main() {
                         .takes_value(true)
                         .index(1)
                         .help("Name of config file (in JSON, TOML, YAML, or INI format)"),
-                    Arg::with_name("port")
-                        .long("port")
-                        .short("p")
+                    Arg::with_name("http_address")
+                        .long("http_address")
                         .takes_value(true)
-                        .default_value("3000")
+                        .default_value("127.0.0.1:3000")
                         .help("Port to listen for settlement requests on"),
                     Arg::with_name("key")
                         .long("key")
@@ -235,7 +234,7 @@ impl Runnable<EthereumLedgerOpt> for Runner {
         tokio::run(run_ethereum_engine(
             redis_uri,
             opt.ethereum_endpoint.clone(),
-            opt.port,
+            opt.http_address.parse().unwrap(),
             opt.key.clone(),
             opt.chain_id,
             opt.confirmations,
@@ -250,8 +249,8 @@ impl Runnable<EthereumLedgerOpt> for Runner {
 
 #[derive(Deserialize, Clone)]
 struct EthereumLedgerOpt {
-    port: u16,
     key: String,
+    http_address: String,
     ethereum_endpoint: String,
     token_address: String,
     connector_url: String,

--- a/crates/interledger-settlement-engines/tests/eth_ledger_settlement.rs
+++ b/crates/interledger-settlement-engines/tests/eth_ledger_settlement.rs
@@ -9,6 +9,7 @@ use interledger::{
 };
 use interledger_packet::Address;
 use interledger_service::Username;
+use std::net::SocketAddr;
 use std::str::FromStr;
 use tokio::runtime::Builder as RuntimeBuilder;
 
@@ -46,10 +47,12 @@ fn eth_ledger_settlement() {
     let node1_http = get_open_port(Some(3010));
     let node1_settlement = get_open_port(Some(3011));
     let node1_engine = get_open_port(Some(3012));
+    let node1_engine_address = SocketAddr::from(([127, 0, 0, 1], node1_engine));
     let alice_key = "380eb0f3d505f087e438eca80bc4df9a7faa24f868e69fc0440261a0fc0567dc".to_string();
     let node2_http = get_open_port(Some(3020));
     let node2_settlement = get_open_port(Some(3021));
     let node2_engine = get_open_port(Some(3022));
+    let node2_engine_address = SocketAddr::from(([127, 0, 0, 1], node2_engine));
     let bob_key = "cc96601bc52293b53c4736a12af9130abf347669b3813f9ec4cafdf6991b087e".to_string();
 
     let mut runtime = RuntimeBuilder::new()
@@ -71,7 +74,7 @@ fn eth_ledger_settlement() {
     };
     let node1_clone = node1.clone();
     runtime.spawn(
-        start_eth_engine(connection_info1, node1_engine, alice_key, node1_settlement).and_then(
+        start_eth_engine(connection_info1, node1_engine_address, alice_key, node1_settlement).and_then(
             move |_| {
                 // TODO insert the accounts via HTTP request
                 node1_clone
@@ -142,7 +145,7 @@ fn eth_ledger_settlement() {
         route_broadcast_interval: Some(200),
     };
     runtime.spawn(
-        start_eth_engine(connection_info2, node2_engine, bob_key, node2_settlement).and_then(
+        start_eth_engine(connection_info2, node2_engine_address, bob_key, node2_settlement).and_then(
             move |_| {
                 node2
                     .insert_account(AccountDetails {

--- a/crates/interledger-settlement-engines/tests/eth_xrp_interoperable.rs
+++ b/crates/interledger-settlement-engines/tests/eth_xrp_interoperable.rs
@@ -8,6 +8,7 @@ use interledger::{
 };
 use interledger_packet::Address;
 use serde_json::json;
+use std::net::SocketAddr;
 use std::str::FromStr;
 use tokio::runtime::Builder as RuntimeBuilder;
 
@@ -42,10 +43,12 @@ fn eth_xrp_interoperable() {
     let node1_http = get_open_port(Some(3010));
     let node1_settlement = get_open_port(Some(3011));
     let node1_engine = get_open_port(Some(3012));
+    let node1_engine_address = SocketAddr::from(([127, 0, 0, 1], node1_engine));
 
     let node2_http = get_open_port(Some(3020));
     let node2_settlement = get_open_port(Some(3021));
     let node2_engine = get_open_port(Some(3022));
+    let node2_engine_address = SocketAddr::from(([127, 0, 0, 1], node2_engine));
     let node2_xrp_engine_port = get_open_port(Some(3023));
     let node2_btp = get_open_port(Some(3024));
 
@@ -82,13 +85,13 @@ fn eth_xrp_interoperable() {
         "cc96601bc52293b53c4736a12af9130abf347669b3813f9ec4cafdf6991b087e".to_string();
     let node1_eth_engine_fut = start_eth_engine(
         connection_info1.clone(),
-        node1_engine,
+        node1_engine_address,
         node1_eth_key,
         node1_settlement,
     );
     let node2_eth_engine_fut = start_eth_engine(
         connection_info2.clone(),
-        node2_engine,
+        node2_engine_address,
         node2_eth_key,
         node2_settlement,
     );

--- a/crates/interledger-settlement-engines/tests/test_helpers.rs
+++ b/crates/interledger-settlement-engines/tests/test_helpers.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::HashMap;
 use std::fmt::{Debug, Display};
+use std::net::SocketAddr;
 use std::process::Command;
 use std::str;
 use std::thread::sleep;
@@ -69,14 +70,14 @@ pub fn start_xrp_engine(
 #[allow(unused)]
 pub fn start_eth_engine(
     db: ConnectionInfo,
-    engine_port: u16,
+    http_address: SocketAddr,
     key: String,
     settlement_port: u16,
 ) -> impl Future<Item = (), Error = ()> {
     run_ethereum_engine(
         db,
         "http://localhost:8545".to_string(),
-        engine_port,
+        http_address,
         key,
         1,
         0,


### PR DESCRIPTION
**This PR should be merged after #236 is merged**

Specifying a port for the settlement engine is not sufficient because sometimes we need to
specify the address, for example, running on Docker.

BREAKING CHANGE: Now --port option is obsolete, use http_address instead.

Signed-off-by: Taiga Nakayama <dora@dora-gt.jp>