### PR TITLE
Don't clone routing table for every packet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,6 @@ dependencies = [
 name = "interledger-router"
 version = "0.2.2-beta.3"
 dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "interledger-packet 0.2.2-beta.5",
  "interledger-service 0.2.2-beta.3",

--- a/crates/ilp-node/src/main.rs
+++ b/crates/ilp-node/src/main.rs
@@ -198,7 +198,7 @@ fn merge_args(config: &mut Config, matches: &ArgMatches) {
 fn get_env_config(prefix: &str) -> Config {
     let mut config = Config::new();
     config
-        .merge(config::Environment::with_prefix(prefix))
+        .merge(config::Environment::with_prefix(prefix).separator("__"))
         .unwrap();
 
     if prefix.to_lowercase() == "ilp" {

--- a/crates/ilp-node/tests/btp.rs
+++ b/crates/ilp-node/tests/btp.rs
@@ -29,7 +29,7 @@ fn two_nodes_btp() {
     let node_b_settlement = get_open_port(Some(3021));
 
     let mut runtime = RuntimeBuilder::new()
-        .panic_handler(|_| panic!("Tokio worker panicked"))
+        .panic_handler(|err| std::panic::resume_unwind(err))
         .build()
         .unwrap();
 

--- a/crates/ilp-node/tests/exchange_rates.rs
+++ b/crates/ilp-node/tests/exchange_rates.rs
@@ -19,7 +19,7 @@ fn coincap() {
     let context = TestContext::new();
 
     let mut runtime = RuntimeBuilder::new()
-        .panic_handler(|_| panic!("Tokio worker panicked"))
+        .panic_handler(|err| std::panic::resume_unwind(err))
         .build()
         .unwrap();
 
@@ -87,7 +87,7 @@ fn cryptocompare() {
     let api_key = SecretString::new(api_key.unwrap());
 
     let mut runtime = RuntimeBuilder::new()
-        .panic_handler(|_| panic!("Tokio worker panicked"))
+        .panic_handler(|err| std::panic::resume_unwind(err))
         .build()
         .unwrap();
 

--- a/crates/ilp-node/tests/prometheus.rs
+++ b/crates/ilp-node/tests/prometheus.rs
@@ -29,7 +29,7 @@ fn prometheus() {
     let prometheus_port = get_open_port(None);
 
     let mut runtime = RuntimeBuilder::new()
-        .panic_handler(|_| panic!("Tokio worker panicked"))
+        .panic_handler(|err| std::panic::resume_unwind(err))
         .build()
         .unwrap();
 

--- a/crates/ilp-node/tests/three_nodes.rs
+++ b/crates/ilp-node/tests/three_nodes.rs
@@ -33,7 +33,7 @@ fn three_nodes() {
     let node3_settlement = get_open_port(Some(3031));
 
     let mut runtime = RuntimeBuilder::new()
-        .panic_handler(|_| panic!("Tokio worker panicked"))
+        .panic_handler(|err| std::panic::resume_unwind(err))
         .build()
         .unwrap();
 

--- a/crates/interledger-api/src/routes/node_settings.rs
+++ b/crates/interledger-api/src/routes/node_settings.rs
@@ -103,7 +103,7 @@ where
         .and_then(|store: S| {
             // Convert the account IDs listed in the routing table
             // to the usernames for the API response
-            let routes = store.routing_table();
+            let routes = store.routing_table().clone();
             store
                 .get_accounts(routes.values().cloned().collect())
                 .map_err::<_, Rejection>(|_| {
@@ -113,15 +113,9 @@ where
                 .and_then(move |accounts| {
                     let routes: HashMap<String, String> = HashMap::from_iter(
                         routes
-                            .keys()
-                            .zip(accounts.into_iter().map(|a| a.username().to_string()))
-                            .filter_map(|(prefix, username)| {
-                                if let Ok(prefix) = str::from_utf8(prefix.as_ref()) {
-                                    Some((prefix.to_string(), username))
-                                } else {
-                                    None
-                                }
-                            }),
+                            .iter()
+                            .map(|(prefix, _)| prefix.to_string())
+                            .zip(accounts.into_iter().map(|a| a.username().to_string())),
                     );
 
                     Ok(warp::reply::json(&routes))

--- a/crates/interledger-ccp/src/fixtures.rs
+++ b/crates/interledger-ccp/src/fixtures.rs
@@ -37,13 +37,13 @@ lazy_static! {
         hold_down_time: 30000,
         speaker: Address::from_str("example.alice").unwrap(),
         new_routes: vec![Route {
-          prefix: Bytes::from("example.prefix1"),
-          path: vec![Bytes::from("example.prefix1")],
+          prefix: "example.prefix1".to_string(),
+          path: vec!["example.prefix1".to_string()],
           auth: [122,108,125,133,134,124,70,162,250,191,173,26,250,122,74,94,34,156,229,116,252,206,99,245,237,238,223,192,63,132,104,234],
           props: Vec::new(),
         }, Route {
-          prefix: Bytes::from("example.prefix2"),
-          path: vec![Bytes::from("example.connector1"), Bytes::from("example.prefix2")],
+          prefix: "example.prefix2".to_string(),
+          path: vec!["example.connector1".to_string(), "example.prefix2".to_string()],
           auth: [43,8,229,63,188,193,124,95,27,213,74,224,217,173,123,163,154,95,154,123,18,108,169,181,192,148,86,9,163,83,36,204],
           props: vec![RouteProp {
             is_optional: false,
@@ -62,8 +62,8 @@ lazy_static! {
           }]
         }],
         withdrawn_routes: vec![
-            Bytes::from("example.prefix3"),
-            Bytes::from("example.prefix4"),
+            "example.prefix3".to_string(),
+            "example.prefix4".to_string(),
         ]
     };
 }

--- a/crates/interledger-ccp/src/lib.rs
+++ b/crates/interledger-ccp/src/lib.rs
@@ -9,7 +9,6 @@
 //! updates are used by the `Router` to forward incoming packets to the best next hop
 //! we know about.
 
-use bytes::Bytes;
 use futures::Future;
 use interledger_service::Account;
 use std::collections::HashMap;
@@ -89,8 +88,8 @@ pub trait CcpRoutingAccount: Account {
 }
 
 // key = Bytes, key should be Address -- TODO
-type Route<T> = HashMap<Bytes, T>;
-type LocalAndConfiguredRoutes<T> = (Route<T>, Route<T>);
+type Routes<T> = HashMap<String, T>;
+type LocalAndConfiguredRoutes<T> = (Routes<T>, Routes<T>);
 
 pub trait RouteManagerStore: Clone {
     type Account: CcpRoutingAccount;
@@ -111,6 +110,6 @@ pub trait RouteManagerStore: Clone {
 
     fn set_routes(
         &mut self,
-        routes: impl IntoIterator<Item = (Bytes, Self::Account)>,
+        routes: impl IntoIterator<Item = (String, Self::Account)>,
     ) -> Box<dyn Future<Item = (), Error = ()> + Send>;
 }

--- a/crates/interledger-ccp/src/test_helpers.rs
+++ b/crates/interledger-ccp/src/test_helpers.rs
@@ -1,7 +1,6 @@
 /* kcov-ignore-start */
 use super::*;
 use crate::{packet::CCP_RESPONSE, server::CcpRouteManager};
-use bytes::Bytes;
 use futures::{
     future::{err, ok},
     Future,
@@ -87,9 +86,9 @@ impl CcpRoutingAccount for TestAccount {
 
 #[derive(Clone)]
 pub struct TestStore {
-    pub local: HashMap<Bytes, TestAccount>,
-    pub configured: HashMap<Bytes, TestAccount>,
-    pub routes: Arc<Mutex<HashMap<Bytes, TestAccount>>>,
+    pub local: HashMap<String, TestAccount>,
+    pub configured: HashMap<String, TestAccount>,
+    pub routes: Arc<Mutex<HashMap<String, TestAccount>>>,
 }
 
 impl TestStore {
@@ -102,8 +101,8 @@ impl TestStore {
     }
 
     pub fn with_routes(
-        local: HashMap<Bytes, TestAccount>,
-        configured: HashMap<Bytes, TestAccount>,
+        local: HashMap<String, TestAccount>,
+        configured: HashMap<String, TestAccount>,
     ) -> TestStore {
         TestStore {
             local,
@@ -113,7 +112,7 @@ impl TestStore {
     }
 }
 
-type RoutingTable<A> = HashMap<Bytes, A>;
+type RoutingTable<A> = HashMap<String, A>;
 
 impl AddressStore for TestStore {
     /// Saves the ILP Address in the store's memory and database
@@ -181,7 +180,7 @@ impl RouteManagerStore for TestStore {
 
     fn set_routes(
         &mut self,
-        routes: impl IntoIterator<Item = (Bytes, TestAccount)>,
+        routes: impl IntoIterator<Item = (String, TestAccount)>,
     ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
         *self.routes.lock() = HashMap::from_iter(routes.into_iter());
         Box::new(ok(()))
@@ -234,11 +233,11 @@ pub fn test_service_with_routes() -> (
 ) {
     let local_routes = HashMap::from_iter(vec![
         (
-            Bytes::from("example.local.1"),
+            "example.local.1".to_string(),
             TestAccount::new(1, "example.local.1"),
         ),
         (
-            Bytes::from("example.connector.other-local"),
+            "example.connector.other-local".to_string(),
             TestAccount {
                 id: 3,
                 ilp_address: Address::from_str("example.connector.other-local").unwrap(),
@@ -247,7 +246,7 @@ pub fn test_service_with_routes() -> (
         ),
     ]);
     let configured_routes = HashMap::from_iter(vec![(
-        Bytes::from("example.configured.1"),
+        "example.configured.1".to_string(),
         TestAccount::new(2, "example.configured.1"),
     )]);
     let store = TestStore::with_routes(local_routes, configured_routes);

--- a/crates/interledger-router/Cargo.toml
+++ b/crates/interledger-router/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 repository = "https://github.com/interledger-rs/interledger-rs"
 
 [dependencies]
-bytes = { version = "0.4.12", default-features = false }
 futures = { version = "0.1.29", default-features = false }
 interledger-packet = { path = "../interledger-packet", version = "^0.2.2-alpha.1", default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.2.2-alpha.1", default-features = false }

--- a/crates/interledger-router/src/lib.rs
+++ b/crates/interledger-router/src/lib.rs
@@ -12,9 +12,8 @@
 //! store can either be configured or populated using the `CcpRouteManager`
 //! (see the `interledger-ccp` crate for more details).
 
-use bytes::Bytes;
 use interledger_service::{Account, AccountStore};
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 mod router;
 
@@ -27,5 +26,5 @@ pub trait RouterStore: AccountStore + Clone + Send + Sync + 'static {
     /// keep the routing table in memory and use PubSub or polling to keep it updated.
     /// This ensures that individual packets can be routed without hitting the underlying store.
     // TODO avoid using HashMap because it means it'll be cloned a lot
-    fn routing_table(&self) -> HashMap<Bytes, <Self::Account as Account>::AccountId>;
+    fn routing_table(&self) -> Arc<HashMap<String, <Self::Account as Account>::AccountId>>;
 }

--- a/crates/interledger-router/src/lib.rs
+++ b/crates/interledger-router/src/lib.rs
@@ -21,10 +21,10 @@ pub use self::router::Router;
 
 /// A trait for Store implmentations that have ILP routing tables.
 pub trait RouterStore: AccountStore + Clone + Send + Sync + 'static {
-    /// **Synchronously** return a copy of the routing table.
+    /// **Synchronously** return the routing table.
     /// Note that this is synchronous because it assumes that Stores should
     /// keep the routing table in memory and use PubSub or polling to keep it updated.
     /// This ensures that individual packets can be routed without hitting the underlying store.
-    // TODO avoid using HashMap because it means it'll be cloned a lot
+    /// An Arc is returned to avoid copying the underlying data while processing each packet.
     fn routing_table(&self) -> Arc<HashMap<String, <Self::Account as Account>::AccountId>>;
 }

--- a/crates/interledger-store-redis/src/store.rs
+++ b/crates/interledger-store-redis/src/store.rs
@@ -277,6 +277,12 @@ pub struct RedisStore {
     connection: RedisReconnect,
     subscriptions: Arc<RwLock<HashMap<AccountId, UnboundedSender<PaymentNotification>>>>,
     exchange_rates: Arc<RwLock<HashMap<String, f64>>>,
+    /// The store keeps the routing table in memory so that it can be returned
+    /// synchronously while the Router is processing packets.
+    /// The outer `Arc<RwLock>` is used so that we can update the stored routing
+    /// table after polling the store for updates.
+    /// The inner `Arc<HashMap>` is used so that the `routing_table` method can
+    /// return a reference to the routing table without cloning the underlying data.
     routes: Arc<RwLock<Arc<HashMap<String, AccountId>>>>,
     encryption_key: Arc<Secret<EncryptionKey>>,
     decryption_key: Arc<Secret<DecryptionKey>>,

--- a/crates/interledger-store-redis/tests/routing_test.rs
+++ b/crates/interledger-store-redis/tests/routing_test.rs
@@ -1,6 +1,5 @@
 mod common;
 
-use bytes::Bytes;
 use common::*;
 use interledger_api::{AccountDetails, NodeStore};
 use interledger_ccp::RouteManagerStore;
@@ -31,10 +30,7 @@ fn polls_for_route_updates() {
                     .and_then(move |alice| {
                         let routing_table = store_clone_1.routing_table();
                         assert_eq!(routing_table.len(), 1);
-                        assert_eq!(
-                            *routing_table.get(&Bytes::from("example.alice")).unwrap(),
-                            alice.id()
-                        );
+                        assert_eq!(*routing_table.get("example.alice").unwrap(), alice.id());
                         store_clone_1
                             .insert_account(AccountDetails {
                                 ilp_address: Some(Address::from_str("example.bob").unwrap()),
@@ -60,10 +56,7 @@ fn polls_for_route_updates() {
                             .and_then(move |bob| {
                                 let routing_table = store_clone_2.routing_table();
                                 assert_eq!(routing_table.len(), 2);
-                                assert_eq!(
-                                    *routing_table.get(&Bytes::from("example.bob")).unwrap(),
-                                    bob.id(),
-                                );
+                                assert_eq!(*routing_table.get("example.bob").unwrap(), bob.id(),);
                                 let alice_id = alice.id();
                                 let bob_id = bob.id();
                                 connection
@@ -88,26 +81,18 @@ fn polls_for_route_updates() {
                                         let routing_table = store_clone_2.routing_table();
                                         assert_eq!(routing_table.len(), 3);
                                         assert_eq!(
-                                            *routing_table
-                                                .get(&Bytes::from("example.alice"))
-                                                .unwrap(),
+                                            *routing_table.get("example.alice").unwrap(),
                                             bob_id
                                         );
                                         assert_eq!(
-                                            *routing_table
-                                                .get(&Bytes::from("example.bob"))
-                                                .unwrap(),
+                                            *routing_table.get("example.bob").unwrap(),
                                             bob.id(),
                                         );
                                         assert_eq!(
-                                            *routing_table
-                                                .get(&Bytes::from("example.charlie"))
-                                                .unwrap(),
+                                            *routing_table.get("example.charlie").unwrap(),
                                             alice_id,
                                         );
-                                        assert!(routing_table
-                                            .get(&Bytes::from("example.other"))
-                                            .is_none());
+                                        assert!(routing_table.get("example.other").is_none());
                                         let _ = context;
                                         Ok(())
                                     })
@@ -203,9 +188,9 @@ fn saves_routes_to_db() {
 
         store
             .set_routes(vec![
-                (Bytes::from("example.a"), account0.clone()),
-                (Bytes::from("example.b"), account0.clone()),
-                (Bytes::from("example.c"), account1.clone()),
+                ("example.a".to_string(), account0.clone()),
+                ("example.b".to_string(), account0.clone()),
+                ("example.c".to_string(), account1.clone()),
             ])
             .and_then(move |_| {
                 get_connection.and_then(move |connection| {
@@ -250,15 +235,15 @@ fn updates_local_routes() {
         store
             .clone()
             .set_routes(vec![
-                (Bytes::from("example.a"), account0.clone()),
-                (Bytes::from("example.b"), account0.clone()),
-                (Bytes::from("example.c"), account1.clone()),
+                ("example.a".to_string(), account0.clone()),
+                ("example.b".to_string(), account0.clone()),
+                ("example.c".to_string(), account1.clone()),
             ])
             .and_then(move |_| {
                 let routes = store.routing_table();
-                assert_eq!(routes[&b"example.a"[..]], account0_id);
-                assert_eq!(routes[&b"example.b"[..]], account0_id);
-                assert_eq!(routes[&b"example.c"[..]], account1_id);
+                assert_eq!(routes["example.a"], account0_id);
+                assert_eq!(routes["example.b"], account0_id);
+                assert_eq!(routes["example.c"], account1_id);
                 assert_eq!(routes.len(), 3);
                 Ok(())
             })
@@ -321,15 +306,15 @@ fn static_routes_override_others() {
                 .unwrap();
                 store_clone
                     .set_routes(vec![
-                        (Bytes::from("example.a"), account1.clone()),
-                        (Bytes::from("example.b"), account1.clone()),
-                        (Bytes::from("example.c"), account1),
+                        ("example.a".to_string(), account1.clone()),
+                        ("example.b".to_string(), account1.clone()),
+                        ("example.c".to_string(), account1),
                     ])
                     .and_then(move |_| {
                         let routes = store.routing_table();
-                        assert_eq!(routes[&b"example.a"[..]], accs[0].id());
-                        assert_eq!(routes[&b"example.b"[..]], accs[0].id());
-                        assert_eq!(routes[&b"example.c"[..]], account1_id);
+                        assert_eq!(routes["example.a"], accs[0].id());
+                        assert_eq!(routes["example.b"], accs[0].id());
+                        assert_eq!(routes["example.c"], account1_id);
                         assert_eq!(routes.len(), 3);
                         let _ = context;
                         Ok(())
@@ -356,14 +341,14 @@ fn default_route() {
                 .unwrap();
                 store_clone
                     .set_routes(vec![
-                        (Bytes::from("example.a"), account1.clone()),
-                        (Bytes::from("example.b"), account1.clone()),
+                        ("example.a".to_string(), account1.clone()),
+                        ("example.b".to_string(), account1.clone()),
                     ])
                     .and_then(move |_| {
                         let routes = store.routing_table();
-                        assert_eq!(routes[&b""[..]], accs[0].id());
-                        assert_eq!(routes[&b"example.a"[..]], account1_id);
-                        assert_eq!(routes[&b"example.b"[..]], account1_id);
+                        assert_eq!(routes[""], accs[0].id());
+                        assert_eq!(routes["example.a"], account1_id);
+                        assert_eq!(routes["example.b"], account1_id);
                         assert_eq!(routes.len(), 3);
                         let _ = context;
                         Ok(())
@@ -385,8 +370,8 @@ fn returns_configured_routes_for_route_manager() {
             .and_then(move |_| store.get_local_and_configured_routes())
             .and_then(move |(_local, configured)| {
                 assert_eq!(configured.len(), 2);
-                assert_eq!(configured[&b"example.a"[..]].id(), accs[0].id());
-                assert_eq!(configured[&b"example.b"[..]].id(), accs[1].id());
+                assert_eq!(configured["example.a"].id(), accs[0].id());
+                assert_eq!(configured["example.b"].id(), accs[1].id());
                 let _ = context;
                 Ok(())
             })


### PR DESCRIPTION
While reviewing the routing table logic with @bstrie, we realized that it was cloning the whole routing table, including account IDs for every account, while processing each packet. This changes the `RouterStore#routing_table()` method to return an `Arc<HashMap>` to avoid copying the underlying data.

This also changes the prefix type to be `String`s instead of `Bytes`, because ILP address prefixes must be UTF8 and we had a lot of unnecessary parsing logic scattered throughout the code to display the prefix.

The first two commits are unrelated but they're small changes I think we should make.

Open questions:
- Should we use the [String crate](https://crates.io/crates/string) instead of `std::string::String` to avoid copying those values around (for example, when creating route broadcasts)?