### PR TITLE
Add Prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arrayvec"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +552,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hdrhistogram"
+version = "6.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "headers"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +708,9 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metrics 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metrics-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metrics-runtime 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -700,6 +722,16 @@ dependencies = [
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "warp 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "im"
+version = "12.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sized-chunks 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1056,6 +1088,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lock_api"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lock_api"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1097,6 +1137,56 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "metrics"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "metrics-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "metrics-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "metrics-observer-prometheus"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hdrhistogram 6.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metrics-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metrics-util 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "metrics-runtime"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "im 12.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metrics 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metrics-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metrics-observer-prometheus 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metrics-util 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quanta 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1315,12 +1405,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1431,6 +1546,15 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quanta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1923,6 +2047,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "slab"
@@ -2594,6 +2726,7 @@ dependencies = [
 [metadata]
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
+"checksum arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "bc4662175ead9cd84451d5c35070517777949a2ed84551764129cedb88384841"
 "checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 "checksum ascii 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 "checksum assert-json-diff 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32946b6d31d50d0e35896c864907f9cb7e47b52bd875fa3c058618601cfdefb1"
@@ -2656,6 +2789,8 @@ dependencies = [
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
+"checksum hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"
+"checksum hdrhistogram 6.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08d331ebcdbca4acbefe5da8c3299b2e246f198a8294cc5163354e743398b89d"
 "checksum headers 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "882ca7d8722f33ce2c2db44f95425d6267ed59ca96ce02acbe58320054ceb642"
 "checksum headers-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "967131279aaa9f7c20c7205b45a391638a83ab118e6509b2d0ccbe08de044237"
 "checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
@@ -2666,6 +2801,7 @@ dependencies = [
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+"checksum im 12.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "de38d1511a0ce7677538acb1e31b5df605147c458e061b2cdb89858afb1cd182"
 "checksum indexmap 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a61202fbe46c4a951e9404a720a0180bcf3212c750d735cb5c4ba4dc551299f3"
 "checksum input_buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e1b822cc844905551931d6f81608ed5f50a79c1078a4e2b4d42dbc7c1eedfbf"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
@@ -2675,12 +2811,18 @@ dependencies = [
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
+"checksum lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed946d4529956a20f2d63ebe1b69996d5a2137c91913fe3ebbeff957f5bca7ff"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
+"checksum metrics 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eef776a4455120b26a3d02ace9df13564d7ee8261a8c9c393ddeb5b1db20686e"
+"checksum metrics-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ead6e166cdc95b0bb5333202025a0cc76d34f3a2b070e5d513162545988df554"
+"checksum metrics-observer-prometheus 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90707830292a6223c046773caaa7c1121aa71dca75d156a4672cba8654eb8d2d"
+"checksum metrics-runtime 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "073904d61007944cbfea73b8c3c1b3402786e752a2e654efa8291cfcb8b98c60"
+"checksum metrics-util 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3024c8bfd2e14b14ca48c38a47d01472401e46492d1b9a45c2b68821d6ede88"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "dd1d63acd1b78403cc0c325605908475dd9b9a3acbf65ed8bcab97e27014afcf"
 "checksum mime_guess 1.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0d977de9ee851a0b16e932979515c0f3da82403183879811bc97d50bd9cc50f7"
@@ -2703,7 +2845,9 @@ dependencies = [
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.51 (registry+https://github.com/rust-lang/crates.io-index)" = "ba24190c8f0805d3bd2ce028f439fe5af1d55882bbe6261bed1dbc93b50dd6b1"
 "checksum os_type 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7edc011af0ae98b7f88cf7e4a83b70a54a75d2b8cb013d6efd02e5956207e9eb"
+"checksum parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
+"checksum parking_lot_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb88cb1cb3790baa6776844f968fea3be44956cf184fa1be5a03341f5491278c"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
@@ -2718,6 +2862,7 @@ dependencies = [
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90cf5f418035b98e655e9cdb225047638296b862b42411c4e45bb88d700f7fc0"
 "checksum publicsuffix 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9bf259a81de2b2eb9850ec990ec78e6a25319715584fd7652b9b26f96fcb1510"
+"checksum quanta 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f7a1905379198075914bc93d32a5465c40474f90a078bb13439cb00c547bcc"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
@@ -2771,6 +2916,7 @@ dependencies = [
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+"checksum sized-chunks 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d3e7f23bad2d6694e0f46f5e470ec27eb07b8f3e8b309a4b0dc17501928b9f2"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"

--- a/crates/ilp-node/Cargo.toml
+++ b/crates/ilp-node/Cargo.toml
@@ -18,6 +18,9 @@ hex = { version = "0.4.0", default-features = false }
 interledger = { path = "../interledger", version = "^0.4.1-alpha.1", default-features = false, features = ["node"] }
 lazy_static = { version = "1.4.0", default-features = false }
 log = { version = "0.4.8", default-features = false }
+metrics = { version = "0.11.1", default-features = false, features = ["std"] }
+metrics-core = { version = "0.5.1", default-features = false }
+metrics-runtime = { version = "0.1.0", default-features = false, features = ["metrics-observer-prometheus"] }
 ring = { version = "0.14.6", default-features = false }
 serde = { version = "1.0.101", default-features = false }
 tokio = { version = "0.1.22", default-features = false }

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -227,10 +227,6 @@ impl InterledgerNode {
                             // The BTP service is both an Incoming and Outgoing one so we pass it first as the Outgoing
                             // service to others like the router and then call handle_incoming on it to set up the incoming handler
                             let outgoing_service = btp_server_service.clone();
-                            let outgoing_service = ValidatorService::outgoing(
-                                store.clone(),
-                                outgoing_service
-                            );
                             let outgoing_service = HttpClientService::new(
                                 store.clone(),
                                 outgoing_service,
@@ -238,6 +234,10 @@ impl InterledgerNode {
 
                             // Note: the expiry shortener must come after the Validator so that the expiry duration
                             // is shortened before we check whether there is enough time left
+                            let outgoing_service = ValidatorService::outgoing(
+                                store.clone(),
+                                outgoing_service
+                            );
                             let outgoing_service =
                                 ExpiryShortenerService::new(outgoing_service);
                             let outgoing_service = StreamReceiverService::new(

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -25,10 +25,8 @@ use interledger::{
 };
 use lazy_static::lazy_static;
 use log::{debug, error, info, trace};
-use ring::{
-    digest, hmac,
-    rand::{SecureRandom, SystemRandom},
-};
+use metrics::{labels, recorder, Key};
+use ring::{digest, hmac};
 use serde::{de::Error as DeserializeError, Deserialize, Deserializer};
 use std::{convert::TryFrom, net::SocketAddr, str, str::FromStr, time::Duration};
 use tokio::{net::TcpListener, spawn};
@@ -158,6 +156,7 @@ pub struct InterledgerNode {
     // For example, take an incoming packet with an amount of 100. If the
     // exchange rate is 1:2 and the spread is 0.01, the amount on the
     // outgoing packet would be 198 (instead of 200 without the spread).
+    #[serde(default)]
     pub exchange_rate_spread: f64,
 }
 
@@ -388,12 +387,4 @@ pub fn tokio_run(fut: impl Future<Item = (), Error = ()> + Send + 'static) {
 
     runtime.spawn(fut);
     runtime.shutdown_on_idle().wait().unwrap();
-}
-
-#[doc(hidden)]
-#[allow(dead_code)]
-pub fn random_secret() -> [u8; 32] {
-    let mut bytes: [u8; 32] = [0; 32];
-    SystemRandom::new().fill(&mut bytes).unwrap();
-    bytes
 }

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -390,7 +390,7 @@ impl InterledgerNode {
                                         recorder().record_counter(Key::from_name_and_labels("requests.incoming.reject", labels.clone()), 1);
                                     }
                                     recorder().record_histogram(
-                                        Key::from_name_and_labels("requests.incoming.reject", labels),
+                                        Key::from_name_and_labels("requests.incoming.duration", labels),
                                         (Instant::now() - start_time).as_nanos() as u64);
                                     result
                                 })

--- a/crates/ilp-node/tests/btp.rs
+++ b/crates/ilp-node/tests/btp.rs
@@ -1,8 +1,6 @@
 use futures::{future::join_all, Future};
-use ilp_node::{random_secret, InterledgerNode};
-use interledger::{packet::Address, service::Username};
-use serde_json::json;
-use std::str::FromStr;
+use ilp_node::InterledgerNode;
+use serde_json::{self, json};
 use tokio::runtime::Builder as RuntimeBuilder;
 
 mod redis_helpers;
@@ -63,33 +61,29 @@ fn two_nodes_btp() {
         "ilp_over_http_incoming_token" : "default account holder",
     });
 
-    let node_a = InterledgerNode {
-        ilp_address: None,
-        default_spsp_account: None,
-        admin_auth_token: "admin".to_string(),
-        redis_connection: connection_info1,
-        http_bind_address: ([127, 0, 0, 1], node_a_http).into(),
-        settlement_api_bind_address: ([127, 0, 0, 1], node_a_settlement).into(),
-        secret_seed: random_secret(),
-        route_broadcast_interval: Some(200),
-        exchange_rate_poll_interval: 60000,
-        exchange_rate_provider: None,
-        exchange_rate_spread: 0.0,
-    };
+    let node_a: InterledgerNode = serde_json::from_value(json!({
+        "admin_auth_token": "admin",
+        "redis_connection": connection_info_to_string(connection_info1),
+        "http_bind_address": format!("127.0.0.1:{}", node_a_http),
+        "settlement_api_bind_address": format!("127.0.0.1:{}", node_a_settlement),
+        "secret_seed": random_secret(),
+        "route_broadcast_interval": 200,
+        "exchange_rate_poll_interval": 60000,
+    }))
+    .unwrap();
 
-    let node_b = InterledgerNode {
-        ilp_address: Some(Address::from_str("example.parent").unwrap()),
-        default_spsp_account: Some(Username::from_str("bob_on_b").unwrap()),
-        admin_auth_token: "admin".to_string(),
-        redis_connection: connection_info2,
-        http_bind_address: ([127, 0, 0, 1], node_b_http).into(),
-        settlement_api_bind_address: ([127, 0, 0, 1], node_b_settlement).into(),
-        secret_seed: random_secret(),
-        route_broadcast_interval: Some(200),
-        exchange_rate_poll_interval: 60000,
-        exchange_rate_provider: None,
-        exchange_rate_spread: 0.0,
-    };
+    let node_b: InterledgerNode = serde_json::from_value(json!({
+        "ilp_address": "example.parent",
+        "default_spsp_account": "bob_on_b",
+        "admin_auth_token": "admin",
+        "redis_connection": connection_info_to_string(connection_info2),
+        "http_bind_address": format!("127.0.0.1:{}", node_b_http),
+        "settlement_api_bind_address": format!("127.0.0.1:{}", node_b_settlement),
+        "secret_seed": random_secret(),
+        "route_broadcast_interval": Some(200),
+        "exchange_rate_poll_interval": 60000,
+    }))
+    .unwrap();
 
     let alice_fut = join_all(vec![
         create_account_on_node(node_a_http, alice_on_a, "admin"),

--- a/crates/ilp-node/tests/exchange_rates.rs
+++ b/crates/ilp-node/tests/exchange_rates.rs
@@ -1,17 +1,17 @@
 use env_logger;
 use futures::Future;
-use ilp_node::{random_secret, ExchangeRateProvider, InterledgerNode};
-use interledger::{packet::Address, service::Username};
+use ilp_node::InterledgerNode;
 use log::error;
 use reqwest::r#async::Client;
 use secrecy::SecretString;
-use serde_json::Value;
+use serde_json::{self, json, Value};
 use std::env;
-use std::str::FromStr;
 use tokio::runtime::Builder as RuntimeBuilder;
 
 mod redis_helpers;
 use redis_helpers::*;
+mod test_helpers;
+use test_helpers::random_secret;
 
 #[test]
 fn coincap() {
@@ -25,19 +25,19 @@ fn coincap() {
 
     let http_port = get_open_port(Some(3010));
 
-    let node = InterledgerNode {
-        ilp_address: Some(Address::from_str("example.one").unwrap()),
-        default_spsp_account: Some(Username::from_str("one").unwrap()),
-        admin_auth_token: "admin".to_string(),
-        redis_connection: context.get_client_connection_info(),
-        http_bind_address: ([127, 0, 0, 1], http_port).into(),
-        settlement_api_bind_address: ([127, 0, 0, 1], get_open_port(None)).into(),
-        secret_seed: random_secret(),
-        route_broadcast_interval: Some(200),
-        exchange_rate_poll_interval: 60000,
-        exchange_rate_provider: Some(ExchangeRateProvider::CoinCap),
-        exchange_rate_spread: 0.0,
-    };
+    let node: InterledgerNode = serde_json::from_value(json!({
+        "ilp_address": "example.one",
+        "default_spsp_account": "one",
+        "admin_auth_token": "admin",
+        "redis_connection": connection_info_to_string(context.get_client_connection_info()),
+        "http_bind_address": format!("127.0.0.1:{}", http_port),
+        "settlement_api_bind_address": format!("127.0.0.1:{}", get_open_port(None)),
+        "secret_seed": random_secret(),
+        "route_broadcast_interval": 200,
+        "exchange_rate_poll_interval": 60000,
+        "exchange_rate_provider": "CoinCap",
+    }))
+    .unwrap();
     runtime.spawn(node.serve());
 
     runtime
@@ -93,19 +93,22 @@ fn cryptocompare() {
 
     let http_port = get_open_port(Some(3011));
 
-    let node = InterledgerNode {
-        ilp_address: Some(Address::from_str("example.one").unwrap()),
-        default_spsp_account: Some(Username::from_str("one").unwrap()),
-        admin_auth_token: "admin".to_string(),
-        redis_connection: context.get_client_connection_info(),
-        http_bind_address: ([127, 0, 0, 1], http_port).into(),
-        settlement_api_bind_address: ([127, 0, 0, 1], get_open_port(None)).into(),
-        secret_seed: random_secret(),
-        route_broadcast_interval: Some(200),
-        exchange_rate_poll_interval: 60000,
-        exchange_rate_provider: Some(ExchangeRateProvider::CryptoCompare(api_key)),
-        exchange_rate_spread: 0.0,
-    };
+    let node: InterledgerNode = serde_json::from_value(json!({
+        "ilp_address": "example.one",
+        "default_spsp_account": "one",
+        "admin_auth_token": "admin",
+        "redis_connection": connection_info_to_string(context.get_client_connection_info()),
+        "http_bind_address": format!("127.0.0.1:{}", http_port),
+        "settlement_api_bind_address": format!("127.0.0.1:{}", get_open_port(None)),
+        "secret_seed": random_secret(),
+        "route_broadcast_interval": 200,
+        "exchange_rate_poll_interval": 60000,
+        "exchange_rate_provider": {
+            "CryptoCompare": api_key
+        },
+        "exchange_rate_spread": 0.0,
+    }))
+    .unwrap();
     runtime.spawn(node.serve());
 
     runtime

--- a/crates/ilp-node/tests/prometheus.rs
+++ b/crates/ilp-node/tests/prometheus.rs
@@ -1,0 +1,196 @@
+use futures::{future::join_all, Future};
+use ilp_node::InterledgerNode;
+use reqwest::r#async::Client;
+use serde_json::{self, json};
+use tokio::runtime::Builder as RuntimeBuilder;
+
+mod redis_helpers;
+use redis_helpers::*;
+
+mod test_helpers;
+use test_helpers::*;
+
+#[test]
+fn prometheus() {
+    // Nodes 1 and 2 are peers, Node 2 is the parent of Node 2
+    let _ = env_logger::try_init();
+    let context = TestContext::new();
+
+    // Each node will use its own DB within the redis instance
+    let mut connection_info1 = context.get_client_connection_info();
+    connection_info1.db = 1;
+    let mut connection_info2 = context.get_client_connection_info();
+    connection_info2.db = 2;
+
+    let node_a_http = get_open_port(Some(3010));
+    let node_a_settlement = get_open_port(Some(3011));
+    let node_b_http = get_open_port(Some(3020));
+    let node_b_settlement = get_open_port(Some(3021));
+    let prometheus_port = get_open_port(None);
+
+    let mut runtime = RuntimeBuilder::new()
+        .panic_handler(|_| panic!("Tokio worker panicked"))
+        .build()
+        .unwrap();
+
+    let alice_on_a = json!({
+        "ilp_address": "example.node_a.alice",
+        "username": "alice_on_a",
+        "asset_code": "XYZ",
+        "asset_scale": 9,
+        "ilp_over_http_incoming_token" : "token",
+    });
+    let b_on_a = json!({
+        "ilp_address": "example.node_b",
+        "username": "node_b",
+        "asset_code": "XYZ",
+        "asset_scale": 9,
+        "ilp_over_http_url": format!("http://localhost:{}/ilp", node_b_http),
+        "ilp_over_http_incoming_token" : "token",
+        "ilp_over_http_outgoing_token" : "node_a:token",
+        "routing_relation": "Peer",
+    });
+
+    let a_on_b = json!({
+        "ilp_address": "example.node_a",
+        "username": "node_a",
+        "asset_code": "XYZ",
+        "asset_scale": 9,
+        "ilp_over_http_url": format!("http://localhost:{}/ilp", node_a_http),
+        "ilp_over_http_incoming_token" : "token",
+        "ilp_over_http_outgoing_token" : "node_b:token",
+        "routing_relation": "Peer",
+    });
+
+    let bob_on_b = json!({
+        "ilp_address": "example.node_b.bob",
+        "username": "bob_on_b",
+        "asset_code": "XYZ",
+        "asset_scale": 6,
+        "ilp_over_http_incoming_token" : "token",
+    });
+
+    let node_a: InterledgerNode = serde_json::from_value(json!({
+        "admin_auth_token": "admin",
+        "redis_connection": connection_info_to_string(connection_info1),
+        "http_bind_address": format!("127.0.0.1:{}", node_a_http),
+        "settlement_api_bind_address": format!("127.0.0.1:{}", node_a_settlement),
+        "secret_seed": random_secret(),
+        "prometheus": {
+            "bind_address": format!("127.0.0.1:{}", prometheus_port),
+            "histogram_window": 10000,
+            "histogram_granularity": 1000,
+        }
+    }))
+    .unwrap();
+
+    let node_b: InterledgerNode = serde_json::from_value(json!({
+        "ilp_address": "example.parent",
+        "default_spsp_account": "bob_on_b",
+        "admin_auth_token": "admin",
+        "redis_connection": connection_info_to_string(connection_info2),
+        "http_bind_address": format!("127.0.0.1:{}", node_b_http),
+        "settlement_api_bind_address": format!("127.0.0.1:{}", node_b_settlement),
+        "secret_seed": random_secret(),
+    }))
+    .unwrap();
+
+    let alice_fut = join_all(vec![
+        create_account_on_node(node_a_http, alice_on_a, "admin"),
+        create_account_on_node(node_a_http, b_on_a, "admin"),
+    ]);
+
+    runtime.spawn(node_a.serve());
+
+    let bob_fut = join_all(vec![
+        create_account_on_node(node_b_http, a_on_b, "admin"),
+        create_account_on_node(node_b_http, bob_on_b, "admin"),
+    ]);
+
+    runtime.spawn(node_b.serve());
+
+    runtime
+        .block_on(
+            // Wait for the nodes to spin up
+            delay(500)
+                .map_err(|_| panic!("Something strange happened"))
+                .and_then(move |_| {
+                    bob_fut
+                        .and_then(|_| alice_fut)
+                        .and_then(|_| delay(500).map_err(|_| panic!("delay error")))
+                })
+                .and_then(move |_| {
+                    let send_1_to_2 = send_money_to_username(
+                        node_a_http,
+                        node_b_http,
+                        1000,
+                        "bob_on_b",
+                        "alice_on_a",
+                        "token",
+                    );
+                    let send_2_to_1 = send_money_to_username(
+                        node_b_http,
+                        node_a_http,
+                        2000,
+                        "alice_on_a",
+                        "bob_on_b",
+                        "token",
+                    );
+
+                    let check_metrics = move || {
+                        Client::new()
+                            .get(&format!("http://127.0.0.1:{}", prometheus_port))
+                            .send()
+                            .map_err(|err| eprintln!("Error getting metrics {:?}", err))
+                            .and_then(|mut res| {
+                                res.text().map_err(|err| {
+                                    eprintln!("Response was not a string: {:?}", err)
+                                })
+                            })
+                    };
+
+                    send_1_to_2
+                        .map_err(|err| {
+                            eprintln!("Error sending from node 1 to node 2: {:?}", err);
+                            err
+                        })
+                        .and_then(move |_| {
+                            check_metrics().and_then(move |ret| {
+                                assert!(ret.starts_with("# metrics snapshot"));
+                                assert!(ret.contains("requests_incoming_fulfill"));
+                                assert!(ret.contains("requests_incoming_prepare"));
+                                assert!(ret.contains("requests_incoming_reject"));
+                                assert!(ret.contains("requests_incoming_duration"));
+                                assert!(ret.contains("requests_outgoing_fulfill"));
+                                assert!(ret.contains("requests_outgoing_prepare"));
+                                assert!(ret.contains("requests_outgoing_reject"));
+                                assert!(ret.contains("requests_outgoing_duration"));
+                                // TODO check the specific numbers of packets
+                                Ok(())
+                            })
+                        })
+                        .and_then(move |_| {
+                            send_2_to_1.map_err(|err| {
+                                eprintln!("Error sending from node 2 to node 1: {:?}", err);
+                                err
+                            })
+                        })
+                        .and_then(move |_| {
+                            check_metrics().and_then(move |ret| {
+                                assert!(ret.starts_with("# metrics snapshot"));
+                                assert!(ret.contains("requests_incoming_fulfill"));
+                                assert!(ret.contains("requests_incoming_prepare"));
+                                assert!(ret.contains("requests_incoming_reject"));
+                                assert!(ret.contains("requests_incoming_duration"));
+                                assert!(ret.contains("requests_outgoing_fulfill"));
+                                assert!(ret.contains("requests_outgoing_prepare"));
+                                assert!(ret.contains("requests_outgoing_reject"));
+                                assert!(ret.contains("requests_outgoing_duration"));
+                                // TODO check the specific numbers of packets
+                                Ok(())
+                            })
+                        })
+                }),
+        )
+        .unwrap();
+}

--- a/crates/ilp-node/tests/redis_helpers.rs
+++ b/crates/ilp-node/tests/redis_helpers.rs
@@ -13,9 +13,17 @@ use std::path::PathBuf;
 
 use futures::Future;
 
-use redis::RedisError;
+use redis::{ConnectionAddr, ConnectionInfo, RedisError};
 
 use tokio::timer::Delay;
+
+#[allow(unused)]
+pub fn connection_info_to_string(info: ConnectionInfo) -> String {
+    match info.addr.as_ref() {
+        ConnectionAddr::Tcp(url, port) => format!("redis://{}:{}/{}", url, port, info.db),
+        ConnectionAddr::Unix(path) => format!("unix:{}?db={}", path.to_str().unwrap(), info.db),
+    }
+}
 
 pub fn get_open_port(try_port: Option<u16>) -> u16 {
     if let Some(port) = try_port {

--- a/crates/ilp-node/tests/test_helpers.rs
+++ b/crates/ilp-node/tests/test_helpers.rs
@@ -1,14 +1,23 @@
 use futures::{stream::Stream, Future};
+use hex;
 use interledger::{
     packet::Address,
     service::Account as AccountTrait,
     store_redis::{Account, AccountId},
 };
+use ring::rand::{SecureRandom, SystemRandom};
 use serde::Serialize;
 use serde_json::json;
 use std::collections::HashMap;
 use std::fmt::{Debug, Display};
 use std::str;
+
+#[allow(unused)]
+pub fn random_secret() -> String {
+    let mut bytes: [u8; 32] = [0; 32];
+    SystemRandom::new().fill(&mut bytes).unwrap();
+    hex::encode(bytes)
+}
 
 #[derive(serde::Deserialize)]
 pub struct DeliveryData {

--- a/crates/interledger-http/src/client.rs
+++ b/crates/interledger-http/src/client.rs
@@ -73,9 +73,7 @@ where
                 Err(_) => {
                     return Box::new(err(RejectBuilder {
                         code: ErrorCode::T00_INTERNAL_ERROR,
-                        message: format!("Cannot parse authorization token {}", token)
-                            .as_str()
-                            .as_ref(),
+                        message: &[],
                         triggered_by: None,
                         data: &[],
                     }

--- a/crates/interledger-service-util/src/exchange_rates_service.rs
+++ b/crates/interledger-service-util/src/exchange_rates_service.rs
@@ -189,10 +189,15 @@ where
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "snake_case")]
 pub enum ExchangeRateProvider {
+    #[serde(alias = "coin_cap", alias = "coincap", alias = "Coincap")]
     CoinCap,
     /// CryptoCompare must be configured with an API key
+    #[serde(
+        alias = "crypto_compare",
+        alias = "cryptocompare",
+        alias = "Cryptocompare"
+    )]
     CryptoCompare(SecretString),
 }
 


### PR DESCRIPTION
Resolves https://github.com/interledger-rs/interledger-rs/issues/139

**Updated:**

This exposes metrics in the Prometheus format when the `prometheus` details are configured on the node.

Currently, it collects the following statistics:
- the number of incoming/outgoing Prepares, Fulfills, and Rejects
- the amount of time it took to service incoming requests
- the amount of time it took other nodes to respond to outgoing requests
- all of the above statistics are broken out by asset code and routing relation (parent, peer, child)

Note that if the `prometheus` configuration is not provided to the node, no metrics will be collected. This means that running the node with metrics turned off should have near zero performance overhead.