### PR TITLE
fix(ccp): fix to update the local table correctly, respecting the best route

### DIFF
--- a/crates/interledger-ccp/src/server.rs
+++ b/crates/interledger-ccp/src/server.rs
@@ -569,7 +569,7 @@ where
                             &incoming_tables,
                             prefix,
                         ) {
-                            if let Some((ref next_account, ref route)) =
+                            if let Some((ref next_account, ref _route)) =
                                 local_table.get_route(prefix)
                             {
                                 if next_account.id() == best_next_account.id() {
@@ -577,8 +577,8 @@ where
                                 } else {
                                     better_routes.push((
                                         prefix,
-                                        next_account.clone(),
-                                        route.clone(),
+                                        best_next_account.clone(),
+                                        best_route.clone(),
                                     ));
                                 }
                             } else {


### PR DESCRIPTION
Fix: `two_nodes_btp` is unstable #464

Currently `better_routes` is set with the old account information. It should be replaced with the latest best route. This bug makes the `two_nodes_btp` test unstable. The reason is a bit complex, there are 2 types of behavior.

1. Success pattern
    - Node A sends an ILDCP request to Node B
    - **Node A has not received Route Update Request at this point**
    - Node A receives ILDCP response
    - The local table finally becomes like:
        - `example.parent.a_on_b.alice_on_a`: `alice_on_a`
1. Failure pattern
    - Node A sends an ILDCP request to Node B
    - **Node A receives a Route Update Request** and the local table becomes like:
        - `example.parent`: `b_on_a`
        - This is correct at this point though I'm not sure this is the desired behavior or not
    - Node A receives ILDCP response
    - Node A tries to update the local table
        - Try to update prefix `example.parent.a_on_b.alice_on_a` and find `example.parent`
        - If `better_routes` is updated with **current** route, it is pointed to `b_on_a`
            - Because `example.parent` is pointed to `b_on_a`
    - The local table finally becomes like:
        - `example.parent.a_on_b.alice_on_a`: `b_on_a`

Then packets that should be routed to `alice_on_a` never get received and the payment from Node B to Node A never ends.