### PR TITLE
feat(http api): return the node version instead of the interledger-api crate version

### DIFF
--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -404,7 +404,7 @@ impl InterledgerNode {
                                 api.default_spsp_account(username);
                             }
                             // add an API of ILP over HTTP and add rejection handler
-                            let api = api.into_warp_filter()
+                            let api = api.into_warp_filter(Some(env!("CARGO_PKG_VERSION").to_owned()))
                                 .or(IlpOverHttpServer::new(incoming_service.clone().wrap(|request, mut next| {
                                     let http = debug_span!(target: "interledger-node", "http");
                                     let _http_scope = http.enter();

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -403,8 +403,9 @@ impl InterledgerNode {
                             if let Some(username) = default_spsp_account {
                                 api.default_spsp_account(username);
                             }
+                            api.node_version(env!("CARGO_PKG_VERSION").to_string());
                             // add an API of ILP over HTTP and add rejection handler
-                            let api = api.into_warp_filter(Some(env!("CARGO_PKG_VERSION").to_owned()))
+                            let api = api.into_warp_filter()
                                 .or(IlpOverHttpServer::new(incoming_service.clone().wrap(|request, mut next| {
                                     let http = debug_span!(target: "interledger-node", "http");
                                     let _http_scope = http.enter();

--- a/crates/interledger-api/src/lib.rs
+++ b/crates/interledger-api/src/lib.rs
@@ -261,7 +261,10 @@ where
         self
     }
 
-    pub fn into_warp_filter(self) -> warp::filters::BoxedFilter<(impl warp::Reply,)> {
+    pub fn into_warp_filter(
+        self,
+        node_version: Option<String>,
+    ) -> warp::filters::BoxedFilter<(impl warp::Reply,)> {
         routes::accounts_api(
             self.server_secret,
             self.admin_api_token.clone(),
@@ -271,12 +274,20 @@ where
             self.btp,
             self.store.clone(),
         )
-        .or(routes::node_settings_api(self.admin_api_token, self.store))
+        .or(routes::node_settings_api(
+            self.admin_api_token,
+            node_version,
+            self.store,
+        ))
         .boxed()
     }
 
-    pub fn bind(self, addr: SocketAddr) -> impl Future<Item = (), Error = ()> {
-        warp::serve(self.into_warp_filter()).bind(addr)
+    pub fn bind(
+        self,
+        addr: SocketAddr,
+        node_version: Option<String>,
+    ) -> impl Future<Item = (), Error = ()> {
+        warp::serve(self.into_warp_filter(node_version)).bind(addr)
     }
 }
 

--- a/crates/interledger-api/src/routes/node_settings.rs
+++ b/crates/interledger-api/src/routes/node_settings.rs
@@ -22,6 +22,7 @@ use warp::{self, Filter, Rejection};
 
 pub fn node_settings_api<S, A>(
     admin_api_token: String,
+    node_version: Option<String>,
     store: S,
 ) -> warp::filters::BoxedFilter<(impl warp::Reply,)>
 where
@@ -57,7 +58,7 @@ where
             warp::reply::json(&json!({
                 "status": "Ready".to_string(),
                 "ilp_address": store.get_ilp_address(),
-                "version": env!("CARGO_PKG_VERSION"),
+                "version": node_version,
             }))
         })
         .boxed();

--- a/crates/interledger-api/src/routes/node_settings.rs
+++ b/crates/interledger-api/src/routes/node_settings.rs
@@ -5,13 +5,13 @@ use futures::{
     Future,
 };
 use interledger_http::{deserialize_json, error::*, HttpAccount, HttpStore};
+use interledger_packet::Address;
 use interledger_router::RouterStore;
 use interledger_service::{Account, Username};
 use interledger_service_util::{BalanceStore, ExchangeRateStore};
 use interledger_settlement::SettlementAccount;
 use log::{error, trace};
 use serde::Serialize;
-use serde_json::json;
 use std::{
     collections::HashMap,
     iter::FromIterator,
@@ -19,6 +19,15 @@ use std::{
 };
 use url::Url;
 use warp::{self, Filter, Rejection};
+
+// TODO add more to this response
+#[derive(Clone, Serialize)]
+struct StatusResponse {
+    status: String,
+    ilp_address: Address,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+}
 
 pub fn node_settings_api<S, A>(
     admin_api_token: String,
@@ -54,12 +63,11 @@ where
         .and(warp::path::end())
         .and(with_store.clone())
         .map(move |store: S| {
-            // TODO add more to this response
-            warp::reply::json(&json!({
-                "status": "Ready".to_string(),
-                "ilp_address": store.get_ilp_address(),
-                "version": node_version,
-            }))
+            warp::reply::json(&StatusResponse {
+                status: "Ready".to_string(),
+                ilp_address: store.get_ilp_address(),
+                version: node_version.clone(),
+            })
         })
         .boxed();
 


### PR DESCRIPTION
We could do some hack when compiling using `build.rs` etc. but it seemed more straightforward to pass the version to API. I'm not so sure there is the case of using `interledger-api` crate for another use but I used `Option` for `node_version`. If that looks too much or unnecessary, I'd be happy to change.

The output looks like:
```
{"ilp_address":"local.host","status":"Ready","version":"0.5.1"}
```
which shows `ilp-node`'s version.