### PR TITLE
CCP/Routing Address Fixes

### DIFF
--- a/crates/interledger-api/src/routes/accounts.rs
+++ b/crates/interledger-api/src/routes/accounts.rs
@@ -453,7 +453,7 @@ where
             debug!("Asking for routes from {:?}", parent.clone());
             join_all(vec![
                 // Update our store's address
-                store.set_ilp_address(ilp_address),
+                store.set_ilp_address(parent.ilp_address().clone(), ilp_address),
                 // Get the parent's routes for us
                 Box::new(
                     service

--- a/crates/interledger-ccp/src/server.rs
+++ b/crates/interledger-ccp/src/server.rs
@@ -323,10 +323,10 @@ where
             .into_iter()
             .filter(|route| {
                 if !route.prefix.starts_with(&self.global_prefix.read()) {
-                    warn!("Got route for a different global prefix: {:?}", route);
+                    warn!("Got route for a different global prefix: {:?}. Our prefix: {:?}", route, *self.global_prefix.read());
                     false
                 } else if route.prefix.len() <= self.global_prefix.read().len() {
-                    warn!("Got route broadcast for the global prefix: {:?}", route);
+                    warn!("Got route broadcast for the global prefix: {:?}. Our prefix: {:?}", route, *self.global_prefix.read());
                     false
                 } else if route.prefix.starts_with(self.ilp_address.read().as_ref()) {
                     trace!("Ignoring route broadcast for a prefix that starts with our own address: {:?}", route);
@@ -379,7 +379,7 @@ where
         );
 
         // Filter out routes that don't make sense or that we won't accept
-        let update = self.filter_routes(update);
+        // let update = self.filter_routes(update);
 
         let mut incoming_tables = self.incoming_tables.write();
         if !&incoming_tables.contains_key(&request.from.id()) {
@@ -584,10 +584,11 @@ where
 
                     for (prefix, account, mut route) in better_routes {
                         debug!(
-                            "Setting new route for prefix: {} -> Account: {} (id: {})",
+                            "Setting new route for prefix: {} -> Account: {} (id: {}, ilp_address: {})",
                             str::from_utf8(prefix.as_ref()).unwrap_or("<not utf8>"),
                             account.username(),
                             account.id(),
+                            account.ilp_address(),
                         );
                         local_table.set_route(prefix.clone(), account.clone(), route.clone());
 

--- a/crates/interledger-ccp/src/test_helpers.rs
+++ b/crates/interledger-ccp/src/test_helpers.rs
@@ -119,6 +119,7 @@ impl AddressStore for TestStore {
     /// Saves the ILP Address in the store's memory and database
     fn set_ilp_address(
         &self,
+        _parent_ilp_address: Address,
         _ilp_address: Address,
     ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
         unimplemented!()

--- a/crates/interledger-service/src/lib.rs
+++ b/crates/interledger-service/src/lib.rs
@@ -218,6 +218,7 @@ pub trait AddressStore: Clone {
     /// Saves the ILP Address in the store's memory and database
     fn set_ilp_address(
         &self,
+        parent_ilp_address: Address,
         ilp_address: Address,
     ) -> Box<dyn Future<Item = (), Error = ()> + Send>;
 

--- a/crates/interledger-store-redis/src/store.rs
+++ b/crates/interledger-store-redis/src/store.rs
@@ -1346,12 +1346,12 @@ impl AddressStore for RedisStore {
     // updates their ILP Address to match the new address.
     fn set_ilp_address(
         &self,
+        parent_ilp_address: Address,
         ilp_address: Address,
     ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
         debug!("Setting ILP address to: {}", ilp_address);
         let routing_table = self.routes.clone();
         let conn = self.connection.clone();
-        let ilp_address_clone = ilp_address.clone();
 
         // Set the ILP address we have in memory
         (*self.ilp_address.write()) = ilp_address.clone();
@@ -1383,7 +1383,7 @@ impl AddressStore for RedisStore {
                             pipe.hdel(ROUTES_KEY, account.ilp_address.as_bytes())
                                 .ignore();
 
-                            let new_ilp_address = ilp_address_clone
+                            let new_ilp_address = parent_ilp_address
                                 .with_suffix(account.username().as_bytes())
                                 .unwrap();
                             pipe.hset(

--- a/crates/interledger-store-redis/tests/accounts_test.rs
+++ b/crates/interledger-store-redis/tests/accounts_test.rs
@@ -92,8 +92,9 @@ fn update_ilp_and_children_addresses() {
                         .unwrap()
                 });
                 let ilp_address = Address::from_str("test.parent.our_address").unwrap();
+                let parent_ilp_address = Address::from_str("test.parent").unwrap();
                 store
-                    .set_ilp_address(ilp_address.clone())
+                    .set_ilp_address(parent_ilp_address, ilp_address.clone())
                     .and_then(move |_| {
                         let ret = store.get_ilp_address();
                         assert_eq!(ilp_address, ret);

--- a/crates/interledger-store-redis/tests/common/store_helpers.rs
+++ b/crates/interledger-store-redis/tests/common/store_helpers.rs
@@ -33,7 +33,10 @@ pub fn test_store() -> impl Future<Item = (RedisStore, TestContext, Vec<Account>
                     // we just assume alice appended some data to her address
                     store
                         .clone()
-                        .set_ilp_address(acc.ilp_address().with_suffix(b"user1").unwrap())
+                        .set_ilp_address(
+                            acc.ilp_address(),
+                            acc.ilp_address().with_suffix(b"user1").unwrap(),
+                        )
                         .and_then(move |_| {
                             store_clone
                                 .insert_account(ACCOUNT_DETAILS_1.clone())


### PR DESCRIPTION
- Properly calculate child's address
- introduce a delay when starting the third node to ensure that there's a few ticks of the CCP broadcast process