### PR TITLE
Enhance details when sending an SPSP payment

### DIFF
--- a/crates/ilp-node/tests/test_helpers.rs
+++ b/crates/ilp-node/tests/test_helpers.rs
@@ -1,5 +1,6 @@
 use futures::{stream::Stream, Future};
 use hex;
+use interledger::stream::Receipt;
 use interledger::{
     packet::Address,
     service::Account as AccountTrait,
@@ -26,11 +27,6 @@ pub fn random_secret() -> String {
     let mut bytes: [u8; 32] = [0; 32];
     SystemRandom::new().fill(&mut bytes).unwrap();
     hex::encode(bytes)
-}
-
-#[derive(serde::Deserialize)]
-pub struct DeliveryData {
-    pub delivered_amount: u64,
 }
 
 #[derive(serde::Deserialize)]
@@ -86,7 +82,7 @@ pub fn send_money_to_username<T: Display + Debug>(
     to_username: T,
     from_username: &str,
     from_auth: &str,
-) -> impl Future<Item = u64, Error = ()> {
+) -> impl Future<Item = Receipt, Error = ()> {
     let client = reqwest::r#async::Client::new();
     let auth = format!("{}:{}", from_username, from_auth);
     client
@@ -106,8 +102,8 @@ pub fn send_money_to_username<T: Display + Debug>(
             eprintln!("Error sending SPSP payment: {:?}", err);
         })
         .and_then(move |body| {
-            let ret: DeliveryData = serde_json::from_slice(&body).unwrap();
-            Ok(ret.delivered_amount)
+            let ret: Receipt = serde_json::from_slice(&body).unwrap();
+            Ok(ret)
         })
 }
 

--- a/crates/ilp-node/tests/test_helpers.rs
+++ b/crates/ilp-node/tests/test_helpers.rs
@@ -1,6 +1,6 @@
 use futures::{stream::Stream, Future};
 use hex;
-use interledger::stream::Receipt;
+use interledger::stream::StreamDelivery;
 use interledger::{
     packet::Address,
     service::Account as AccountTrait,
@@ -82,7 +82,7 @@ pub fn send_money_to_username<T: Display + Debug>(
     to_username: T,
     from_username: &str,
     from_auth: &str,
-) -> impl Future<Item = Receipt, Error = ()> {
+) -> impl Future<Item = StreamDelivery, Error = ()> {
     let client = reqwest::r#async::Client::new();
     let auth = format!("{}:{}", from_username, from_auth);
     client
@@ -102,7 +102,7 @@ pub fn send_money_to_username<T: Display + Debug>(
             eprintln!("Error sending SPSP payment: {:?}", err);
         })
         .and_then(move |body| {
-            let ret: Receipt = serde_json::from_slice(&body).unwrap();
+            let ret: StreamDelivery = serde_json::from_slice(&body).unwrap();
             Ok(ret)
         })
 }

--- a/crates/ilp-node/tests/three_nodes.rs
+++ b/crates/ilp-node/tests/three_nodes.rs
@@ -10,7 +10,7 @@ use redis_helpers::*;
 
 mod test_helpers;
 use interledger::packet::Address;
-use interledger::stream::Receipt;
+use interledger::stream::StreamDelivery;
 use std::str::FromStr;
 use test_helpers::*;
 
@@ -227,7 +227,7 @@ fn three_nodes() {
                             eprintln!("Error sending from node 1 to node 3: {:?}", err);
                             err
                         })
-                        .and_then(move |receipt: Receipt| {
+                        .and_then(move |receipt: StreamDelivery| {
                             assert_eq!(receipt.from, Address::from_str("example.alice").unwrap());
                             assert!(receipt.to.to_string().starts_with("example.bob.charlie"));
                             assert_eq!(receipt.sent_asset_code, "XYZ");

--- a/crates/interledger-api/tests/accounts.rs
+++ b/crates/interledger-api/tests/accounts.rs
@@ -531,7 +531,6 @@ fn accounts_test() {
                 assert!(res.error_for_status_ref().is_ok(), "{}", &content);
                 let receipt: StreamDelivery = serde_json::from_str(&content).unwrap();
                 assert_eq!(receipt.from, Address::from_str(ILP_ADDRESS_1).unwrap());
-                println!("{}", receipt.to.to_owned());
                 assert!(receipt.to.to_string().starts_with(&format!("{}.{}", NODE_ILP_ADDRESS, USERNAME_2)));
                 assert_eq!(receipt.sent_amount, amount);
                 assert_eq!(receipt.sent_asset_scale as usize, ASSET_SCALE);

--- a/crates/interledger-api/tests/accounts.rs
+++ b/crates/interledger-api/tests/accounts.rs
@@ -11,7 +11,7 @@ use tokio::runtime::Builder as RuntimeBuilder;
 
 use ilp_node::InterledgerNode;
 use interledger::{packet::Address, service::Username};
-use interledger_stream::Receipt;
+use interledger_stream::StreamDelivery;
 
 // Integration tests of accounts APIs
 // These are very rough tests. It confirms only that the paths and HTTP methods are working correctly.
@@ -529,7 +529,7 @@ fn accounts_test() {
             .and_then(move|mut res| {
                 let content = res.text().wait().expect("Error getting response!");
                 assert!(res.error_for_status_ref().is_ok(), "{}", &content);
-                let receipt: Receipt = serde_json::from_str(&content).unwrap();
+                let receipt: StreamDelivery = serde_json::from_str(&content).unwrap();
                 assert_eq!(receipt.from, Address::from_str(ILP_ADDRESS_1).unwrap());
                 println!("{}", receipt.to.to_owned());
                 assert!(receipt.to.to_string().starts_with(&format!("{}.{}", NODE_ILP_ADDRESS, USERNAME_2)));

--- a/crates/interledger-spsp/src/client.rs
+++ b/crates/interledger-spsp/src/client.rs
@@ -2,7 +2,7 @@ use super::{Error, SpspResponse};
 use futures::{future::result, Future};
 use interledger_packet::Address;
 use interledger_service::{Account, IncomingService};
-use interledger_stream::{send_money, Receipt};
+use interledger_stream::{send_money, StreamDelivery};
 use log::{debug, error, trace};
 use reqwest::r#async::Client;
 use std::convert::TryFrom;
@@ -31,7 +31,7 @@ pub fn pay<S, A>(
     from_account: A,
     receiver: &str,
     source_amount: u64,
-) -> impl Future<Item = Receipt, Error = Error>
+) -> impl Future<Item = StreamDelivery, Error = Error>
 where
     S: IncomingService<A> + Clone,
     A: Account,
@@ -48,7 +48,7 @@ where
 
             send_money(service, &from_account, addr, &shared_secret, source_amount)
                 .map(move |(receipt, _plugin)| {
-                    debug!("Sent SPSP payment. Receipt: {:?}", receipt);
+                    debug!("Sent SPSP payment. StreamDelivery: {:?}", receipt);
                     receipt
                 })
                 .map_err(move |err| {

--- a/crates/interledger-stream/Cargo.toml
+++ b/crates/interledger-stream/Cargo.toml
@@ -15,7 +15,7 @@ metrics_csv = ["csv"]
 base64 = { version = "0.10.1", default-features = false }
 bytes = { version = "0.4.12", default-features = false }
 byteorder = { version = "1.3.2", default-features = false }
-chrono = { version = "0.4.9", default-features = false }
+chrono = { version = "0.4.9", default-features = false, features = ["clock"] }
 csv = { version = "1.1.1", default-features = false, optional = true }
 failure = { version = "0.1.5", default-features = false, features = ["derive"] }
 futures = { version = "0.1.29", default-features = false }

--- a/crates/interledger-stream/src/client.rs
+++ b/crates/interledger-stream/src/client.rs
@@ -36,25 +36,6 @@ pub struct StreamDelivery {
 }
 
 impl StreamDelivery {
-    fn new(
-        from: Address,
-        to: Address,
-        sent_amount: u64,
-        sent_asset_scale: u8,
-        sent_asset_code: impl ToString,
-    ) -> Self {
-        StreamDelivery {
-            from,
-            to,
-            sent_amount,
-            sent_asset_scale,
-            sent_asset_code: sent_asset_code.to_string(),
-            delivered_amount: 0,
-            delivered_asset_code: None,
-            delivered_asset_scale: None,
-        }
-    }
-
     fn increment_delivered_amount(&mut self, amount: u64) {
         self.delivered_amount += amount;
     }
@@ -100,13 +81,16 @@ where
                 // sending as much as possible per packet vs getting money flowing ASAP differently
                 congestion_controller: CongestionController::new(source_amount, source_amount / 10, 2.0),
                 pending_requests: Cell::new(Vec::new()),
-                receipt: StreamDelivery::new(
-                    from_account.ilp_address().clone(),
-                    destination_account,
-                    source_amount,
-                    from_account.asset_scale(),
-                    from_account.asset_code(),
-                ),
+                receipt: StreamDelivery {
+                    from: from_account.ilp_address().clone(),
+                    to: destination_account,
+                    sent_amount: source_amount,
+                    sent_asset_scale: from_account.asset_scale(),
+                    sent_asset_code: from_account.asset_code().to_string(),
+                    delivered_asset_scale: None,
+                    delivered_asset_code: None,
+                    delivered_amount: 0,
+                },
                 should_send_source_account: true,
                 sequence: 1,
                 rejected_packets: 0,

--- a/crates/interledger-stream/src/crypto.rs
+++ b/crates/interledger-stream/src/crypto.rs
@@ -97,6 +97,11 @@ fn encrypt_with_nonce(
 }
 
 pub fn decrypt(shared_secret: &[u8], mut ciphertext: BytesMut) -> Result<BytesMut, ()> {
+    // ciphertext must include at least a nonce and tag,
+    if ciphertext.len() < AUTH_TAG_LENGTH {
+        return Err(());
+    }
+
     let key = hmac_sha256(shared_secret, &ENCRYPTION_KEY_STRING);
     let key = aead::UnboundKey::new(&aead::AES_256_GCM, &key)
         .expect("Failed to create a new opening key for decrypting data!");

--- a/crates/interledger-stream/src/lib.rs
+++ b/crates/interledger-stream/src/lib.rs
@@ -11,7 +11,7 @@ mod error;
 mod packet;
 mod server;
 
-pub use client::send_money;
+pub use client::{send_money, Receipt};
 pub use error::Error;
 pub use server::{
     ConnectionGenerator, PaymentNotification, StreamNotificationsStore, StreamReceiverService,
@@ -194,8 +194,8 @@ mod send_money_to_receiver {
             &shared_secret[..],
             100,
         )
-        .and_then(|(delivered_amount, _service)| {
-            assert_eq!(delivered_amount, 100);
+        .and_then(|(receipt, _service)| {
+            assert_eq!(receipt.delivered_amount, 100);
             Ok(())
         })
         .map_err(|err| panic!(err));

--- a/crates/interledger-stream/src/lib.rs
+++ b/crates/interledger-stream/src/lib.rs
@@ -11,7 +11,7 @@ mod error;
 mod packet;
 mod server;
 
-pub use client::{send_money, Receipt};
+pub use client::{send_money, StreamDelivery};
 pub use error::Error;
 pub use server::{
     ConnectionGenerator, PaymentNotification, StreamNotificationsStore, StreamReceiverService,

--- a/crates/interledger-stream/src/server.rs
+++ b/crates/interledger-stream/src/server.rs
@@ -236,12 +236,18 @@ fn receive_money(
                 receive_max: u64::max_value(),
             }));
         }
-    }
 
-    response_frames.push(Frame::ConnectionAssetDetails(ConnectionAssetDetailsFrame {
-        source_asset_code: asset_code,
-        source_asset_scale: asset_scale,
-    }));
+        // If we receive a ConnectionNewAddress frame, then send them our asset
+        // code & scale. The client is suppoesd to only send the
+        // ConnectionNewAddress frame once, so we expect that we will only have
+        // to respond with the ConnectionAssetDetails frame only one time.
+        if let Frame::ConnectionNewAddress(_) = frame {
+            response_frames.push(Frame::ConnectionAssetDetails(ConnectionAssetDetailsFrame {
+                source_asset_code: asset_code,
+                source_asset_scale: asset_scale,
+            }));
+        }
+    }
 
     // Return Fulfill or Reject Packet
     if is_fulfillable && prepare_amount >= stream_packet.prepare_amount() {

--- a/docs/api.md
+++ b/docs/api.md
@@ -158,9 +158,15 @@ Account-holder only.
 
 ```json
 {
-    "delivered_amount": 2000000
+   "delivered_asset_scale" : 9,
+   "delivered_asset_code" : "ABC",
+   "sent_amount" : 1000000,
+   "sent_asset_code" : "XYZ",
+   "from" : "example.node_a.alice",
+   "to" : "example.node_b.bob.-p3zU4tXsDRCBLg8vt_U6iiyQ5pgZk4MfoCaG1wZDW8",
+   "delivered_amount" : 1000000,
+   "sent_asset_scale" : 9
 }
-```
 
 ### (WebSocket) /accounts/:username/payments/incoming
 


### PR DESCRIPTION
Closes https://github.com/interledger-rs/interledger-rs/issues/419. 

Uses the `ConnectionAssetDetails` frame to return additional useful information to the sender.

Running the simple example:

```
Sending payment of 500 from Alice (on Node A) to Bob (on Node B)...

{
   "delivered_asset_scale" : 9,
   "delivered_asset_code" : "ABC",
   "sent_amount" : 500,
   "sent_asset_code" : "ABC",
   "from" : "example.node_a.alice",
   "to" : "example.node_b.bob.-p3zU4tXsDRCBLg8vt_U6iiyQ5pgZk4MfoCaG1wZDW8",
   "delivered_amount" : 500,
   "sent_asset_scale" : 9
}
```