### PR TITLE
Don't broadcast routes to unavailable accounts

### DIFF
--- a/crates/interledger-ccp/src/lib.rs
+++ b/crates/interledger-ccp/src/lib.rs
@@ -102,6 +102,7 @@ pub trait RouteManagerStore: Clone {
 
     fn get_accounts_to_send_routes_to(
         &self,
+        ignore_accounts: Vec<<Self::Account as Account>::AccountId>,
     ) -> Box<dyn Future<Item = Vec<Self::Account>, Error = ()> + Send>;
 
     fn get_accounts_to_receive_routes_from(

--- a/crates/interledger-ccp/src/server.rs
+++ b/crates/interledger-ccp/src/server.rs
@@ -636,7 +636,7 @@ where
     fn send_route_updates(&self) -> impl Future<Item = (), Error = ()> {
         let self_clone = self.clone();
         self.store
-            .get_accounts_to_send_routes_to()
+            .get_accounts_to_send_routes_to(Vec::new())
             .and_then(move |mut accounts| {
                 let mut outgoing = self_clone.outgoing.clone();
                 let to_epoch_index = self_clone.forwarding_table.read().epoch();

--- a/crates/interledger-ccp/src/test_helpers.rs
+++ b/crates/interledger-ccp/src/test_helpers.rs
@@ -148,13 +148,16 @@ impl RouteManagerStore for TestStore {
 
     fn get_accounts_to_send_routes_to(
         &self,
+        ignore_accounts: Vec<u64>,
     ) -> Box<dyn Future<Item = Vec<TestAccount>, Error = ()> + Send> {
         let mut accounts: Vec<TestAccount> = self
             .local
             .values()
             .chain(self.configured.values())
             .chain(self.routes.lock().values())
-            .filter(|account| account.should_send_routes())
+            .filter(|account| {
+                account.should_send_routes() && !ignore_accounts.contains(&account.id())
+            })
             .cloned()
             .collect();
         accounts.dedup_by_key(|a| a.id());

--- a/crates/interledger-ccp/src/test_helpers.rs
+++ b/crates/interledger-ccp/src/test_helpers.rs
@@ -156,7 +156,7 @@ impl RouteManagerStore for TestStore {
             .chain(self.configured.values())
             .chain(self.routes.lock().values())
             .filter(|account| {
-                account.should_send_routes() && !ignore_accounts.contains(&account.id())
+                account.should_send_routes() && !ignore_accounts.contains(&account.id)
             })
             .cloned()
             .collect();

--- a/crates/interledger-store-redis/src/reconnect.rs
+++ b/crates/interledger-store-redis/src/reconnect.rs
@@ -59,7 +59,6 @@ impl ConnectionLike for RedisReconnect {
                 .req_packed_command(cmd)
                 .or_else(move |error| {
                     if error.is_connection_dropped() {
-                        // TODO should the request be retried automatically?
                         debug!("Redis connection was dropped, attempting to reconnect");
                         Either::A(clone.reconnect().then(|_| Err(error)))
                     } else {

--- a/crates/interledger-store-redis/tests/routing_test.rs
+++ b/crates/interledger-store-redis/tests/routing_test.rs
@@ -122,13 +122,25 @@ fn polls_for_route_updates() {
 fn gets_accounts_to_send_routes_to() {
     block_on(test_store().and_then(|(store, context, _accs)| {
         store
-            .get_accounts_to_send_routes_to()
+            .get_accounts_to_send_routes_to(Vec::new())
             .and_then(move |accounts| {
-                assert_eq!(
-                    *accounts[0].ilp_address(),
-                    Address::from_str("example.alice.user1.bob").unwrap()
-                );
+                // We send to child accounts but not parents
+                assert_eq!(accounts[0].username().as_ref(), "bob");
                 assert_eq!(accounts.len(), 1);
+                let _ = context;
+                Ok(())
+            })
+    }))
+    .unwrap()
+}
+
+#[test]
+fn gets_accounts_to_send_routes_to_and_skips_ignored() {
+    block_on(test_store().and_then(|(store, context, accs)| {
+        store
+            .get_accounts_to_send_routes_to(vec![accs[1].id()])
+            .and_then(move |accounts| {
+                assert!(accounts.is_empty());
                 let _ = context;
                 Ok(())
             })


### PR DESCRIPTION
Right now the testnet node wastes a lot of resources trying to broadcast routes to all of the child accounts, many of whom are offline (because they use localtunnel to connect). This changes the behavior such that it will back off from sending route updates to child accounts when the requests fail. This does not affect the behavior for Peer accounts.