### PR TITLE
Reduce CCP log chattiness

### DIFF
--- a/crates/interledger-service-util/src/expiry_shortener_service.rs
+++ b/crates/interledger-service-util/src/expiry_shortener_service.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Duration, Utc};
 use interledger_service::{Account, OutgoingRequest, OutgoingService};
-use log::debug;
+use log::trace;
 
 pub const DEFAULT_ROUND_TRIP_TIME: u32 = 500;
 pub const DEFAULT_MAX_EXPIRY_DURATION: u32 = 30000;
@@ -60,7 +60,7 @@ where
         let latest_allowable_expiry =
             Utc::now() + Duration::milliseconds(i64::from(self.max_expiry_duration));
         let new_expiry = if new_expiry > latest_allowable_expiry {
-            debug!(
+            trace!(
                 "Shortening packet expiry duration to {}ms in the future",
                 self.max_expiry_duration
             );

--- a/crates/interledger-store-redis/src/store.rs
+++ b/crates/interledger-store-redis/src/store.rs
@@ -1855,6 +1855,8 @@ fn update_routes(
                         .chain(static_routes.into_iter())
                         .map(|(prefix, account_id)| (Bytes::from(prefix), account_id)),
                 );
+                // TODO we may not want to print this because the routing table will be very big
+                // if the node has a lot of local accounts
                 trace!("Routing table is: {:?}", routes);
                 *routing_table.write() = routes;
                 Ok(())


### PR DESCRIPTION
Minor PR but looking through the testnet node logs, they are currently filled with output from a couple of these log lines