### PR TITLE
Fix exchange rate bug

### DIFF
--- a/crates/ilp-node/tests/three_nodes.rs
+++ b/crates/ilp-node/tests/three_nodes.rs
@@ -174,7 +174,7 @@ fn three_nodes() {
                 client
                     .put(&format!("http://localhost:{}/rates", node2_http))
                     .header("Authorization", "Bearer admin")
-                    .json(&json!({"ABC": 2, "XYZ": 1}))
+                    .json(&json!({"ABC": 1, "XYZ": 2}))
                     .send()
                     .map_err(|err| panic!(err))
                     .and_then(move |res| {

--- a/crates/interledger-service-util/src/exchange_rates_service.rs
+++ b/crates/interledger-service-util/src/exchange_rates_service.rs
@@ -95,9 +95,10 @@ where
                 .store
                 .get_exchange_rates(&[&request.from.asset_code(), &request.to.asset_code()])
             {
-                // if `from` is worth 1 USD and `to` is worth 10 USD, the
-                // outgoing amount will actually be 1/10th of the source amount,
-                // i.e. `from_amount * (from_rate / to_rate)`
+                // Exchange rates are expressed as `base asset / asset`. To calculate the outgoing amount,
+                // we multiply by the incoming asset's rate and divide by the outgoing asset's rate. For example,
+                // if an incoming packet is denominated in an asset worth 1 USD and the outgoing asset is worth
+                // 10 USD, the outgoing amount will be 1/10th of the source amount.
                 rates[0] / rates[1]
             } else {
                 error!(


### PR DESCRIPTION
We were upscaling instead of downscaling when converting between assets.

example:

ABC is worth $1 USD
XYZ is worth $10 USD

from = ABC
to = XYZ

previously:
rates[0] = 1
rates[1] = 10
rates[1]/rates[0] = 10

For each unit of ABC we would send out 10 units of XYZ, while instead we should be sending 0.1 unit. This is wrong.

We fix that by reverting the numerator with the denominator. Now, rates[0]/rates[1] = 0.1, which represents the correct amount whcih we should be sending.

--

In the opposite case:

from = XYZ
to = ABC

rates[0] = 10
rates [1] = 1
rates[0]/rates[1] = 10, which means that for each unit of XYZ we should send 10 units of ABC, which now makes perfect sense