### PR TITLE
Update error handling in cli-app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,11 +693,11 @@ name = "ilp-cli"
 version = "0.2.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tungstenite 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2064,6 +2064,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2943,6 +2961,8 @@ dependencies = [
 "checksum synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9fe148fa0fc3363a27092d48f7787363ded15bb8623c5d5dd4e2e9f23e4b21bc"
+"checksum thiserror-impl 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "258da67e99e590650fa541ac6be764313d23e80cefb6846b516deb8de6b6d921"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4574b75faccaacddb9b284faecdf0b544b80b6b294f3d062d325c5726a209c20"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,6 +693,7 @@ name = "ilp-cli"
 version = "0.2.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/ilp-cli/Cargo.toml
+++ b/crates/ilp-cli/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 
 [dependencies]
 clap = { version = "2.33.0", default-features = false }
-failure = { version = "0.1.6", default-features = false }
+thiserror = { version = "1.0.4", default-features = false }
 http = { version = "0.1.18", default-features = false }
 reqwest = { version = "0.9.21", default-features = false, features = ["default-tls"] }
 serde = { version = "1.0.101", default-features = false }

--- a/crates/ilp-cli/Cargo.toml
+++ b/crates/ilp-cli/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 
 [dependencies]
 clap = { version = "2.33.0", default-features = false }
+failure = { version = "0.1.6", default-features = false }
 http = { version = "0.1.18", default-features = false }
 reqwest = { version = "0.9.21", default-features = false, features = ["default-tls"] }
 serde = { version = "1.0.101", default-features = false }

--- a/crates/ilp-cli/src/interpreter.rs
+++ b/crates/ilp-cli/src/interpreter.rs
@@ -1,17 +1,24 @@
 use clap::ArgMatches;
+use failure::Fail;
 use http;
 use reqwest::{self, Client, Response};
 use std::{borrow::Cow, collections::HashMap};
 use tungstenite::{connect, handshake::client::Request};
 use url::Url;
 
-#[derive(Debug)]
+#[derive(Debug, Fail)]
 pub enum Error {
+    #[fail(display = "Usage error")]
     UsageErr(&'static str),
+    #[fail(display = "Error sending request: {}", _0)]
     ClientErr(reqwest::Error),
+    #[fail(display = "Error receiving response: {}", _0)]
     ResponseErr(String),
+    #[fail(display = "Error parsing URL protocol: {}", _0)]
     ProtocolErr(&'static str),
+    #[fail(display = "Error parsing URL: {}", _0)]
     UrlErr(url::ParseError),
+    #[fail(display = "Error connecting to WebSocket host: {}", _0)]
     WebsocketErr(tungstenite::error::Error),
 }
 
@@ -134,7 +141,7 @@ impl NodeClient<'_> {
         let scheme = match url.scheme() {
             "http" => Ok("ws"),
             "https" => Ok("wss"),
-            _ => Err(Error::ProtocolErr("Unexpected URL protocol")),
+            _ => Err(Error::ProtocolErr("Unexpected protocol")),
         }?;
 
         // The scheme has already been sanitized so this should always succeed

--- a/crates/ilp-cli/src/interpreter.rs
+++ b/crates/ilp-cli/src/interpreter.rs
@@ -21,67 +21,40 @@ pub fn run(matches: &ArgMatches) -> Result<Response, Error> {
 
     // Dispatch based on parsed input
     match matches.subcommand() {
-        // Execute the specified subcommand
-        (ilp_cli_subcommand, Some(ilp_cli_matches)) => {
-            // Send HTTP request
-            match ilp_cli_subcommand {
-                "accounts" => match ilp_cli_matches.subcommand() {
-                    (accounts_subcommand, Some(accounts_matches)) => match accounts_subcommand {
-                        "balance" => client.get_account_balance(accounts_matches),
-                        "create" => client.post_accounts(accounts_matches),
-                        "delete" => client.delete_account(accounts_matches),
-                        "incoming-payments" => {
-                            client.ws_account_payments_incoming(accounts_matches)
-                        }
-                        "info" => client.get_account(accounts_matches),
-                        "list" => client.get_accounts(accounts_matches),
-                        "update" => client.put_account(accounts_matches),
-                        "update-settings" => client.put_account_settings(accounts_matches),
-                        command => panic!("Unhandled `ilp-cli accounts` subcommand: {}", command),
-                    },
-                    _ => Err(Error::UsageErr("ilp-cli help accounts")),
-                },
-                "pay" => client.post_account_payments(ilp_cli_matches),
-                "rates" => match ilp_cli_matches.subcommand() {
-                    (rates_subcommand, Some(rates_matches)) => match rates_subcommand {
-                        "list" => client.get_rates(rates_matches),
-                        "set-all" => client.put_rates(rates_matches),
-                        command => panic!("Unhandled `ilp-cli rates` subcommand: {}", command),
-                    },
-                    _ => Err(Error::UsageErr("ilp-cli help rates")),
-                },
-                "routes" => match ilp_cli_matches.subcommand() {
-                    (routes_subcommand, Some(routes_matches)) => match routes_subcommand {
-                        "list" => client.get_routes(routes_matches),
-                        "set" => client.put_route_static(routes_matches),
-                        "set-all" => client.put_routes_static(routes_matches),
-                        command => panic!("Unhandled `ilp-cli routes` subcommand: {}", command),
-                    },
-                    _ => Err(Error::UsageErr("ilp-cli help routes")),
-                },
-                "settlement-engines" => match ilp_cli_matches.subcommand() {
-                    (settlement_engines_subcommand, Some(settlement_engines_matches)) => {
-                        match settlement_engines_subcommand {
-                            "set-all" => client.put_settlement_engines(settlement_engines_matches),
-                            command => panic!(
-                                "Unhandled `ilp-cli settlement-engines` subcommand: {}",
-                                command
-                            ),
-                        }
-                    }
-                    _ => Err(Error::UsageErr("ilp-cli help settlement-engines")),
-                },
-                "status" => client.get_root(ilp_cli_matches),
-                "testnet" => match ilp_cli_matches.subcommand() {
-                    (testnet_subcommand, Some(testnet_matches)) => match testnet_subcommand {
-                        "setup" => client.xpring_account(testnet_matches),
-                        command => panic!("Unhandled `ilp-cli testnet` subcommand: {}", command),
-                    },
-                    _ => Err(Error::UsageErr("ilp-cli help testnet")),
-                },
-                command => panic!("Unhandled `ilp-cli` subcommand: {}", command),
+        ("accounts", Some(accounts_matches)) => match accounts_matches.subcommand() {
+            ("balance", Some(submatches)) => client.get_account_balance(submatches),
+            ("create", Some(submatches)) => client.post_accounts(submatches),
+            ("delete", Some(submatches)) => client.delete_account(submatches),
+            ("incoming-payments", Some(submatches)) => {
+                client.ws_account_payments_incoming(submatches)
             }
-        }
+            ("info", Some(submatches)) => client.get_account(submatches),
+            ("list", Some(submatches)) => client.get_accounts(submatches),
+            ("update", Some(submatches)) => client.put_account(submatches),
+            ("update-settings", Some(submatches)) => client.put_account_settings(submatches),
+            _ => Err(Error::UsageErr("ilp-cli help accounts")),
+        },
+        ("pay", Some(pay_matches)) => client.post_account_payments(pay_matches),
+        ("rates", Some(rates_matches)) => match rates_matches.subcommand() {
+            ("list", Some(submatches)) => client.get_rates(submatches),
+            ("set-all", Some(submatches)) => client.put_rates(submatches),
+            _ => Err(Error::UsageErr("ilp-cli help rates")),
+        },
+        ("routes", Some(routes_matches)) => match routes_matches.subcommand() {
+            ("list", Some(submatches)) => client.get_routes(submatches),
+            ("set", Some(submatches)) => client.put_route_static(submatches),
+            ("set-all", Some(submatches)) => client.put_routes_static(submatches),
+            _ => Err(Error::UsageErr("ilp-cli help routes")),
+        },
+        ("settlement-engines", Some(settlement_matches)) => match settlement_matches.subcommand() {
+            ("set-all", Some(submatches)) => client.put_settlement_engines(submatches),
+            _ => Err(Error::UsageErr("ilp-cli help settlement-engines")),
+        },
+        ("status", Some(status_matches)) => client.get_root(status_matches),
+        ("testnet", Some(testnet_matches)) => match testnet_matches.subcommand() {
+            ("setup", Some(submatches)) => client.xpring_account(submatches),
+            _ => Err(Error::UsageErr("ilp-cli help testnet")),
+        },
         _ => Err(Error::UsageErr("ilp-cli help")),
     }
 }

--- a/crates/ilp-cli/src/interpreter.rs
+++ b/crates/ilp-cli/src/interpreter.rs
@@ -16,6 +16,8 @@ pub enum Error {
     ResponseErr(String),
     #[fail(display = "Error parsing URL protocol: {}", _0)]
     ProtocolErr(&'static str),
+    #[fail(display = "Error altering URL scheme")]
+    SchemeErr(),
     #[fail(display = "Error parsing URL: {}", _0)]
     UrlErr(url::ParseError),
     #[fail(display = "Error connecting to WebSocket host: {}", _0)]
@@ -144,8 +146,9 @@ impl NodeClient<'_> {
             _ => Err(Error::ProtocolErr("Unexpected protocol")),
         }?;
 
-        // The scheme has already been sanitized so this should always succeed
-        url.set_scheme(scheme).expect("Could not alter URL scheme");
+        if url.set_scheme(scheme).is_err() {
+            return Err(Error::SchemeErr());
+        };
 
         let mut request: Request = url.into();
         request.add_header(

--- a/crates/ilp-cli/src/main.rs
+++ b/crates/ilp-cli/src/main.rs
@@ -20,12 +20,12 @@ pub fn main() {
             app.get_matches_from(s.split(' '));
         }
         Err(e) => {
-            eprintln!("ILP CLI error: {}", e);
+            eprintln!("ilp-cli error: {}", e);
             exit(1);
         }
         Ok(mut response) => match response.text() {
             Err(e) => {
-                eprintln!("ILP CLI error: Failed to parse HTTP response: {}", e);
+                eprintln!("ilp-cli error: Failed to parse HTTP response: {}", e);
                 exit(1);
             }
             Ok(body) => {
@@ -35,7 +35,7 @@ pub fn main() {
                     }
                 } else {
                     eprintln!(
-                        "ILP CLI error: Unexpected response from server: {}: {}",
+                        "ilp-cli error: Unexpected response from server: {}: {}",
                         response.status(),
                         body,
                     );
@@ -55,9 +55,6 @@ pub fn main() {
 // run the interpreter in order to detect panics.
 // Conveniently this section also serves as a reference for example invocations.
 mod interface_tests {
-    use crate::interpreter;
-    use crate::parser;
-
     #[test]
     fn ilp_cli() {
         should_parse(&[
@@ -101,18 +98,6 @@ mod interface_tests {
         should_parse(&[
             "ilp-cli accounts incoming-payments alice --auth foo", // minimal
         ]);
-    }
-
-    #[test]
-    fn accounts_incoming_payments_invalid_protocol() {
-        should_parse(&[
-            "ilp-cli --node tftp://localhost:7770 accounts incoming-payments alice --auth foo",
-        ]);
-    }
-
-    #[test]
-    fn accounts_incoming_payments_invalid_host() {
-        should_parse(&["ilp-cli --node http://:7770 accounts incoming-payments alice --auth foo"]);
     }
 
     #[test]
@@ -211,16 +196,19 @@ mod interface_tests {
     }
 
     fn should_parse(examples: &[&str]) {
+        use crate::interpreter::{run, Error};
+        use crate::parser;
+
         let mut app = parser::build();
         for example in examples {
             let parser_result = app.get_matches_from_safe_borrow(example.split(' '));
             match parser_result {
-                Err(e) => panic!("Failure while parsing command `{}`: {}", example, e),
-                Ok(matches) => {
-                    // Any unanticipated errors at this stage will result in a panic from
-                    // within the interpreter, so no need to manually check the result.
-                    let _interpreter_result = interpreter::run(&matches);
-                }
+                Err(e) => panic!("Failed to parse command `{}`: {}", example, e),
+                Ok(matches) => match run(&matches) {
+                    // Because these are interface tests, not integration tests, network errors are expected
+                    Ok(_) | Err(Error::ClientErr(_)) | Err(Error::WebsocketErr(_)) => (),
+                    Err(e) => panic!("Unexpected interpreter failure: {}", e),
+                },
             }
         }
     }

--- a/crates/ilp-cli/src/main.rs
+++ b/crates/ilp-cli/src/main.rs
@@ -101,7 +101,23 @@ mod interface_tests {
     }
 
     #[test]
-    fn accounts_incoming_payments() {}
+    fn accounts_incoming_payments() {
+        should_parse(&[
+            "ilp-cli accounts incoming-payments alice --auth foo", // minimal
+        ]);
+    }
+
+    #[test]
+    fn accounts_incoming_payments_invalid_protocol() {
+        should_parse(&[
+            "ilp-cli --node tftp://localhost:7770 accounts incoming-payments alice --auth foo",
+        ]);
+    }
+
+    #[test]
+    fn accounts_incoming_payments_invalid_host() {
+        should_parse(&["ilp-cli --node http://:7770 accounts incoming-payments alice --auth foo"]);
+    }
 
     #[test]
     fn accounts_info() {

--- a/crates/ilp-cli/src/main.rs
+++ b/crates/ilp-cli/src/main.rs
@@ -27,6 +27,18 @@ pub fn main() {
             eprintln!("ILP CLI error: invalid response: {}", e);
             exit(1);
         }
+        Err(interpreter::Error::ProtocolErr(e)) => {
+            eprintln!("ILP CLI error: failed to send request: {}", e);
+            exit(1);
+        }
+        Err(interpreter::Error::UrlErr(e)) => {
+            eprintln!("ILP CLI error: failed to send request: {}", e);
+            exit(1);
+        }
+        Err(interpreter::Error::WebsocketErr(e)) => {
+            eprintln!("ILP CLI error: Could not connect to WebSocket host: {}", e);
+            exit(1);
+        }
         Ok(mut response) => match response.text() {
             Err(e) => {
                 eprintln!("ILP CLI error: Failed to parse HTTP response: {}", e);

--- a/crates/ilp-cli/src/main.rs
+++ b/crates/ilp-cli/src/main.rs
@@ -19,24 +19,8 @@ pub fn main() {
             // help text for an arbitrary subcommand, but this works just the same.
             app.get_matches_from(s.split(' '));
         }
-        Err(interpreter::Error::ClientErr(e)) => {
-            eprintln!("ILP CLI error: failed to send request: {}", e);
-            exit(1);
-        }
-        Err(interpreter::Error::ResponseErr(e)) => {
-            eprintln!("ILP CLI error: invalid response: {}", e);
-            exit(1);
-        }
-        Err(interpreter::Error::ProtocolErr(e)) => {
-            eprintln!("ILP CLI error: failed to send request: {}", e);
-            exit(1);
-        }
-        Err(interpreter::Error::UrlErr(e)) => {
-            eprintln!("ILP CLI error: failed to send request: {}", e);
-            exit(1);
-        }
-        Err(interpreter::Error::WebsocketErr(e)) => {
-            eprintln!("ILP CLI error: Could not connect to WebSocket host: {}", e);
+        Err(e) => {
+            eprintln!("ILP CLI error: {}", e);
             exit(1);
         }
         Ok(mut response) => match response.text() {

--- a/crates/ilp-cli/src/main.rs
+++ b/crates/ilp-cli/src/main.rs
@@ -206,7 +206,10 @@ mod interface_tests {
                 Err(e) => panic!("Failed to parse command `{}`: {}", example, e),
                 Ok(matches) => match run(&matches) {
                     // Because these are interface tests, not integration tests, network errors are expected
-                    Ok(_) | Err(Error::ClientErr(_)) | Err(Error::WebsocketErr(_)) => (),
+                    Ok(_)
+                    | Err(Error::SendErr(_))
+                    | Err(Error::WebsocketErr(_))
+                    | Err(Error::TestnetErr(_)) => (),
                     Err(e) => panic!("Unexpected interpreter failure: {}", e),
                 },
             }


### PR DESCRIPTION
The cli app will panic in `ws_account_payments_incoming` for several legitimate use cases:

  * invalid URL
  * invalid URL protocol/scheme
  * ilp node not running

This extends the `interpreter.rs` module's `Error` enum, allowing the `?` to gracefully report failures to the end user. Is this the style you prefer for error handling?

A few other notes:

  * Refactored a nested match statement for readability, drawn from this [clap example](https://docs.rs/clap/2.33.0/clap/struct.ArgMatches.html#examples-13). The behavior should be the same.
  * Is there a more descriptive name for `ClientErr`, say, `RequestErr`?
  * Can `socket.read_message().expect("Could not receive WebSocket message")` occur in normal use?
  * Is there is a reasonable way to spin up an ilp node for testing runtime failures? There doesn't seem to be anything that actually exercises `NodeClient::ws_account_payments_incoming()`.
