### PR TITLE
fix(examples): avoid unnecessary blocking in simple example

### DIFF
--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -95,7 +95,6 @@ ILP_REDIS_CONNECTION=redis://127.0.0.1:6379/0 \
 ILP_HTTP_ADDRESS=127.0.0.1:7770 \
 ILP_BTP_ADDRESS=127.0.0.1:7768 \
 ILP_SETTLEMENT_ADDRESS=127.0.0.1:7771 \
-ILP_DEFAULT_SPSP_ACCOUNT=0 \
 cargo run --package interledger -- node &> logs/node_a.log &
 
 ILP_ADDRESS=example.node_b \
@@ -105,7 +104,6 @@ ILP_REDIS_CONNECTION=redis://127.0.0.1:6379/1 \
 ILP_HTTP_ADDRESS=127.0.0.1:8770 \
 ILP_BTP_ADDRESS=127.0.0.1:8768 \
 ILP_SETTLEMENT_ADDRESS=127.0.0.1:8771 \
-ILP_DEFAULT_SPSP_ACCOUNT=0 \
 cargo run --package interledger -- node &> logs/node_b.log &
 ```
 

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -85,6 +85,8 @@ When you want to watch logs, use the `tail` command. You can use the command lik
 # Turn on debug logging for all of the interledger.rs components
 export RUST_LOG=interledger=debug
 
+export CARGO_ROOT=$(git rev-parse --show-toplevel)
+
 # Start both nodes
 # Note that the configuration options can be passed as environment variables
 # or saved to a YAML file and passed to the node with the `--config` or `-c` CLI argument
@@ -95,7 +97,7 @@ ILP_REDIS_CONNECTION=redis://127.0.0.1:6379/0 \
 ILP_HTTP_ADDRESS=127.0.0.1:7770 \
 ILP_BTP_ADDRESS=127.0.0.1:7768 \
 ILP_SETTLEMENT_ADDRESS=127.0.0.1:7771 \
-cargo run --package interledger -- node &> logs/node_a.log &
+${CARGO_ROOT}/target/debug/interledger node &> logs/node_a.log &
 
 ILP_ADDRESS=example.node_b \
 ILP_SECRET_SEED=1604966725982139900555208458637022875563691455429373719368053354 \
@@ -104,7 +106,7 @@ ILP_REDIS_CONNECTION=redis://127.0.0.1:6379/1 \
 ILP_HTTP_ADDRESS=127.0.0.1:8770 \
 ILP_BTP_ADDRESS=127.0.0.1:8768 \
 ILP_SETTLEMENT_ADDRESS=127.0.0.1:8771 \
-cargo run --package interledger -- node &> logs/node_b.log &
+${CARGO_ROOT}/target/debug/interledger node &> logs/node_b.log &
 ```
 
 <!--!


### PR DESCRIPTION
Upon running the readme that executes the simple example, it first compiles the interledger-node binary from source with `cargo build  --bins` and once that's finished it runs the nodes using `cargo run`. The reason that these steps are separated (since `cargo run` already implies `cargo build`) is that we want to send the output of the first command to stdout so that the user has visual indication that compilation is happening, but we want to send the output of the second command to the logs. However I think we may currently be exposing some strange behavior of Cargo where the subsequent `cargo run` spends quite a long time blocked on waiting for the prior explicit `cargo build` to free the file lock on the build directory, despite the fact that the `cargo build` has long since finished. The easy way to visualize the delay is that our script prints one dot per second while waiting for the nodes to start up, here's the relevant excerpt:
```
  Compiling interledger v0.4.0 (/Users/bstriegel/Code/interledger-rs/crates/interledger)
    Finished dev [unoptimized + debuginfo] target(s) in 2m 47s

Waiting for Interledger.rs nodes to start up...
.......................................................................
The Interledger.rs nodes are up and running!
```
That's over a minute spent doing nothing but waiting *after* the `cargo build` has finished but *before* the `cargo run` thinks it has the go-ahead to proceed. In contrast, here's what it looks like if the README invokes the binaries directly rather than via `cargo run`:
```
Waiting for Interledger.rs nodes to start up...
..
The Interledger.rs nodes are up and running!
```
On my machine this causes the node start-up phase to take 2 seconds rather than 71. The current situation is especially unfortunate since the script output would lead a new or prospective user (who is just the person we expect to be running this example) to believe that our nodes are spending all that time slowly initializing, when in fact the machine is doing nothing at all.

This PR makes it so that we bypass `cargo run` when invoking the interledger-node binary in order to sidestep the problem, invoking the binaries directly. We don't hardcode any absolute paths because we don't want to assume that we know where the user is invoking this from (they could be doing `./run-md.sh ../examples/simple/README.md` or `../../scripts/run-md.sh README.md` or anything in between), so instead we use git to find the root of the repository and then navigate starting from there.

[This PR is based on #274, which fixes a bug that prevents the simple example from working at all]