### PR TITLE
fix(health-check api): fix to return a correct semantic version

### DIFF
--- a/crates/interledger-api/src/routes/node_settings.rs
+++ b/crates/interledger-api/src/routes/node_settings.rs
@@ -48,14 +48,6 @@ where
         .boxed();
     let with_store = warp::any().map(move || store.clone()).boxed();
 
-    let crate_version = format!(
-        "{}.{}.{}{}",
-        env!("CARGO_PKG_VERSION_MAJOR"),
-        env!("CARGO_PKG_VERSION_MINOR"),
-        env!("CARGO_PKG_VERSION_PATCH"),
-        option_env!("CARGO_PKG_VERSION_PRE").unwrap_or("")
-    );
-
     // GET /
     let get_root = warp::get2()
         .and(warp::path::end())
@@ -65,7 +57,7 @@ where
             warp::reply::json(&json!({
                 "status": "Ready".to_string(),
                 "ilp_address": store.get_ilp_address(),
-                "version": crate_version,
+                "version": env!("CARGO_PKG_VERSION"),
             }))
         })
         .boxed();

--- a/docs/api.md
+++ b/docs/api.md
@@ -236,7 +236,7 @@ Health check.
 {
     "status": "Ready",
     "ilp_address": "example.node",
-    "version": "0.1.1beta.3"
+    "version": "0.1.1-beta.3"
 }
 ```
 


### PR DESCRIPTION
Resolves: #452

Can't we just use `CARGO_PKG_VERSION`?