### PR TITLE
Fetch ILP Address from the store

### DIFF
--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -214,11 +214,10 @@ impl InterledgerNode {
                             // service to others like the router and then call handle_incoming on it to set up the incoming handler
                             let outgoing_service = btp_server_service.clone();
                             let outgoing_service = ValidatorService::outgoing(
-                                ilp_address.clone(),
+                                store.clone(),
                                 outgoing_service
                             );
                             let outgoing_service = HttpClientService::new(
-                                ilp_address.clone(),
                                 store.clone(),
                                 outgoing_service,
                             );
@@ -233,12 +232,10 @@ impl InterledgerNode {
                                 outgoing_service,
                             );
                             let outgoing_service = BalanceService::new(
-                                ilp_address.clone(),
                                 store.clone(),
                                 outgoing_service,
                             );
                             let outgoing_service = ExchangeRateService::new(
-                                ilp_address.clone(),
                                 exchange_rate_spread,
                                 store.clone(),
                                 outgoing_service,
@@ -246,7 +243,6 @@ impl InterledgerNode {
 
                             // Set up the Router and Routing Manager
                             let incoming_service = Router::new(
-                                ilp_address.clone(),
                                 store.clone(),
                                 outgoing_service.clone()
                             );
@@ -261,18 +257,17 @@ impl InterledgerNode {
                                 ccp_builder.broadcast_interval(ms);
                             }
                             let incoming_service = ccp_builder.to_service();
-                            let incoming_service = EchoService::new(ilp_address.clone(), incoming_service);
-                            let incoming_service = SettlementMessageService::new(ilp_address.clone(), incoming_service);
+                            let incoming_service = EchoService::new(store.clone(), incoming_service);
+                            let incoming_service = SettlementMessageService::new(incoming_service);
                             let incoming_service = IldcpService::new(incoming_service);
                             let incoming_service =
                                 MaxPacketAmountService::new(
-                                    ilp_address.clone(),
+                                    store.clone(),
                                     incoming_service
                             );
                             let incoming_service =
-                                ValidatorService::incoming(ilp_address.clone(), incoming_service);
+                                ValidatorService::incoming(store.clone(), incoming_service);
                             let incoming_service = RateLimitService::new(
-                                ilp_address.clone(),
                                 store.clone(),
                                 incoming_service,
                             );

--- a/crates/interledger-service-util/src/max_packet_amount_service.rs
+++ b/crates/interledger-service-util/src/max_packet_amount_service.rs
@@ -1,5 +1,5 @@
 use futures::future::err;
-use interledger_packet::{Address, ErrorCode, MaxPacketAmountDetails, RejectBuilder};
+use interledger_packet::{ErrorCode, MaxPacketAmountDetails, RejectBuilder};
 use interledger_service::*;
 use log::debug;
 
@@ -16,20 +16,21 @@ pub trait MaxPacketAmountAccount: Account {
 /// Signaling: nodes SHOULD set the maximum packet amount _lower_ than the maximum amount in flight (also known as the payment or money bandwidth). `T04: Insufficient Liquidity` errors do not communicate to the sender how much they can send, largely because the "available liquidity" may be time based or based on the rate of other payments going through and thus difficult to communicate effectively. In contrast, the `F08: Amount Too Large` error conveys the maximum back to the sender, because this limit is assumed to be a static value, and alllows sender-side software like STREAM implementations to respond accordingly. Therefore, setting the maximum packet amount lower than the total money bandwidth allows client implementations to quickly adjust their packet amounts to appropriate levels.
 /// Requires a `MaxPacketAmountAccount` and _no store_.
 #[derive(Clone)]
-pub struct MaxPacketAmountService<I> {
-    ilp_address: Address,
+pub struct MaxPacketAmountService<I, S> {
     next: I,
+    store: S,
 }
 
-impl<I> MaxPacketAmountService<I> {
-    pub fn new(ilp_address: Address, next: I) -> Self {
-        MaxPacketAmountService { ilp_address, next }
+impl<I, S> MaxPacketAmountService<I, S> {
+    pub fn new(store: S, next: I) -> Self {
+        MaxPacketAmountService { store, next }
     }
 }
 
-impl<I, A> IncomingService<A> for MaxPacketAmountService<I>
+impl<I, S, A> IncomingService<A> for MaxPacketAmountService<I, S>
 where
     I: IncomingService<A>,
+    S: AddressStore,
     A: MaxPacketAmountAccount,
 {
     type Future = BoxedIlpFuture;
@@ -37,6 +38,7 @@ where
     /// On receive request:
     /// 1. if request.prepare.amount <= request.from.max_packet_amount forward the request, else error
     fn handle_request(&mut self, request: IncomingRequest<A>) -> Self::Future {
+        let ilp_address = self.store.get_ilp_address();
         let max_packet_amount = request.from.max_packet_amount();
         if request.prepare.amount() <= max_packet_amount {
             Box::new(self.next.handle_request(request))
@@ -51,7 +53,7 @@ where
             Box::new(err(RejectBuilder {
                 code: ErrorCode::F08_AMOUNT_TOO_LARGE,
                 message: &[],
-                triggered_by: Some(&self.ilp_address),
+                triggered_by: Some(&ilp_address),
                 data: &details[..],
             }
             .build()))

--- a/crates/interledger-settlement/src/message_service.rs
+++ b/crates/interledger-settlement/src/message_service.rs
@@ -3,7 +3,7 @@ use futures::{
     future::{err, Either},
     Future, Stream,
 };
-use interledger_packet::{Address, ErrorCode, FulfillBuilder, RejectBuilder};
+use interledger_packet::{ErrorCode, FulfillBuilder, RejectBuilder};
 use interledger_service::{BoxedIlpFuture, IncomingRequest, IncomingService};
 use log::error;
 use reqwest::r#async::Client;
@@ -14,7 +14,6 @@ const PEER_FULFILLMENT: [u8; 32] = [0; 32];
 
 #[derive(Clone)]
 pub struct SettlementMessageService<I, A> {
-    ilp_address: Address,
     next: I,
     http_client: Client,
     account_type: PhantomData<A>,
@@ -25,10 +24,9 @@ where
     I: IncomingService<A>,
     A: SettlementAccount,
 {
-    pub fn new(ilp_address: Address, next: I) -> Self {
+    pub fn new(next: I) -> Self {
         SettlementMessageService {
             next,
-            ilp_address,
             http_client: Client::new(),
             account_type: PhantomData,
         }
@@ -125,7 +123,7 @@ mod tests {
     use super::*;
     use crate::fixtures::{BODY, DATA, SERVICE_ADDRESS, TEST_ACCOUNT_0};
     use crate::test_helpers::{block_on, mock_message, test_service};
-    use interledger_packet::{Fulfill, PrepareBuilder, Reject};
+    use interledger_packet::{Address, Fulfill, PrepareBuilder, Reject};
     use std::str::FromStr;
     use std::time::SystemTime;
 

--- a/crates/interledger-settlement/src/test_helpers.rs
+++ b/crates/interledger-settlement/src/test_helpers.rs
@@ -218,18 +218,15 @@ where
 
 pub fn test_service(
 ) -> SettlementMessageService<impl IncomingService<TestAccount> + Clone, TestAccount> {
-    SettlementMessageService::new(
-        SERVICE_ADDRESS.clone(),
-        incoming_service_fn(|_request| {
-            Box::new(err(RejectBuilder {
-                code: ErrorCode::F02_UNREACHABLE,
-                message: b"No other incoming handler!",
-                data: &[],
-                triggered_by: Some(&SERVICE_ADDRESS),
-            }
-            .build()))
-        }),
-    )
+    SettlementMessageService::new(incoming_service_fn(|_request| {
+        Box::new(err(RejectBuilder {
+            code: ErrorCode::F02_UNREACHABLE,
+            message: b"No other incoming handler!",
+            data: &[],
+            triggered_by: Some(&SERVICE_ADDRESS),
+        }
+        .build()))
+    }))
 }
 
 pub fn test_store(store_fails: bool, account_has_engine: bool) -> TestStore {

--- a/crates/interledger-stream/src/lib.rs
+++ b/crates/interledger-stream/src/lib.rs
@@ -24,7 +24,7 @@ pub mod test_helpers {
     use futures::{future::ok, sync::mpsc::UnboundedSender, Future};
     use interledger_packet::Address;
     use interledger_router::RouterStore;
-    use interledger_service::{Account, AccountStore, Username};
+    use interledger_service::{Account, AccountStore, AddressStore, Username};
     use lazy_static::lazy_static;
     use std::collections::HashMap;
     use std::iter::FromIterator;
@@ -113,6 +113,25 @@ pub mod test_helpers {
             HashMap::from_iter(vec![(self.route.0.clone(), self.route.1.id())].into_iter())
         }
     }
+
+    impl AddressStore for TestStore {
+        /// Saves the ILP Address in the store's memory and database
+        fn set_ilp_address(
+            &self,
+            _ilp_address: Address,
+        ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+            unimplemented!()
+        }
+
+        fn clear_ilp_address(&self) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+            unimplemented!()
+        }
+
+        /// Get's the store's ilp address from memory
+        fn get_ilp_address(&self) -> Address {
+            Address::from_str("example.connector").unwrap()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -156,7 +175,7 @@ mod send_money_to_receiver {
                 .build())
             }),
         );
-        let server = Router::new(EXAMPLE_RECEIVER.clone(), store, server);
+        let server = Router::new(store, server);
         let server = IldcpService::new(server);
 
         let (destination_account, shared_secret) =


### PR DESCRIPTION
Previously we were constructing the value once, and did not account for any changes to the node's ilp address due to adding a parent.