### PR TITLE
fix(three node example): fixes three node example

### DIFF
--- a/examples/eth-xrp-three-nodes/README.md
+++ b/examples/eth-xrp-three-nodes/README.md
@@ -314,7 +314,7 @@ else
 -->
 
 ```bash #
-# This should be done outside of the interledger-rs ditrectory, otherwise it will cause an error
+# This should be done outside of the interledger-rs directory, otherwise it will cause an error
 git clone https://github.com/interledger-rs/settlement-engines
 cd settlement-engines
 ```

--- a/examples/eth-xrp-three-nodes/README.md
+++ b/examples/eth-xrp-three-nodes/README.md
@@ -247,7 +247,7 @@ In this example, we'll connect 3 Interledger nodes and each node needs its own s
 
 By default, the XRP settlement engine generates new testnet XRPL accounts prefunded with 1,000 testnet XRP (a new account is generated each run). Alternatively, you may supply an `XRP_SECRET` environment variable by generating your own testnet credentials from the [official faucet](https://xrpl.org/xrp-test-net-faucet.html).
 
-The engines are part of a [separate repository](https://github.com/interledger-rs/settlement-engines) so you have to clone and install them according to [the instructions](https://github.com/interledger-rs/settlement-engines/blob/master/README.md). In case you've never cloned `settlement-engine`, clone it first.
+The engines are part of a [separate repository](https://github.com/interledger-rs/settlement-engines) so you have to clone and install them according to [the instructions in settlement-engine](https://github.com/interledger-rs/settlement-engines/blob/master/README.md). In case you've never cloned `settlement-engine`, the first step would be to clone the repository.
 
 <!--!
 printf "\nStarting settlement engines...\n"
@@ -352,7 +352,7 @@ cargo run --features "ethereum" -- ethereum-ledger \
 --settlement_api_bind_address 127.0.0.1:3001 \
 &> logs/node-bob-settlement-engine-eth.log &
 
-# Now go back to interledger-rs directory.
+# Now go back to the `interledger-rs` directory.
 
 DEBUG="settlement*" \
 CONNECTOR_URL="http://localhost:8771" \

--- a/examples/eth-xrp-three-nodes/README.md
+++ b/examples/eth-xrp-three-nodes/README.md
@@ -314,7 +314,7 @@ else
 -->
 
 ```bash #
-# Do this somewhere OUTER the interledger-rs directory otherwise you'll get an error.
+# This should be done outside of the interledger-rs ditrectory, otherwise it will cause an error
 git clone https://github.com/interledger-rs/settlement-engines
 cd settlement-engines
 ```

--- a/scripts/run-md-lib.sh
+++ b/scripts/run-md-lib.sh
@@ -14,6 +14,12 @@ function init() {
         TEST_MODE=0
     fi
 
+    # set global settlement engine dir so that the engine never gets compiled many times when test
+    # furthermore, we cannot clone `settlement-engine` in `interledger-rs` directory.
+    if [ -z "${SETTLEMENT_ENGINE_INSTALLL_DIR}" ]; then
+        SETTLEMENT_ENGINE_INSTALLL_DIR=$(cd ~; pwd)
+    fi
+
     # define commands
     CMD_DOCKER=docker
     if [ -n "$USE_SUDO" ] && [ "$USE_SUDO" -ne "0" ]; then


### PR DESCRIPTION
This is originally a part of #305 but I feel like we should not leave this, people are struggling to try out `interledger-rs`.

Cloning settlement-engines inside interledger-rs is not good because it causes an error. In
addition, node setting of Charlie is wrong.