### PR TITLE
refactor(cli): now CLI doesn't include when returning the response

### DIFF
--- a/crates/ilp-cli/src/main.rs
+++ b/crates/ilp-cli/src/main.rs
@@ -31,7 +31,7 @@ pub fn main() {
             Ok(body) => {
                 if response.status().is_success() {
                     if !matches.is_present("quiet") {
-                        println!("{}", body);
+                        print!("{}", body);
                     }
                 } else {
                     eprintln!(


### PR DESCRIPTION
Now CLI doesn't include `\n` when returning the response so that it more looks like CURL style.

Because of the `\n`, examples look a bit weird. If you guys don't have any preference, I'd like to introduce this.