### PR TITLE
fix(examples): spruce up all three examples

### DIFF
--- a/examples/eth-settlement/README.md
+++ b/examples/eth-settlement/README.md
@@ -51,7 +51,7 @@ Make sure your Redis is empty. You could run `redis-cli flushall` to clear all t
 <!--!
 printf "Stopping Interledger nodes\n"
 
-if lsof -Pi :6379 -sTCP:LISTEN -t >/dev/null ; then
+if lsof -Pi :6379 -sTCP:LISTEN -t ; then
     redis-cli -p 6379 shutdown
 fi
 
@@ -85,12 +85,13 @@ First of all, let's build interledger.rs. (This may take a couple of minutes)
 
 <!--! printf "Building interledger.rs... (This may take a couple of minutes)\n" -->
 ```bash
-cargo build --bins
+cargo build --bin interledger --bin interledger-settlement-engines
 ```
 
 ### 2. Launch Redis
 
 <!--!
+printf "Starting Redis\n"
 redis-server --version > /dev/null || printf "\e[31mUh oh! You need to install redis-server before running this example\e[m\n"
 -->
 
@@ -100,6 +101,15 @@ mkdir -p logs
 
 # Start Redis
 redis-server &> logs/redis.log &
+```
+
+<!--!
+sleep 1
+-->
+
+To remove all the data in Redis, you might additionally perform:
+
+```bash
 redis-cli flushall
 ```
 
@@ -125,7 +135,7 @@ Because each node needs its own settlement engine, we need to launch both a sett
 export RUST_LOG=interledger=debug
 
 # Start Alice's settlement engine
-cargo run --package interledger-settlement-engines -- ethereum-ledger \
+cargo run --bin interledger-settlement-engines -- ethereum-ledger \
 --key 380eb0f3d505f087e438eca80bc4df9a7faa24f868e69fc0440261a0fc0567dc \
 --confirmations 0 \
 --poll_frequency 1000 \
@@ -137,7 +147,7 @@ cargo run --package interledger-settlement-engines -- ethereum-ledger \
 &> logs/node-alice-settlement-engine.log &
 
 # Start Bob's settlement engine
-cargo run --package interledger-settlement-engines -- ethereum-ledger \
+cargo run --bin interledger-settlement-engines -- ethereum-ledger \
 --key cc96601bc52293b53c4736a12af9130abf347669b3813f9ec4cafdf6991b087e \
 --confirmations 0 \
 --poll_frequency 1000 \
@@ -160,8 +170,7 @@ ILP_REDIS_CONNECTION=redis://127.0.0.1:6379/0 \
 ILP_HTTP_ADDRESS=127.0.0.1:7770 \
 ILP_BTP_ADDRESS=127.0.0.1:7768 \
 ILP_SETTLEMENT_ADDRESS=127.0.0.1:7771 \
-ILP_DEFAULT_SPSP_ACCOUNT=0 \
-cargo run --package interledger -- node &> logs/node-alice.log &
+cargo run --bin interledger -- node &> logs/node-alice.log &
 
 # Start Bob's node
 ILP_ADDRESS=example.bob \
@@ -171,8 +180,7 @@ ILP_REDIS_CONNECTION=redis://127.0.0.1:6379/1 \
 ILP_HTTP_ADDRESS=127.0.0.1:8770 \
 ILP_BTP_ADDRESS=127.0.0.1:8768 \
 ILP_SETTLEMENT_ADDRESS=127.0.0.1:8771 \
-ILP_DEFAULT_SPSP_ACCOUNT=0 \
-cargo run --package interledger -- node &> logs/node-bob.log &
+cargo run --bin interledger -- node &> logs/node-bob.log &
 ```
 
 <!--!
@@ -394,7 +402,11 @@ fi
 ### 9. Kill All the Services
 Finally, you can stop all the services as follows:
 
-```bash #
+<!--!
+exec 2> /dev/null
+-->
+
+```bash
 if lsof -Pi :6379 -sTCP:LISTEN -t >/dev/null ; then
     redis-cli -p 6379 shutdown
 fi
@@ -402,24 +414,19 @@ fi
 if [ -f dump.rdb ] ; then
     rm -f dump.rdb
 fi
-
-if lsof -tPi :8545 ; then
+if lsof -tPi :8545 > /dev/null ; then
     kill `lsof -tPi :8545`
 fi
-
-if lsof -tPi :7770 ; then
+if lsof -tPi :7770 > /dev/null ; then
     kill `lsof -tPi :7770`
 fi
-
-if lsof -tPi :8770 ; then
+if lsof -tPi :8770 > /dev/null ; then
     kill `lsof -tPi :8770`
 fi
-
-if lsof -tPi :3000 ; then
+if lsof -tPi :3000 > /dev/null ; then
     kill `lsof -tPi :3000`
 fi
-
-if lsof -tPi :3001 ; then
+if lsof -tPi :3001 > /dev/null ; then
     kill `lsof -tPi :3001`
 fi
 ```

--- a/examples/eth_xrp_three_nodes/README.md
+++ b/examples/eth_xrp_three_nodes/README.md
@@ -69,15 +69,15 @@ function error_and_exit() {
 
 printf "Stopping Interledger nodes\n"
 
-if lsof -Pi :6379 -sTCP:LISTEN -t >/dev/null ; then
+if lsof -Pi :6379 -sTCP:LISTEN -t ; then
     redis-cli -p 6379 shutdown
 fi
 
-if lsof -Pi :6380 -sTCP:LISTEN -t >/dev/null ; then
+if lsof -Pi :6380 -sTCP:LISTEN -t ; then
     redis-cli -p 6380 shutdown
 fi
 
-if lsof -Pi :6381 -sTCP:LISTEN -t >/dev/null ; then
+if lsof -Pi :6381 -sTCP:LISTEN -t ; then
     redis-cli -p 6381 shutdown
 fi
 
@@ -123,12 +123,13 @@ First of all, let's build interledger.rs. (This may take a couple of minutes)
 
 <!--! printf "Building interledger.rs... (This may take a couple of minutes)\n" -->
 ```bash
-cargo build --bins
+cargo build --bin interledger --bin interledger-settlement-engines
 ```
 
 ### 2. Launch Redis
 
 <!--!
+printf "Starting Redis\n"
 redis-server --version &> /dev/null || error_and_exit "Uh oh! You need to install redis-server before running this example"
 -->
 
@@ -185,7 +186,7 @@ which ilp-settlement-xrp &> /dev/null || error_and_exit "You need to install \"i
 export RUST_LOG=interledger=debug
 
 # Start Alice's settlement engine (ETH)
-cargo run --package interledger-settlement-engines -- ethereum-ledger \
+cargo run --bin interledger-settlement-engines -- ethereum-ledger \
 --key 380eb0f3d505f087e438eca80bc4df9a7faa24f868e69fc0440261a0fc0567dc \
 --confirmations 0 \
 --poll_frequency 1000 \
@@ -198,7 +199,7 @@ cargo run --package interledger-settlement-engines -- ethereum-ledger \
 &> logs/node-alice-settlement-engine-eth.log &
 
 # Start Bob's settlement engine (ETH, XRPL)
-cargo run --package interledger-settlement-engines -- ethereum-ledger \
+cargo run --bin interledger-settlement-engines -- ethereum-ledger \
 --key cc96601bc52293b53c4736a12af9130abf347669b3813f9ec4cafdf6991b087e \
 --confirmations 0 \
 --poll_frequency 1000 \
@@ -241,8 +242,7 @@ ILP_REDIS_CONNECTION=redis://127.0.0.1:6379/0 \
 ILP_HTTP_ADDRESS=127.0.0.1:7770 \
 ILP_BTP_ADDRESS=127.0.0.1:7768 \
 ILP_SETTLEMENT_ADDRESS=127.0.0.1:7771 \
-ILP_DEFAULT_SPSP_ACCOUNT=0 \
-cargo run --package interledger -- node &> logs/node-alice.log &
+cargo run --bin interledger -- node &> logs/node-alice.log &
 
 # Start Bob's node
 ILP_ADDRESS=example.bob \
@@ -252,8 +252,7 @@ ILP_REDIS_CONNECTION=redis://127.0.0.1:6380/0 \
 ILP_HTTP_ADDRESS=127.0.0.1:8770 \
 ILP_BTP_ADDRESS=127.0.0.1:8768 \
 ILP_SETTLEMENT_ADDRESS=127.0.0.1:8771 \
-ILP_DEFAULT_SPSP_ACCOUNT=0 \
-cargo run --package interledger -- node &> logs/node-bob.log &
+cargo run --bin interledger -- node &> logs/node-bob.log &
 
 # Start Charlie's node
 ILP_ADDRESS=example.bob.charlie \
@@ -263,8 +262,7 @@ ILP_REDIS_CONNECTION=redis://127.0.0.1:6381/0 \
 ILP_HTTP_ADDRESS=127.0.0.1:9770 \
 ILP_BTP_ADDRESS=127.0.0.1:9768 \
 ILP_SETTLEMENT_ADDRESS=127.0.0.1:9771 \
-ILP_DEFAULT_SPSP_ACCOUNT=0 \
-cargo run --package interledger -- node &> logs/node-charlie.log &
+cargo run --bin interledger -- node &> logs/node-charlie.log &
 ```
 
 <!--!
@@ -493,7 +491,7 @@ curl \
 
 You may see unsettled balances before the settlement engines exactly work. Wait a few seconds and try later.
 
-```bash #
+```bash
 printf "\nAlice's balance on Alice's node: "
 curl \
 -H "Authorization: Bearer hi_alice" \
@@ -586,7 +584,11 @@ fi
 ### 9. Kill All the Services
 Finally, you can stop all the services as follows:
 
-```bash #
+<!--!
+exec 2> /dev/null
+-->
+
+```bash
 if lsof -Pi :6379 -sTCP:LISTEN -t >/dev/null ; then
     redis-cli -p 6379 shutdown
 fi
@@ -603,35 +605,35 @@ if [ -f dump.rdb ] ; then
     rm -f dump.rdb
 fi
 
-if lsof -tPi :8545 ; then
+if lsof -tPi :8545 > /dev/null ; then
     kill `lsof -tPi :8545`
 fi
 
-if lsof -tPi :7770 ; then
+if lsof -tPi :7770 > /dev/null ; then
     kill `lsof -tPi :7770`
 fi
 
-if lsof -tPi :8770 ; then
+if lsof -tPi :8770 > /dev/null ; then
     kill `lsof -tPi :8770`
 fi
 
-if lsof -tPi :9770 ; then
+if lsof -tPi :9770 > /dev/null ; then
     kill `lsof -tPi :9770`
 fi
 
-if lsof -tPi :3000 ; then
+if lsof -tPi :3000 > /dev/null ; then
     kill `lsof -tPi :3000`
 fi
 
-if lsof -tPi :3001 ; then
+if lsof -tPi :3001 > /dev/null ; then
     kill `lsof -tPi :3001`
 fi
 
-if lsof -tPi :3002 ; then
+if lsof -tPi :3002 > /dev/null ; then
     kill `lsof -tPi :3002`
 fi
 
-if lsof -tPi :3003 ; then
+if lsof -tPi :3003 > /dev/null ; then
     kill `lsof -tPi :3003`
 fi
 ```

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -36,7 +36,7 @@ Make sure your Redis is empty. You could run `redis-cli flushall` to clear all t
 <!--!
 printf "Stopping Interledger nodes\n"
 
-if lsof -Pi :6379 -sTCP:LISTEN -t >/dev/null ; then
+if lsof -Pi :6379 -sTCP:LISTEN -t ; then
     redis-cli -p 6379 shutdown
 fi
 
@@ -60,7 +60,7 @@ First of all, let's build interledger.rs. (This may take a couple of minutes)
 
 <!--! printf "Building interledger.rs... (This may take a couple of minutes)\n" -->
 ```bash
-cargo build --bins
+cargo build --bin interledger
 ```
 
 ### 2. Launch Redis
@@ -95,7 +95,7 @@ ILP_REDIS_CONNECTION=redis://127.0.0.1:6379/0 \
 ILP_HTTP_ADDRESS=127.0.0.1:7770 \
 ILP_BTP_ADDRESS=127.0.0.1:7768 \
 ILP_SETTLEMENT_ADDRESS=127.0.0.1:7771 \
-cargo run --package interledger -- node &> logs/node_a.log &
+cargo run --bin interledger -- node &> logs/node_a.log &
 
 ILP_ADDRESS=example.node_b \
 ILP_SECRET_SEED=1604966725982139900555208458637022875563691455429373719368053354 \
@@ -104,7 +104,7 @@ ILP_REDIS_CONNECTION=redis://127.0.0.1:6379/1 \
 ILP_HTTP_ADDRESS=127.0.0.1:8770 \
 ILP_BTP_ADDRESS=127.0.0.1:8768 \
 ILP_SETTLEMENT_ADDRESS=127.0.0.1:8771 \
-cargo run --package interledger -- node &> logs/node_b.log &
+cargo run --bin interledger -- node &> logs/node_b.log &
 ```
 
 <!--!
@@ -290,7 +290,10 @@ http://localhost:8770/accounts/bob/balance
 ### 7. Kill All the Services
 Finally, you can stop all the services as follows:
 
-<!--! printf "Stopping Interledger nodes\n" -->
+<!--!
+printf "Stopping Interledger nodes\n"
+exec 2> /dev/null
+-->
 
 ```bash
 if lsof -Pi :6379 -sTCP:LISTEN -t >/dev/null ; then
@@ -302,11 +305,11 @@ if [ -f dump.rdb ] ; then
     rm -f dump.rdb
 fi
 
-if lsof -tPi :7770 ; then
+if lsof -tPi :7770 > /dev/null ; then
     kill `lsof -tPi :7770`
 fi
 
-if lsof -tPi :8770 ; then
+if lsof -tPi :8770 > /dev/null ; then
     kill `lsof -tPi :8770`
 fi
 ```


### PR DESCRIPTION
While fixing a bug in one of the examples I got caught up in fixing other bugs that I found, and did so for all three examples. This commit fixes the following:

1. Previously we were building with `cargo build --bins` and running with `cargo run --package foo`, but because --bin and --package represent different things, we were actually building nearly the whole repo twice in every example. I've switched to using --bin everywhere, which should have a dramatic effect on build times for new users.

2. Scripts weren't tearing down their servers at the end, presumably as a temporary solution to solve the problem of the user seeing error messages from processes as they were force-killed. I've addressed this with `exec 2> /dev/null` before we kill the processes and re-enabled the teardown at the end.

3. We intentionally tear down twice in each example: at the beginning to make sure we're starting fresh (in case a previous run of the script was killed prematurely, for instance), and at the end to be nice to our users. We were somewhat inconsistently silencing the output of various teardown steps; now we silence all teardown for the finishing stage, but don't silence teardown for the beginning stage (since tearing down in the beginning stage is unexpected, so if we see anything that may indicative of a bug).

4. Inserted a sleep in one spot so that Redis has a chance to start before trying to flush it, which avoids printing an error to the terminal.

5. Updates the two advanced examples so that they function following #268 