### PR TITLE
chore: update metrics-rs to new version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,11 +552,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "hdrhistogram"
 version = "6.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,9 +703,9 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "metrics 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metrics 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "metrics-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "metrics-runtime 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metrics-runtime 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1088,14 +1083,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lock_api"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "lock_api"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1141,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "metrics-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1164,19 +1151,18 @@ dependencies = [
 
 [[package]]
 name = "metrics-runtime"
-version = "0.1.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "im 12.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "metrics 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "metrics 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "metrics-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "metrics-observer-prometheus 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "metrics-util 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quanta 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1405,37 +1391,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2789,7 +2750,6 @@ dependencies = [
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
-"checksum hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"
 "checksum hdrhistogram 6.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08d331ebcdbca4acbefe5da8c3299b2e246f198a8294cc5163354e743398b89d"
 "checksum headers 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "882ca7d8722f33ce2c2db44f95425d6267ed59ca96ce02acbe58320054ceb642"
 "checksum headers-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "967131279aaa9f7c20c7205b45a391638a83ab118e6509b2d0ccbe08de044237"
@@ -2811,17 +2771,16 @@ dependencies = [
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
-"checksum lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed946d4529956a20f2d63ebe1b69996d5a2137c91913fe3ebbeff957f5bca7ff"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
-"checksum metrics 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eef776a4455120b26a3d02ace9df13564d7ee8261a8c9c393ddeb5b1db20686e"
+"checksum metrics 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d00d6b3f57357c199d4cad1ab4d96f0d7de9ecd64ffc03600d2b89cc4c3126d2"
 "checksum metrics-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ead6e166cdc95b0bb5333202025a0cc76d34f3a2b070e5d513162545988df554"
 "checksum metrics-observer-prometheus 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90707830292a6223c046773caaa7c1121aa71dca75d156a4672cba8654eb8d2d"
-"checksum metrics-runtime 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "073904d61007944cbfea73b8c3c1b3402786e752a2e654efa8291cfcb8b98c60"
+"checksum metrics-runtime 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2863204c75646de78a93d961562cebca30608508250da9f98bd0754c6e7a5b4"
 "checksum metrics-util 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3024c8bfd2e14b14ca48c38a47d01472401e46492d1b9a45c2b68821d6ede88"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "dd1d63acd1b78403cc0c325605908475dd9b9a3acbf65ed8bcab97e27014afcf"
@@ -2845,9 +2804,7 @@ dependencies = [
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.51 (registry+https://github.com/rust-lang/crates.io-index)" = "ba24190c8f0805d3bd2ce028f439fe5af1d55882bbe6261bed1dbc93b50dd6b1"
 "checksum os_type 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7edc011af0ae98b7f88cf7e4a83b70a54a75d2b8cb013d6efd02e5956207e9eb"
-"checksum parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
-"checksum parking_lot_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb88cb1cb3790baa6776844f968fea3be44956cf184fa1be5a03341f5491278c"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"

--- a/crates/ilp-node/Cargo.toml
+++ b/crates/ilp-node/Cargo.toml
@@ -18,9 +18,9 @@ hex = { version = "0.4.0", default-features = false }
 interledger = { path = "../interledger", version = "^0.4.1-alpha.1", default-features = false, features = ["node"] }
 lazy_static = { version = "1.4.0", default-features = false }
 log = { version = "0.4.8", default-features = false }
-metrics = { version = "0.11.1", default-features = false, features = ["std"] }
+metrics = { version = "0.12.0", default-features = false, features = ["std"] }
 metrics-core = { version = "0.5.1", default-features = false }
-metrics-runtime = { version = "0.1.0", default-features = false, features = ["metrics-observer-prometheus"] }
+metrics-runtime = { version = "0.12.0", default-features = false, features = ["metrics-observer-prometheus"] }
 ring = { version = "0.14.6", default-features = false }
 serde = { version = "1.0.101", default-features = false }
 tokio = { version = "0.1.22", default-features = false }

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -305,14 +305,14 @@ impl InterledgerNode {
 
                                 // TODO replace these calls with the counter! macro if there's a way to easily pass in the already-created labels
                                 // right now if you pass the labels into one of the other macros, it gets a recursion limit error while expanding the macro
-                                recorder().record_counter(Key::from_name_and_labels("requests.outgoing.prepare", labels.clone()), 1);
+                                recorder().increment_counter(Key::from_name_and_labels("requests.outgoing.prepare", labels.clone()), 1);
                                 let start_time = Instant::now();
 
                                 next.send_request(request).then(move |result| {
                                     if result.is_ok() {
-                                        recorder().record_counter(Key::from_name_and_labels("requests.outgoing.fulfill", labels.clone()), 1);
+                                        recorder().increment_counter(Key::from_name_and_labels("requests.outgoing.fulfill", labels.clone()), 1);
                                     } else {
-                                        recorder().record_counter(Key::from_name_and_labels("requests.outgoing.reject", labels.clone()), 1);
+                                        recorder().increment_counter(Key::from_name_and_labels("requests.outgoing.reject", labels.clone()), 1);
                                     }
 
                                     recorder().record_histogram(
@@ -380,14 +380,14 @@ impl InterledgerNode {
                                     "from_asset_code" => request.from.asset_code().to_string(),
                                     "from_routing_relation" => request.from.routing_relation().to_string(),
                                 );
-                                recorder().record_counter(Key::from_name_and_labels("requests.incoming.prepare", labels.clone()), 1);
+                                recorder().increment_counter(Key::from_name_and_labels("requests.incoming.prepare", labels.clone()), 1);
                                 let start_time = Instant::now();
 
                                 next.handle_request(request).then(move |result| {
                                     if result.is_ok() {
-                                        recorder().record_counter(Key::from_name_and_labels("requests.incoming.fulfill", labels.clone()), 1);
+                                        recorder().increment_counter(Key::from_name_and_labels("requests.incoming.fulfill", labels.clone()), 1);
                                     } else {
-                                        recorder().record_counter(Key::from_name_and_labels("requests.incoming.reject", labels.clone()), 1);
+                                        recorder().increment_counter(Key::from_name_and_labels("requests.incoming.reject", labels.clone()), 1);
                                     }
                                     recorder().record_histogram(
                                         Key::from_name_and_labels("requests.incoming.duration", labels),
@@ -465,7 +465,7 @@ impl InterledgerNode {
                 )
                 .build()
                 .expect("Failed to create metrics Receiver");
-            let controller = receiver.get_controller();
+            let controller = receiver.controller();
             // Try installing the global recorder
             match metrics::set_boxed_recorder(Box::new(receiver)) {
                 Ok(_) => {


### PR DESCRIPTION
Most pertinently this removes some obsolete transitive dependencies on hashbrown and parking_lot.