### PR TITLE
Speed up CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,10 @@
 version: 2
 jobs:
-  build:
+  style-and-audit:
     docker:
       - image: circleci/rust
         environment:
           CARGO_HOME: /home/circleci/.cargo
-    resource_class: medium+
     steps:
       - checkout
       - run:
@@ -14,11 +13,26 @@ jobs:
             cargo install --quiet cargo-audit || true # cargo-kcov
             rustup component add rustfmt clippy || true
       - run:
-          name: Install Redis
+          name: cargo fmt
           command: |
-            sudo apt-get update
-            sudo apt-get install redis-server
-            redis-server --version
+            cargo fmt --all -- --check
+      - run:
+          name: cargo clippy
+          command: |
+            cargo clippy --all-targets --all-features -- -D warnings
+      - run:
+          name: cargo audit
+          command: cargo audit
+
+  build-test:
+    docker:
+      - image: circleci/rust
+        environment:
+          CARGO_HOME: /home/circleci/.cargo
+    # TODO try even larger box, maybe we can speed it up and avoid needing to reduce the codegen units
+    resource_class: medium+
+    steps:
+      - checkout
       - run:
           name: Reduce codegen units
           # If we don't include this, the linker runs out of memory when building
@@ -29,6 +43,13 @@ jobs:
           name: Build
           command: cargo build --all-features --all-targets
       - run:
+          name: Install Redis
+          command: |
+            # TODO is this update needed?
+            sudo apt-get update
+            sudo apt-get install redis-server
+            redis-server --version
+      - run:
           name: Test
           # Note the timeout is included to make sure that they
           # do not run for more than 10 minutes under any circumstances
@@ -37,34 +58,10 @@ jobs:
           command: timeout 10m cargo test --all --all-features
           environment:
             RUST_BACKTRACE: "1"
-      - run:
-          name: Check Style
-          command: |
-            cargo fmt --all -- --check
-            cargo clippy --all-targets --all-features -- -D warnings
-      - run:
-          name: Audit Dependencies
-          command: cargo audit
-      # - run:
-      #     name: Install kcov
-      #     command: >-
-      #       kcov --version ||
-      #       (sudo apt-get install cmake g++ pkg-config jq libcurl4-openssl-dev libelf-dev libdw-dev binutils-dev libiberty-dev
-      #       && cargo kcov --print-install-kcov-sh | sh)
-      # - run:
-      #     name: Generate Coverage Report
-      #     # Enable sudo to avoid the error: "Can't set personality: Operation not permitted"
-      #     # See discussion in https://github.com/travis-ci/travis-ci/issues/9061
-      #     sudo: required
-      #     command:
-      #       cargo kcov --all --verbose
-      #       # -- --verify
-      #       # --exclude-region="kcov-ignore-start:kcov-ignore-end"
-      #       # --exclude-pattern="$CARGO_HOME,**/tests/**"
-      #       # --exclude-line="^(\)*\}*,*)$"
-      #     environment:
-      #       # Configure the redis tests to use a unix socket instead of TCP
-      #       REDISRS_SERVER_TYPE: unix
-      # - run:
-      #     name: Upload Code Coverage
-      #     command: "bash <(curl -s https://codecov.io/bash)"
+
+workflows:
+  version: 2
+  build-test-check:
+    jobs:
+      - style-and-audit
+      - build-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,6 @@ jobs:
       - run:
           name: Install Cargo Extensions
           command: |
-            # cargo-audit started requiring libcurl3
-            echo "deb http://security.ubuntu.com/ubuntu xenial-security main" | sudo tee -a /etc/apt/sources.list
-            sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 3B4FE6ACC0B21F32
-            sudo apt-get update
-            sudo apt-get install libcurl3 -y
             cargo install --quiet cargo-audit || true # cargo-kcov
             rustup component add rustfmt clippy || true
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,6 @@ jobs:
     resource_class: medium+
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - cargo-cache-1-{{ checksum "Cargo.toml" }}-{{ .Branch }}
-            - cargo-cache-1-{{ checksum "Cargo.toml" }}
-            - cargo-cache-1-
       - run:
           name: Install Cargo Extensions
           command: |
@@ -78,7 +73,3 @@ jobs:
       # - run:
       #     name: Upload Code Coverage
       #     command: "bash <(curl -s https://codecov.io/bash)"
-      - save_cache:
-          key: cargo-cache-1-{{ checksum "Cargo.toml" }}-{{ .Branch }}
-          paths:
-            - /home/circleci/.cargo


### PR DESCRIPTION
- Don't use cargo cache (creating and loading the cache is slower than building from scratch)
- Remove unnecessary libcurl3 dep
- Split style checking from main build and test task to run them in parallel

Resolves https://github.com/interledger-rs/interledger-rs/issues/341

Note: I tried switching to a `large` box and removing the command to reduce codegen units but it only shaved 40 seconds off the build time so it doesn't seem worth it