### PR TITLE
feat: allow endpoints to accept strings or numbers in JSON

### DIFF
--- a/crates/interledger-api/src/routes/accounts.rs
+++ b/crates/interledger-api/src/routes/accounts.rs
@@ -1,4 +1,6 @@
-use crate::{http_retry::Client, AccountDetails, AccountSettings, ApiError, NodeStore};
+use crate::{
+    http_retry::Client, number_or_string, AccountDetails, AccountSettings, ApiError, NodeStore,
+};
 use bytes::Bytes;
 use futures::{
     future::{err, join_all, ok, Either},
@@ -30,6 +32,7 @@ const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_millis(5000);
 #[derive(Deserialize, Debug)]
 struct SpspPayRequest {
     receiver: String,
+    #[serde(deserialize_with = "number_or_string")]
     source_amount: u64,
 }
 


### PR DESCRIPTION
This PR extracts the node-side pieces of #334 that allow clients of the HTTP API to choose to pass strings where numbers are expected. Has already incorporated feedback from #334 so should not be difficult to review.