### PR TITLE
ci(circleci): enables run-md-test.sh on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,16 @@
+# Cache spec
+# - cargo-cache-1
+#    - contents: .cargo
+#    - based on: Cargo.toml
+# - cargo-cache-2
+#    - contents: .cargo
+#    - based on: Cargo.lock
+
 version: 2
 jobs:
   build:
     docker:
-      - image: circleci/rust
+      - image: interledgerrs/circleci-rust-dind:latest
         environment:
           CARGO_HOME: /home/circleci/.cargo
     resource_class: medium+
@@ -10,25 +18,9 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-cache-1-{{ checksum "Cargo.toml" }}-{{ .Branch }}
-            - cargo-cache-1-{{ checksum "Cargo.toml" }}
-            - cargo-cache-1-
-      - run:
-          name: Install Cargo Extensions
-          command: |
-            # cargo-audit started requiring libcurl3
-            echo "deb http://security.ubuntu.com/ubuntu xenial-security main" | sudo tee -a /etc/apt/sources.list
-            sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 3B4FE6ACC0B21F32
-            sudo apt-get update
-            sudo apt-get install libcurl3 -y
-            cargo install --quiet cargo-audit || true # cargo-kcov
-            rustup component add rustfmt clippy || true
-      - run:
-          name: Install Redis
-          command: |
-            sudo apt-get update
-            sudo apt-get install redis-server
-            redis-server --version
+            - cargo-cache-2-{{ checksum "Cargo.lock" }}-{{ .Branch }}
+            - cargo-cache-2-{{ checksum "Cargo.lock" }}
+            - cargo-cache-2-
       - run:
           name: Reduce codegen units
           # If we don't include this, the linker runs out of memory when building
@@ -80,6 +72,96 @@ jobs:
       #     name: Upload Code Coverage
       #     command: "bash <(curl -s https://codecov.io/bash)"
       - save_cache:
-          key: cargo-cache-1-{{ checksum "Cargo.toml" }}-{{ .Branch }}
+          key: cargo-cache-2-{{ checksum "Cargo.lock" }}-{{ .Branch }}
           paths:
             - /home/circleci/.cargo
+  test-md:
+    docker:
+      - image: interledgerrs/circleci-rust-dind:latest
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - checkout
+      # If something wrong is cached, use these lines
+      #- run:
+      #    name: Clear docker cache
+      #    command: docker images --no-trunc --format '{{.ID}}' interledgerrs/settlement-engines | xargs --no-run-if-empty docker rmi
+      - restore_cache:
+          keys:
+            - cargo-cache-2-{{ checksum "Cargo.lock" }}-{{ .Branch }}
+            - cargo-cache-2-{{ checksum "Cargo.lock" }}
+            - cargo-cache-2-
+      - run:
+          name: Set Default Target musl
+          command: |
+            mkdir -p .cargo
+            printf "[build]\ntarget = \"x86_64-unknown-linux-musl\"\n" > .cargo/config
+      - run:
+          name: Build
+          command: cargo build --bin ilp-node --bin ilp-cli
+      - run:
+          # builds dev profile images because these images are not going to be released
+          # also, we have to copy binaries so remove target from .dockerignore
+          name: Build docker images
+          command: |
+            dockerignore=$(cat .dockerignore | sed /^target/d)
+            echo "$dockerignore" > .dockerignore
+            echo "target/**/*.d" >> .dockerignore
+            echo "target/**/*.rlib" >> .dockerignore
+            echo "target/**/deps" >> .dockerignore
+            echo "target/**/incremental" >> .dockerignore
+            docker/docker-build.sh ci-node ci-ilp-cli
+      - run:
+          name: Run run-md test
+          command: scripts/run-md-test.sh
+      - store_artifacts:
+          path: /tmp/run-md-test
+          destination: run-md-test
+      - save_cache:
+          key: cargo-cache-2-{{ checksum "Cargo.lock" }}-{{ .Branch }}
+          paths:
+            - /home/circleci/.cargo
+  update-docker-images:
+    docker:
+      - image: interledgerrs/circleci-rust-dind:latest
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - checkout
+      - restore_cache:
+          keys:
+            - cargo-cache-2-{{ checksum "Cargo.lock" }}-{{ .Branch }}
+            - cargo-cache-2-{{ checksum "Cargo.lock" }}
+            - cargo-cache-2-
+      - run:
+          # builds release profile images to be released
+          name: Build docker images
+          command: docker/docker-build.sh node ilp-cli
+          environment:
+            PROFILE: "release"
+      - run:
+          name: Push to DockerHub
+          # TODO tag properly
+          command: |
+            echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
+            docker push interledgerrs/node:latest
+            docker push interledgerrs/ilp-cli:latest
+      - save_cache:
+          key: cargo-cache-2-{{ checksum "Cargo.lock" }}-{{ .Branch }}
+          paths:
+            - /home/circleci/.cargo
+
+workflows:
+  version: 2
+  build_and_test-md:
+    jobs:
+      - build
+      - test-md
+      - update-docker-images: # updates docker images on DockerHub, only if the branch is master
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - build
+            - test-md

--- a/docker/CI/README.md
+++ b/docker/CI/README.md
@@ -1,0 +1,25 @@
+## Docker Images for CI
+### Why Do We Need This?
+In short, it is to **reduce the compilation time**.
+
+In the CI process, we are testing runnable `README.md` files which are written in the literate programming style run by `run-md.sh`. Against the `README.md` files, we are testing both:
+
+- **Normal** mode, which does NOT use Docker and just runs `cargo build` and `cargo run` commands.
+- **Docker** mode, which uses Docker.
+
+For the Docker mode, we need **NEW Docker images** which contain the latest changes. Otherwise it is meaningless to test the markdown files because we definitely want to test the latest build of `interledger-rs`.
+
+So we need new docker images of:
+
+- ilp-node
+- ilp-cli
+
+In order to build new docker images, we build the source code once like `cargo build --bin ilp-node --bin ilp-cli`, not twice because we want to reduce compilation time. After the build, we just copy the binaries to docker containers using `CI/node.dockerimage` and `CI/ilp-cli.dockerimage`. That is why we don't use normal `node.dockerfile` and `ilp-cli.dockerfile`. It compiles the source files of `interledger-rs` **inside** the container, so we need **two** compilation of the source although that seems natural for normal uses.
+
+The docker images `node.dockerfile` and `ilp-cli.dockerfile` contain platform-agnostic (although it is not completely agnostic) binaries which means it does not rely on dynamic libraries and uses `musl` instead. So we have to provide `musl` environment for `Cargo`. That is why `circleci-rust-dind.dockerfile` contains `musl`.
+
+Also why `circleci-rust-dind.dockerfile` is an independent image is that there isn't any suitable image which contains `Cargo`, `musl` and `dind` (docker in docker). `dind` is required to test the Docker mode because `run-md.sh` runs docker commands such as `docker run`. It requires docker commands inside the docker image. CircleCI spins up a Docker environment somewhere outer the container. So it would be called rater "docker command in container" than "docker in docker".
+
+![docker commands in container](./images/dind.svg)
+
+In the runnable markdown files, we provide normal mode which does not use Docker. Now we compiled the source code for the Docker images, it seems natural that we use the binaries for the normal mode. That is why we set the default target of `Cargo` to `musl` so that `run-md.sh` never compiles the source code again.

--- a/docker/CI/circleci-rust-dind.dockerfile
+++ b/docker/CI/circleci-rust-dind.dockerfile
@@ -1,0 +1,75 @@
+# rust + dind + musl + (nvm + npm + yarn + ganache + ilp-settlement-xrp)
+FROM circleci/rust:1.38
+
+USER root
+
+# Install libcurl3 etc.
+# cargo-audit started requiring libcurl3
+RUN echo "deb http://security.ubuntu.com/ubuntu xenial-security main" | tee -a /etc/apt/sources.list && \
+    apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 3B4FE6ACC0B21F32 && \
+    apt-get update && \
+    apt-get install libcurl3 -y && \
+    # get libcurl to a place where it won't get overwritten
+    cp /usr/lib/x86_64-linux-gnu/libcurl.so.3 /usr/lib && \
+    apt-get install curl -y
+
+# Because nc command doesn't accept -k argument correctly, we need to install ncat of buster.
+RUN echo "deb http://deb.debian.org/debian/ buster main contrib non-free" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y ncat redis-server redis-tools lsof libssl-dev
+
+# Install Rust tools
+RUN cargo install --quiet cargo-audit && \
+    rustup component add rustfmt && \
+    rustup component add clippy && \
+    rustup target add x86_64-unknown-linux-musl && \
+    rustup show
+
+# Build musl and openssl
+# https://github.com/clux/muslrust/blob/master/Dockerfile
+# Using export not to affect env vars of CircleCI.
+# Affecting these env vars causes compilation errors in CircleCI.
+WORKDIR /opt/musl
+RUN export SSL_VER="1.0.2s" && \
+    export CC=musl-gcc && \
+    export PREFIX=/opt/musl && \
+    export LD_LIBRARY_PATH=$PREFIX && \
+    echo "$PREFIX/lib" >> /etc/ld-musl-x86_64.path && \
+    ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/x86_64-linux-musl/asm && \
+    ln -s /usr/include/asm-generic /usr/include/x86_64-linux-musl/asm-generic && \
+    ln -s /usr/include/linux /usr/include/x86_64-linux-musl/linux
+RUN export SSL_VER="1.0.2s" && \
+    export CC=musl-gcc && \
+    export PREFIX=/opt/musl && \
+    export LD_LIBRARY_PATH=$PREFIX && \
+    curl -sSL https://www.openssl.org/source/openssl-$SSL_VER.tar.gz | tar xz && \
+    cd openssl-$SSL_VER && \
+    ./Configure no-zlib no-shared -fPIC --prefix=$PREFIX --openssldir=$PREFIX/ssl linux-x86_64 && \
+    env C_INCLUDE_PATH=$PREFIX/include make depend 2> /dev/null && \
+    make -j$(nproc) && make install && \
+    cd .. && rm -rf openssl-$SSL_VER
+
+USER circleci
+WORKDIR /home/circleci
+
+# Install nvm, node and ganache-cli
+# node v12 causes a compilation error
+# Because npm is super annoyingly slow & unstable, use yarn instead.
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+ENV NVM_DIR="/home/circleci/.nvm"
+ENV NODE_VERSION="v11.15.0"
+ENV NODE_PATH=$NVM_DIR/versions/node/$NODE_VERSION/lib/node_modules
+ENV PATH=$NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
+RUN . ~/.nvm/nvm.sh && \
+    nvm install $NODE_VERSION && \
+    curl -o- -L https://yarnpkg.com/install.sh | bash && \
+    export PATH=/home/circleci/.yarn/bin:=/home/circleci/.config/yarn/global/node_modules/.bin:$PATH && \
+    yarn global add ganache-cli ilp-settlement-xrp
+ENV PATH=/home/circleci/.yarn/bin:=/home/circleci/.config/yarn/global/node_modules/.bin:$PATH
+
+WORKDIR /home/circleci
+ENV CARGO_HOME=/home/circleci/.cargo
+ENV OPENSSL_DIR=/opt/musl
+
+ENTRYPOINT [ "/bin/bash" ]
+CMD [ ]

--- a/docker/CI/ilp-cli.dockerfile
+++ b/docker/CI/ilp-cli.dockerfile
@@ -1,0 +1,18 @@
+# Just to test markdown files
+# Deploy compiled binary
+FROM alpine
+
+# Install SSL certs
+RUN apk --no-cache add ca-certificates
+
+# Copy ilp-cli binary
+COPY \
+    target/x86_64-unknown-linux-musl/debug/ilp-cli \
+    /usr/local/bin/ilp-cli
+
+WORKDIR /opt/app
+
+# ENV RUST_BACKTRACE=1
+ENV RUST_LOG=interledger=debug
+
+ENTRYPOINT [ "/usr/local/bin/ilp-cli" ]

--- a/docker/CI/images/dind.svg
+++ b/docker/CI/images/dind.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xl="http://www.w3.org/1999/xlink" viewBox="101.5 178 853 387.5" width="853" height="387.5">
+  <defs>
+    <font-face font-family="Helvetica Neue" font-size="16" panose-1="2 0 5 3 0 0 0 2 0 4" units-per-em="1000" underline-position="-100" underline-thickness="50" slope="0" x-height="517" cap-height="714" ascent="951.9958" descent="-212.99744" font-weight="400">
+      <font-face-src>
+        <font-face-name name="HelveticaNeue"/>
+      </font-face-src>
+    </font-face>
+    <marker orient="auto" overflow="visible" markerUnits="strokeWidth" id="FilledArrow_Marker" stroke-linejoin="miter" stroke-miterlimit="10" viewBox="-1 -4 10 8" markerWidth="10" markerHeight="8" color="black">
+      <g>
+        <path d="M 8 0 L 0 -3 L 0 3 Z" fill="currentColor" stroke="currentColor" stroke-width="1"/>
+      </g>
+    </marker>
+    <font-face font-family="Courier" font-size="16" units-per-em="1000" underline-position="-178.22266" underline-thickness="57.61719" slope="0" x-height="456.54297" cap-height="586.91406" ascent="753.90625" descent="-246.09375" font-weight="400">
+      <font-face-src>
+        <font-face-name name="Courier"/>
+      </font-face-src>
+    </font-face>
+  </defs>
+  <metadata> Produced by OmniGraffle 7.11.4 
+    <dc:date>2019-10-19 14:22:05 +0000</dc:date>
+  </metadata>
+  <g id="キャンバス______1" stroke-opacity="1" stroke-dasharray="none" fill="none" stroke="none" fill-opacity="1">
+    <title>キャンバス 1</title>
+    <g id="キャンバス______1: レイヤー 1">
+      <title>レイヤー 1</title>
+      <g id="Graphic_2">
+        <rect x="112" y="188.5" width="328" height="325.5" fill="white"/>
+        <rect x="112" y="188.5" width="328" height="325.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(117 490.552)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="118.4" y="15">CI Machine</tspan>
+        </text>
+      </g>
+      <g id="Graphic_3">
+        <rect x="133.5" y="214.5" width="284" height="261" fill="white"/>
+        <rect x="133.5" y="214.5" width="284" height="261" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(138.5 452.052)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="93.744" y="15">Base Kernel</tspan>
+        </text>
+      </g>
+      <g id="Graphic_4">
+        <rect x="156" y="236.5" width="237.5" height="201.5" fill="white"/>
+        <rect x="156" y="236.5" width="237.5" height="201.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(161 414.552)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="68.862" y="15">CI Container</tspan>
+        </text>
+      </g>
+      <g id="Graphic_7">
+        <rect x="616" y="188.5" width="328" height="325.5" fill="white"/>
+        <rect x="616" y="188.5" width="328" height="325.5" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(621 490.552)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="70.384" y="15">Remote Docker Machine</tspan>
+        </text>
+      </g>
+      <g id="Graphic_6">
+        <rect x="637.5" y="214.5" width="284" height="261" fill="white"/>
+        <rect x="637.5" y="214.5" width="284" height="261" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(642.5 452.052)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="93.744" y="15">Base Kernel</tspan>
+        </text>
+      </g>
+      <g id="Graphic_5">
+        <rect x="660" y="236.5" width="237.5" height="88" fill="white"/>
+        <rect x="660" y="236.5" width="237.5" height="88" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(665 301.052)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="50.038" y="15">Another container</tspan>
+        </text>
+      </g>
+      <g id="Graphic_8">
+        <rect x="660" y="350" width="237.5" height="88" fill="white"/>
+        <rect x="660" y="350" width="237.5" height="88" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(665 414.552)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="25.574" y="15">Remote Docker Daemon</tspan>
+        </text>
+      </g>
+      <g id="Graphic_10">
+        <rect x="180" y="316.5" width="186.5" height="88" fill="white"/>
+        <rect x="180" y="316.5" width="186.5" height="88" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(185 381.052)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="20.37" y="15">Docker commands</tspan>
+        </text>
+      </g>
+      <g id="Line_11">
+        <path d="M 366.5 360.5 L 513.25 360.5 L 513.25 394 L 650.1 394" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Line_12">
+        <line x1="778.75" y1="350" x2="778.75" y2="334.4" marker-end="url(#FilledArrow_Marker)" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+      </g>
+      <g id="Graphic_13">
+        <text transform="translate(722.3906 531.5)" fill="black">
+          <tspan font-family="Courier" font-size="16" font-weight="400" fill="black" x="0" y="15">$DOCKER_HOST</tspan>
+        </text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/docker/CI/node.dockerfile
+++ b/docker/CI/node.dockerfile
@@ -1,0 +1,24 @@
+# Just to test markdown files
+# Deploy compiled binary
+FROM alpine
+
+# Expose ports for HTTP and BTP
+# - 7770: HTTP - ILP over HTTP, API, BTP
+# - 7771: HTTP - settlement
+EXPOSE 7770
+EXPOSE 7771
+
+# Install SSL certs
+RUN apk --no-cache add ca-certificates
+
+# Copy Interledger binary
+COPY \
+    target/x86_64-unknown-linux-musl/debug/ilp-node \
+    /usr/local/bin/ilp-node
+
+WORKDIR /opt/app
+
+# ENV RUST_BACKTRACE=1
+ENV RUST_LOG=interledger=debug
+
+ENTRYPOINT [ "/usr/local/bin/ilp-node" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,7 @@ FROM clux/muslrust:stable as rust
 
 WORKDIR /usr/src/interledger-rs
 COPY ./Cargo.toml /usr/src/interledger-rs/Cargo.toml
+COPY ./Cargo.lock /usr/src/interledger-rs/Cargo.lock
 COPY ./crates /usr/src/interledger-rs/crates
 
 # TODO: investigate using a method like https://whitfin.io/speeding-up-rust-docker-builds/

--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# intended to be run in the top directory
+
+build_targets=()
+
+if [ "$PROFILE" = "release" ]; then
+    printf "\e[32;1mBuilding profile: release\e[m\n"
+    CARGO_BUILD_OPTION=--release
+    RUST_BIN_DIR_NAME=release
+else
+    printf "\e[32;1mBuilding profile: dev\e[m\n"
+    CARGO_BUILD_OPTION=
+    RUST_BIN_DIR_NAME=debug
+fi
+
+if [ $# -eq 0 ]; then
+    printf "\e[33mNo build target is given, building all targets.\e[m\n"
+    build_targets+=(ilp-cli)
+    build_targets+=(node)
+    build_targets+=(testnet-bundle)
+    build_targets+=(circleci-rust-dind)
+fi
+
+# if arguments are given, add it as build targets
+build_targets+=($@)
+
+for build_target in "${build_targets[@]}"; do
+    case $build_target in
+        "ilp-cli") docker build -f ./docker/ilp-cli.dockerfile -t interledgerrs/ilp-cli:latest . ;;
+        "node") docker build -f ./docker/node.dockerfile -t interledgerrs/node:latest \
+                --build-arg CARGO_BUILD_OPTION="${CARGO_BUILD_OPTION}" \
+                --build-arg RUST_BIN_DIR_NAME="${RUST_BIN_DIR_NAME}" \
+                . ;;
+        "testnet-bundle") docker build -f ./docker/Dockerfile -t interledgerrs/testnet-bundle:latest . ;;
+        "circleci-rust-dind") docker build -f ./docker/CI/circleci-rust-dind.dockerfile -t interledgerrs/circleci-rust-dind:latest . ;;
+        "ci-node") docker build -f ./docker/CI/node.dockerfile -t interledgerrs/node:latest . ;;
+        "ci-ilp-cli") docker build -f ./docker/CI/ilp-cli.dockerfile -t interledgerrs/ilp-cli:latest . ;;
+    esac
+done

--- a/docker/node.dockerfile
+++ b/docker/node.dockerfile
@@ -1,18 +1,24 @@
 # Build Interledger node into standalone binary
 FROM clux/muslrust:stable as rust
+ARG CARGO_BUILD_OPTION=""
+ARG RUST_BIN_DIR_NAME="debug"
+
+RUN echo "Building profile: ${CARGO_BUILD_OPTION}, output dir: ${RUST_BIN_DIR_NAME}"
 
 WORKDIR /usr/src
 COPY ./Cargo.toml /usr/src/Cargo.toml
+COPY ./Cargo.lock /usr/src/Cargo.lock
 COPY ./crates /usr/src/crates
 
-RUN cargo build --release --package ilp-node
-# RUN cargo build --package ilp-node
+RUN cargo build ${CARGO_BUILD_OPTION} --package ilp-node --bin ilp-node
 
 # Deploy compiled binary to another container
 FROM alpine
+ARG CARGO_BUILD_OPTION=""
+ARG RUST_BIN_DIR_NAME="debug"
 
 # Expose ports for HTTP and BTP
-# - 7770: HTTP - ILP over HTTP, API
+# - 7770: HTTP - ILP over HTTP, API, BTP
 # - 7771: HTTP - settlement
 EXPOSE 7770
 EXPOSE 7771
@@ -22,11 +28,8 @@ RUN apk --no-cache add ca-certificates
 
 # Copy Interledger binary
 COPY --from=rust \
-    /usr/src/target/x86_64-unknown-linux-musl/release/ilp-node \
+    /usr/src/target/x86_64-unknown-linux-musl/${RUST_BIN_DIR_NAME}/ilp-node \
     /usr/local/bin/ilp-node
-# COPY --from=rust \
-#     /usr/src/target/x86_64-unknown-linux-musl/debug/ilp-node \
-#     /usr/local/bin/ilp-node
 
 WORKDIR /opt/app
 

--- a/examples/eth-xrp-three-nodes/README.md
+++ b/examples/eth-xrp-three-nodes/README.md
@@ -1,3 +1,63 @@
+<!--!
+# For integration tests
+function pre_test_hook() {
+    if [ $TEST_MODE -eq 1 ] && [ "${CIRCLECI}" = "true" ] && [ "${USE_DOCKER}" = "1" ]; then
+        # Make tunnels to DOCKER_HOST containers if run on CircleCI.
+        # This is because the docker is not running on the CI container and
+        # we have to connect the following two:
+        #   - 127.0.0.1:xxxx (on CI container)
+        #   - 127.0.0.1:xxxx (on DOCKER_HOST's container:xxxx)
+        # so that we could `curl localhost:xxxx` to connect to DOCKER_HOST's containers.
+        printf "Setting tunnels..."
+        # node
+        ncat -l -k -c "docker exec -i interledger-rs-node_a nc 127.0.0.1 7770" -p 7770 &
+        ncat -l -k -c "docker exec -i interledger-rs-node_b nc 127.0.0.1 7770" -p 8770 &
+        ncat -l -k -c "docker exec -i interledger-rs-node_c nc 127.0.0.1 7770" -p 9770 &
+        # se
+        ncat -l -k -c "docker exec -i interledger-rs-se_a nc 127.0.0.1 3000" -p 3000 &
+        ncat -l -k -c "docker exec -i interledger-rs-se_b nc 127.0.0.1 3000" -p 3001 &
+        ncat -l -k -c "docker exec -i interledger-rs-se_c nc 127.0.0.1 3000" -p 3002 &
+        ncat -l -k -c "docker exec -i interledger-rs-se_d nc 127.0.0.1 3000" -p 3003 &
+        printf "done\n"
+    fi
+    if [ $TEST_MODE -eq 1 ] && [ ${USE_DOCKER} -eq 1 ]; then
+        trap 'output_docker_logs; exit;' 0
+    fi
+}
+
+function post_test_hook() {
+    if [ $TEST_MODE -eq 1 ]; then
+        test_equals_or_exit '{"balance":-500}' test_http_response_body -H "Authorization: Bearer hi_alice" http://localhost:7770/accounts/alice/balance
+        test_equals_or_exit '{"balance":0}' test_http_response_body -H "Authorization: Bearer hi_alice" http://localhost:7770/accounts/bob/balance
+        test_equals_or_exit '{"balance":0}' test_http_response_body -H "Authorization: Bearer hi_bob" http://localhost:8770/accounts/alice/balance
+        test_equals_or_exit '{"balance":0}' test_http_response_body -H "Authorization: Bearer hi_bob" http://localhost:8770/accounts/charlie/balance
+        test_equals_or_exit '{"balance":0}' test_http_response_body -H "Authorization: Bearer hi_charlie" http://localhost:9770/accounts/bob/balance
+        test_equals_or_exit '{"balance":500}' test_http_response_body -H "Authorization: Bearer hi_charlie" http://localhost:9770/accounts/charlie/balance
+    fi
+}
+
+function output_docker_logs() {
+    printf "\e[33m%s\e[m" "Writing docker logs..." 1>&2
+    mkdir -p logs
+    docker logs interledger-rs-node_a &> logs/interledger-rs-node_a.log
+    docker logs interledger-rs-node_b &> logs/interledger-rs-node_b.log
+    docker logs interledger-rs-node_c &> logs/interledger-rs-node_c.log
+    docker logs interledger-rs-se_a &> logs/interledger-rs-se_a.log
+    docker logs interledger-rs-se_b &> logs/interledger-rs-se_b.log
+    docker logs interledger-rs-se_c &> logs/interledger-rs-se_c.log
+    docker logs interledger-rs-se_d &> logs/interledger-rs-se_d.log
+    docker logs ganache &> logs/ganache.log
+    docker logs redis-alice_node &> logs/redis-alice_node.log
+    docker logs redis-alice_se_eth &> logs/redis-alice_se_eth.log
+    docker logs redis-bob_node &> logs/redis-bob_node.log
+    docker logs redis-bob_se_eth &> logs/redis-bob_se_eth.log
+    docker logs redis-bob_se_xrp &> logs/redis-bob_se_xrp.log
+    docker logs redis-charlie_node &> logs/redis-charlie_node.log
+    docker logs redis-charlie_se_xrp &> logs/redis-charlie_se_xrp.log
+    printf "\e[33m%s\e[m\n" "done" 1>&2
+}
+-->
+
 # Interledger with Ethereum and XRP On-Ledger Settlement
 
 > A demo that sends payments between 3 Interledger.rs nodes and settles using Ethereum transactions and XRP transactions.
@@ -129,6 +189,8 @@ else
         fi
     done
 fi
+
+run_pre_test_hook
 -->
 
 ### 1. Build interledger.rs
@@ -157,8 +219,9 @@ fi
 ### 2. Launch Redis
 
 <!--!
-printf "\nStarting Redis...\n"
+printf "\nStarting Redis instances..."
 if [ "$USE_DOCKER" -eq 1 ]; then
+    printf "\n"
     $CMD_DOCKER run --name redis-alice_node -d -p 127.0.0.1:6379:6379 --network=interledger redis:5.0.5
     $CMD_DOCKER run --name redis-alice_se_eth -d -p 127.0.0.1:6380:6379 --network=interledger redis:5.0.5
     $CMD_DOCKER run --name redis-bob_node -d -p 127.0.0.1:6381:6379 --network=interledger redis:5.0.5
@@ -184,12 +247,16 @@ redis-server --port 6384 &> logs/redis-c-node.log &
 redis-server --port 6385 &> logs/redis-c-se-xrp.log &
 ```
 
-<!--!
-sleep 1
--->
-
 To remove all the data in Redis, you might additionally perform:
 
+<!--!
+fi
+
+sleep 2
+printf "done\n"
+
+if [ "$USE_DOCKER" -eq 0 ]; then
+-->
 ```bash
 for port in `seq 6379 6385`; do
     redis-cli -p $port flushall
@@ -247,7 +314,7 @@ In this example, we'll connect 3 Interledger nodes and each node needs its own s
 
 By default, the XRP settlement engine generates new testnet XRPL accounts prefunded with 1,000 testnet XRP (a new account is generated each run). Alternatively, you may supply an `XRP_SECRET` environment variable by generating your own testnet credentials from the [official faucet](https://xrpl.org/xrp-test-net-faucet.html).
 
-The engines are part of a [separate repository](https://github.com/interledger-rs/settlement-engines) so you have to clone and install them according to [the instructions in settlement-engine](https://github.com/interledger-rs/settlement-engines/blob/master/README.md). In case you've never cloned `settlement-engine`, the first step would be to clone the repository.
+The engines are part of a [separate repository](https://github.com/interledger-rs/settlement-engines) so you have to clone and install them according to [the instructions in `settlement-engines`](https://github.com/interledger-rs/settlement-engines/blob/master/README.md). In case you've never cloned `settlement-engines`, the first step would be to clone the repository.
 
 <!--!
 printf "\nStarting settlement engines...\n"
@@ -314,7 +381,7 @@ else
 -->
 
 ```bash #
-# This should be done outside of the interledger-rs directory, otherwise it will cause an error
+# This should be done outside of the interledger-rs directory, otherwise it will cause an error.
 git clone https://github.com/interledger-rs/settlement-engines
 cd settlement-engines
 ```
@@ -463,10 +530,10 @@ printf "\nWaiting for nodes to start up"
 wait_to_serve "http://localhost:7770" 10 || error_and_exit "\nFailed to spin up nodes. Check out your configuration and log files."
 wait_to_serve "http://localhost:8770" 10 || error_and_exit "\nFailed to spin up nodes. Check out your configuration and log files."
 wait_to_serve "http://localhost:9770" 10 || error_and_exit "\nFailed to spin up nodes. Check out your configuration and log files."
-wait_to_serve "http://localhost:3000" 10 || error_and_exit "\nFailed to spin up nodes. Check out your configuration and log files."
-wait_to_serve "http://localhost:3001" 10 || error_and_exit "\nFailed to spin up nodes. Check out your configuration and log files."
-wait_to_serve "http://localhost:3002" 10 || error_and_exit "\nFailed to spin up nodes. Check out your configuration and log files."
-wait_to_serve "http://localhost:3003" 10 || error_and_exit "\nFailed to spin up nodes. Check out your configuration and log files."
+wait_to_serve "http://localhost:3000" 10 || error_and_exit "\nFailed to spin up settlement engine. Check out your configuration and log files."
+wait_to_serve "http://localhost:3001" 10 || error_and_exit "\nFailed to spin up settlement engine. Check out your configuration and log files."
+wait_to_serve "http://localhost:3002" 10 || error_and_exit "\nFailed to spin up settlement engine. Check out your configuration and log files."
+wait_to_serve "http://localhost:3003" 10 || error_and_exit "\nFailed to spin up settlement engine. Check out your configuration and log files."
 
 printf "done\nThe Interledger.rs nodes are up and running!\n\n"
 -->
@@ -567,7 +634,11 @@ if [ "$USE_DOCKER" -eq 1 ]; then
         "settle_to" : 0,
         "routing_relation": "Child"}' \
         http://localhost:8770/accounts > logs/account-bob-charlie.log 2>/dev/null &
-
+    
+    # We have to wait here to ensure that the parent account is created because
+    # the child account tries to acquire its ILP address from the parent account.
+    sleep 2
+    
     printf "Adding Bob's account on Charlie's node (XRP Parent relation)...\n"
     curl \
         -H "Content-Type: application/json" \
@@ -685,6 +756,10 @@ curl \
     "routing_relation": "Child"}' \
     http://localhost:8770/accounts > logs/account-bob-charlie.log 2>/dev/null &
 
+# We have to wait here to ensure that the parent account is created because
+# the child account tries to acquire its ILP address from the parent account.
+sleep 2
+
 printf "Adding Bob's account on Charlie's node (XRP Parent relation)...\n"
 curl \
     -H "Content-Type: application/json" \
@@ -796,11 +871,11 @@ printf "\n"
 
 # wait untill the settlement is done
 printf "\nWaiting for Ethereum block to be mined"
-wait_to_get_http_response_body '{"balance":"0"}' 10 -H "Authorization: Bearer hi_bob" "http://localhost:8770/accounts/alice/balance"
+wait_to_get_http_response_body '{"balance":0}' 10 -H "Authorization: Bearer hi_bob" "http://localhost:8770/accounts/alice/balance" || error_and_exit "Could not confirm settlement."
 printf "done\n"
 
 printf "Waiting for XRP ledger to be validated"
-wait_to_get_http_response_body '{"balance":"0"}' 10 -H "Authorization: Bearer hi_charlie" "http://localhost:9770/accounts/bob/balance"
+wait_to_get_http_response_body '{"balance":0}' 20 -H "Authorization: Bearer hi_charlie" "http://localhost:9770/accounts/bob/balance" || error_and_exit "Could not confirm settlement."
 printf "done\n"
 -->
 
@@ -971,9 +1046,9 @@ else
     printf "\tcat logs/node-charlie-settlement-engine-xrpl.log | grep \"Received incoming XRP payment\"\n"
 fi
 printf "\n"
-run_hook_before_kill
+run_post_test_hook
 if [ $TEST_MODE -ne 1 ]; then
-    prompt_yn "Do you want to kill the services? [Y/n]" "y"
+    prompt_yn "Do you want to kill the services? [Y/n] " "y"
 fi
 printf "\n"
 if [ "$PROMPT_ANSWER" = "y" ] || [ $TEST_MODE -eq 1 ] ; then
@@ -1059,17 +1134,3 @@ You might have run another example. Stop them first and try again. How to stop t
 This example showed an SPSP payment sent between three Interledger.rs nodes that settled using on-ledger Ethereum and XRPL transactions.
 
 More examples that enhance your integration with ILP are coming soon!
-
-<!--!
-# For integration tests
-function hook_before_kill() {
-    if [ $TEST_MODE -eq 1 ]; then
-        test_equals_or_exit '{"balance":"-500"}' test_http_response_body -H "Authorization: Bearer hi_alice" http://localhost:7770/accounts/alice/balance
-        test_equals_or_exit '{"balance":"0"}' test_http_response_body -H "Authorization: Bearer hi_alice" http://localhost:7770/accounts/bob/balance
-        test_equals_or_exit '{"balance":"0"}' test_http_response_body -H "Authorization: Bearer hi_bob" http://localhost:8770/accounts/alice/balance
-        test_equals_or_exit '{"balance":"0"}' test_http_response_body -H "Authorization: Bearer hi_bob" http://localhost:8770/accounts/charlie/balance
-        test_equals_or_exit '{"balance":"0"}' test_http_response_body -H "Authorization: Bearer hi_charlie" http://localhost:9770/accounts/bob/balance
-        test_equals_or_exit '{"balance":"500"}' test_http_response_body -H "Authorization: Bearer hi_charlie" http://localhost:9770/accounts/charlie/balance
-    fi
-}
--->

--- a/examples/xrp-settlement/README.md
+++ b/examples/xrp-settlement/README.md
@@ -1,3 +1,51 @@
+<!--!
+# For integration tests
+function pre_test_hook() {
+    if [ $TEST_MODE -eq 1 ] && [ "${CIRCLECI}" = "true" ] && [ "${USE_DOCKER}" = "1" ]; then
+        # Make tunnels to DOCKER_HOST containers if run on CircleCI.
+        # This is because the docker is not running on the CI container and
+        # we have to connect the following two:
+        #   - 127.0.0.1:xxxx (on CI container)
+        #   - 127.0.0.1:xxxx (on DOCKER_HOST's container:xxxx)
+        # so that we could `curl localhost:xxxx` to connect to DOCKER_HOST's containers.
+        printf "Setting tunnels..."
+        # node
+        ncat -l -k -c "docker exec -i interledger-rs-node_a nc 127.0.0.1 7770" -p 7770 &
+        ncat -l -k -c "docker exec -i interledger-rs-node_b nc 127.0.0.1 7770" -p 8770 &
+        # se
+        ncat -l -k -c "docker exec -i interledger-rs-se_a nc 127.0.0.1 3000" -p 3000 &
+        ncat -l -k -c "docker exec -i interledger-rs-se_b nc 127.0.0.1 3000" -p 3001 &
+        printf "done\n"
+    fi
+    if [ $TEST_MODE -eq 1 ] && [ ${USE_DOCKER} -eq 1 ]; then
+        trap 'output_docker_logs; exit;' 0
+    fi
+}
+
+function post_test_hook() {
+    if [ $TEST_MODE -eq 1 ]; then
+        test_equals_or_exit '{"balance":-500}' test_http_response_body -H "Authorization: Bearer alice:in_alice" http://localhost:7770/accounts/alice/balance
+        test_equals_or_exit '{"balance":0}' test_http_response_body -H "Authorization: Bearer bob:bob_password" http://localhost:7770/accounts/bob/balance
+        test_equals_or_exit '{"balance":0}' test_http_response_body -H "Authorization: Bearer alice:alice_password" http://localhost:8770/accounts/alice/balance
+        test_equals_or_exit '{"balance":500}' test_http_response_body -H "Authorization: Bearer bob:in_bob" http://localhost:8770/accounts/bob/balance
+    fi
+}
+
+function output_docker_logs() {
+    printf "\e[33m%s\e[m" "Writing docker logs..." 1>&2
+    mkdir -p logs
+    docker logs interledger-rs-node_a &> logs/interledger-rs-node_a.log
+    docker logs interledger-rs-node_b &> logs/interledger-rs-node_b.log
+    docker logs interledger-rs-se_a &> logs/interledger-rs-se_a.log
+    docker logs interledger-rs-se_b &> logs/interledger-rs-se_b.log
+    docker logs redis-alice_node &> logs/redis-alice_node.log
+    docker logs redis-alice_se &> logs/redis-alice_se.log
+    docker logs redis-bob_node &> logs/redis-bob_node.log
+    docker logs redis-bob_se &> logs/redis-bob_se.log
+    printf "\e[33m%s\e[m\n" "done" 1>&2
+}
+-->
+
 # Interledger with XRP On-Ledger Settlement
 
 > A demo that sends payments between 2 Interledger.rs nodes and settles using XRP transactions.
@@ -24,7 +72,7 @@ Interledger.rs and settlement engines written in other languages are fully inter
 
 Install the settlement engine as follows:
 
-```bash
+```bash #
 npm i -g ilp-settlement-xrp
 ```
 
@@ -107,11 +155,12 @@ else
     done
 fi
 
+run_pre_test_hook
+
 # Aliases don't play nicely with scripts, so this is our faux-alias
 function ilp-cli {
     cargo run --quiet --bin ilp-cli -- $@
 }
-
 -->
 
 ### 1. Build interledger.rs
@@ -140,8 +189,9 @@ fi
 ### 2. Launch Redis
 
 <!--!
-printf "\n\nStarting Redis instances...\n\n"
+printf "\nStarting Redis instances..."
 if [ "$USE_DOCKER" -eq 1 ]; then
+    printf "\n"
     $CMD_DOCKER run --name redis-alice_node -d -p 127.0.0.1:6379:6379 --network=interledger redis:5.0.5
     $CMD_DOCKER run --name redis-alice_se -d -p 127.0.0.1:6380:6379 --network=interledger redis:5.0.5
     $CMD_DOCKER run --name redis-bob_node -d -p 127.0.0.1:6381:6379 --network=interledger redis:5.0.5
@@ -161,12 +211,16 @@ redis-server --port 6381 &> logs/redis-b-node.log &
 redis-server --port 6382 &> logs/redis-b-se.log &
 ```
 
-<!--!
-sleep 1
--->
-
 To remove all the data in Redis, you might additionally perform:
 
+<!--!
+fi
+
+sleep 2
+printf "done\n"
+
+if [ "$USE_DOCKER" -eq 0 ]; then
+-->
 ```bash
 for port in `seq 6379 6382`; do
     redis-cli -p $port flushall
@@ -299,8 +353,8 @@ printf "\nWaiting for Interledger.rs nodes to start up"
 
 wait_to_serve "http://localhost:7770" 10 || error_and_exit "\nFailed to spin up nodes. Check out your configuration and log files."
 wait_to_serve "http://localhost:8770" 10 || error_and_exit "\nFailed to spin up nodes. Check out your configuration and log files."
-wait_to_serve "http://localhost:3000" 10 || error_and_exit "\nFailed to spin up nodes. Check out your configuration and log files."
-wait_to_serve "http://localhost:3001" 10 || error_and_exit "\nFailed to spin up nodes. Check out your configuration and log files."
+wait_to_serve "http://localhost:3000" 10 || error_and_exit "\nFailed to spin up settlement engine. Check out your configuration and log files."
+wait_to_serve "http://localhost:3001" 10 || error_and_exit "\nFailed to spin up settlement engine. Check out your configuration and log files."
 
 printf " done\nThe Interledger.rs nodes are up and running!\n\n"
 -->
@@ -310,7 +364,7 @@ printf " done\nThe Interledger.rs nodes are up and running!\n\n"
 <!--!
 printf "Creating accounts:\n"
 if [ "$USE_DOCKER" -eq 1 ]; then
-    # Adding settlement accounts should be done at the same time because it checks each other
+    export ILP_CLI_API_AUTH=hi_alice
 
     printf "Adding Alice's account...\n"
     curl \
@@ -389,10 +443,7 @@ else
 ```bash
 # This alias makes our CLI invocations more natural
 alias ilp-cli="cargo run --quiet --bin ilp-cli --"
-
 export ILP_CLI_API_AUTH=hi_alice
-
-# Adding settlement accounts should be done at the same time because it checks each other
 
 printf "Adding Alice's account...\n"
 ilp-cli accounts create alice \
@@ -467,13 +518,13 @@ printf "\n\nChecking balances prior to payment...\n"
 printf "\nAlice's balance on Alice's node: "
 ilp-cli accounts balance alice
 
-printf "\nBob's balance on Alice's node: "
+printf "Bob's balance on Alice's node: "
 ilp-cli accounts balance bob
 
-printf "\nAlice's balance on Bob's node: "
+printf "Alice's balance on Bob's node: "
 ilp-cli --node http://localhost:8770 accounts balance alice --auth hi_bob 
 
-printf "\nBob's balance on Bob's node: "
+printf "Bob's balance on Bob's node: "
 ilp-cli --node http://localhost:8770 accounts balance bob --auth hi_bob 
 
 printf "\n\n"
@@ -507,7 +558,7 @@ printf "\n"
 
 # wait untill the settlement is done
 printf "\nWaiting for XRP ledger to be validated"
-wait_to_get_http_response_body '{"balance":"0"}' 10 -H "Authorization: Bearer alice:alice_password" "http://localhost:8770/accounts/alice/balance"
+wait_to_get_http_response_body '{"balance":0}' 20 -H "Authorization: Bearer alice:alice_password" "http://localhost:8770/accounts/alice/balance" || error_and_exit "Could not confirm settlement."
 printf "done\n"
 -->
 
@@ -521,13 +572,13 @@ printf "Checking balances after payment...\n"
 printf "\nAlice's balance on Alice's node: "
 ilp-cli accounts balance alice
 
-printf "\nBob's balance on Alice's node: "
+printf "Bob's balance on Alice's node: "
 ilp-cli accounts balance bob
 
-printf "\nAlice's balance on Bob's node: "
+printf "Alice's balance on Bob's node: "
 ilp-cli --node http://localhost:8770 accounts balance alice --auth hi_bob 
 
-printf "\nBob's balance on Bob's node: "
+printf "Bob's balance on Bob's node: "
 ilp-cli --node http://localhost:8770 accounts balance bob --auth hi_bob 
 ```
 
@@ -592,7 +643,7 @@ else
     printf "\tcat logs/node-bob-settlement-engine.log | grep \"Received incoming XRP payment\"\n"
 fi
 printf "\n"
-run_hook_before_kill
+run_post_test_hook
 if [ $TEST_MODE -ne 1 ]; then
     prompt_yn "Do you want to kill the services? [Y/n] " "y"
 fi
@@ -651,15 +702,3 @@ You might have run another example. Stop them first and try again. How to stop t
 This example showed an SPSP payment sent between two Interledger.rs nodes that settled using on-ledger XRP transactions.
 
 Check out the [other examples](../README.md) for more complex demos that show other features of Interledger, including multi-hop routing and cross-currency payments.
-
-<!--!
-# For integration tests
-function hook_before_kill() {
-    if [ $TEST_MODE -eq 1 ]; then
-        test_equals_or_exit '{"balance":"-500"}' test_http_response_body -H "Authorization: Bearer alice:in_alice" http://localhost:7770/accounts/alice/balance
-        test_equals_or_exit '{"balance":"0"}' test_http_response_body -H "Authorization: Bearer bob:bob_password" http://localhost:7770/accounts/bob/balance
-        test_equals_or_exit '{"balance":"0"}' test_http_response_body -H "Authorization: Bearer alice:alice_password" http://localhost:8770/accounts/alice/balance
-        test_equals_or_exit '{"balance":"500"}' test_http_response_body -H "Authorization: Bearer bob:in_bob" http://localhost:8770/accounts/bob/balance
-    fi
-}
--->

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# intended to be run in the top directory
-docker build -f ./docker/node.dockerfile -t interledgerrs/node:latest .
-docker build -f ./docker/eth-se.dockerfile -t interledgerrs/settlement-engine:latest .
-docker build -f ./docker/Dockerfile -t interledgerrs/testnet-bundle:latest .
-docker build -f ./docker/ilp-cli.dockerfile -t interledgerrs/ilp-cli:latest .

--- a/scripts/run-md-lib.sh
+++ b/scripts/run-md-lib.sh
@@ -27,12 +27,21 @@ function init() {
     fi
 }
 
-# run hook_before_kill function only if it exists
-function run_hook_before_kill {
+# run pre_test_hook function only if it exists
+function run_pre_test_hook {
     # only when the hook is defined
-    type hook_before_kill &>/dev/null
+    type pre_test_hook &>/dev/null
     if [ $? -eq 0 ]; then
-        hook_before_kill
+        pre_test_hook
+    fi
+}
+
+# run post_test_hook function only if it exists
+function run_post_test_hook {
+    # only when the hook is defined
+    type post_test_hook &>/dev/null
+    if [ $? -eq 0 ]; then
+        post_test_hook
     fi
 }
 
@@ -56,7 +65,6 @@ function wait_to_serve() {
     while :
     do
         printf "."
-        sleep 1
         curl $1 &> /dev/null
         if [ $? -eq 0 ]; then
             break
@@ -64,6 +72,7 @@ function wait_to_serve() {
         if [ $timeout -ge 0 ] && [ $(($SECONDS - $start)) -ge $timeout ]; then
           return 1
         fi
+        sleep 1
     done
     return 0
 }
@@ -81,7 +90,6 @@ function wait_to_get_http_response_body() {
     while :
     do
         printf "."
-        sleep 1
         local json=$(curl "$@" 2> /dev/null)
         if [ "$json" = "$expected" ]; then
             break
@@ -89,6 +97,7 @@ function wait_to_get_http_response_body() {
         if [ $timeout -ge 0 ] && [ $(($SECONDS - $start)) -ge $timeout ]; then
           return 1
         fi
+        sleep 1
     done
     return 0
 }

--- a/scripts/run-md-test.sh
+++ b/scripts/run-md-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-function init_test() {
+function clear_environment() {
     clear_logs
     clear_docker
     free_ports
@@ -12,9 +12,9 @@ function clear_logs() {
 }
 
 function clear_docker() {
-    docker network rm interledger 2>/dev/null
     docker stop $(docker ps -aq) 2>/dev/null
     docker rm $(docker ps -aq) 2>/dev/null
+    docker network rm interledger 2>/dev/null
 }
 
 function free_ports() {
@@ -22,6 +22,13 @@ function free_ports() {
     for port in $(seq 6379 6385); do
         if lsof -Pi :${port} -sTCP:LISTEN -t >/dev/null ; then
             redis-cli -p ${port} shutdown
+        fi
+    done
+
+    # ports of redis
+    for port in $(seq 6379 6385); do
+        if lsof -tPi :${port} >/dev/null ; then
+            kill `lsof -tPi :${port}`
         fi
     done
 
@@ -42,54 +49,88 @@ function clear_redis_file() {
 
 # $1 = target directory
 # $2 = docker mode in [01]
+# $3 = test name filter
 #
 # test_example examples/eth-settlement 0
 function test_example() {
     local target_directory=$1
     local docker_mode=$2
+    local test_name_filter=$3
     local target_name=$(basename $target_directory)
+    local result
 
-    cd $target_directory
+    pushd $target_directory > /dev/null
     if [ $docker_mode -eq 1 ]; then
-        printf "\e[33;1m%b [%d/%d]\e[m\n" "Testing \"${target_name}\" on docker mode." "$((TESTING_INDEX + 1))" "${TESTS_TOTAL}"
-        init_test; USE_DOCKER=1 $RUN_MD .
-        return $?
+        printf "\e[33;1mTesting \"${target_name}\" on docker mode. [%d/%d]\e[m\n" "$((TESTING_INDEX + 1))" "${TESTS_TOTAL}"
+        clear_environment; TEST_MODE=1 USE_DOCKER=1 $RUN_MD .
+        result=$?
     else
-        printf "\e[33;1m%b [%d/%d]\e[m\n" "Testing \"${target_name}\" on non-docker mode." "$((TESTING_INDEX + 1))" "${TESTS_TOTAL}"
-        init_test; $RUN_MD .
-        return $?
+        printf "\e[33;1mTesting \"${target_name}\" on non-docker mode. [%d/%d]\e[m\n" "$((TESTING_INDEX + 1))" "${TESTS_TOTAL}"
+        clear_environment; TEST_MODE=1 $RUN_MD .
+        result=$?
     fi
+    mkdir -p ${LOG_DIR}/${target_name}
+    mv logs ${LOG_DIR}/${target_name}/${docker_mode}
+    # there may not be logs when testing non-settlement ones
+    mv ${SETTLEMENT_ENGINE_DIR}/logs/* ${LOG_DIR}/${target_name}/${docker_mode}/ &>/dev/null
+    popd > /dev/null
+    return $result
 }
 
 # Adds all directories in `examples` directory as test targets.
 function add_example_tests() {
-    # This will add tests like "test_example eth-settlement 0" which means an example test of
+    local test_name_filter=$1
+    local docker_mode_filter=$2
+
+    # This will add tests like "test_example examples/eth-settlement 0" which means an example test of
     # eth-settlement in non-docker mode.
-    for directory in $(find $BASE_DIR/../examples/* -type d -maxdepth 0); do
-        TESTS+=("test_example ${directory} 0") # this cannot contain space in the directory path
-        TESTS+=("test_example ${directory} 1")
+    for directory in $(find $BASE_DIR/../examples/* -maxdepth 0 -type d); do
+        if [ -n "${test_name_filter}" ] && [[ ! "${directory}" =~ ${test_name_filter} ]]; then
+            printf "\e[33;1mSkipping \"%s\"\e[m\n" "${directory}"
+            continue
+        fi
+        if [ -n "${docker_mode_filter}" ]; then
+            printf "\e[33;1mAdding only USE_DOCKER=%d for \"%s\"\e[m\n" "${docker_mode_filter}" "${directory}"
+            TESTS+=("test_example ${directory} ${docker_mode_filter} ${test_name_filter}")
+        else
+            TESTS+=("test_example ${directory} 0 ${test_name_filter}") # this cannot contain space in the directory path
+            TESTS+=("test_example ${directory} 1 ${test_name_filter}")
+        fi
     done
 }
 
+# $1 = test name filter
+# $2 = docker mode filter
+
 BASE_DIR=$(cd $(dirname $0); pwd)
 RUN_MD=$BASE_DIR/run-md.sh
+LOG_DIR=/tmp/run-md-test/logs
+export SETTLEMENT_ENGINE_INSTALLL_DIR=$(cd ~; pwd)
+SETTLEMENT_ENGINE_DIR=${SETTLEMENT_ENGINE_INSTALLL_DIR}/settlement-engines
 
+# set up example tests
 TESTS=()
-add_example_tests
+add_example_tests $@
+
+# set up log dir for CircleCI
+# the log files will be put as artifacts
+rm -rf $LOG_DIR
+mkdir -p $LOG_DIR
+
 TESTS_TOTAL=${#TESTS[@]}
 TESTS_FAILED=0
 TESTING_INDEX=0
 for test in "${TESTS[@]}"; do
-    TEST_MODE=1 $test
+    $test
     if [ $? -ne 0 ]; then
         TESTS_FAILED=$((TESTS_FAILED + 1))
     fi
     TESTING_INDEX=$((TESTING_INDEX + 1))
 done
 if [ $TESTS_FAILED -eq 0 ]; then
-    printf "\e[32;1m%b [%d/%d]\e[m\n" "All tests passed!" "${TESTS_TOTAL}" "${TESTS_TOTAL}"
+    printf "\e[32;1mAll tests passed! [%d/%d]\e[m\n" $((TESTS_TOTAL - TESTS_FAILED)) "${TESTS_TOTAL}"
     exit 0
 else
-    printf "\e[31;1m%b [%d/%d]\e[m\n" "Some tests failed." "${TESTS_FAILED}" "${TESTS_TOTAL}"
+    printf "\e[31;1mSome tests failed. [%d/%d]\e[m\n" $((TESTS_TOTAL - TESTS_FAILED)) "${TESTS_TOTAL}"
     exit 1
 fi


### PR DESCRIPTION
[Separated PR](https://github.com/interledger-rs/interledger-rs/pull/305#pullrequestreview-310992490) of #305 "Enables `run-md-test.sh` on CircleCI". The following PRs should be merged at once, because latter PRs optimize some of former PRs (e.g. cache).

- #492 ci(circleci): enables run-md-test.sh on CircleCI
- #493 feat(examples): fixed to use CLI arguments instead of ENV vars, etc
- #494 feat(.circleci): tag docker images
- #495 ci(ci): publish binaries when tags are pushed

Note that some of these will be simplified when examples start using binaries. Some of docker images will be removed, examples get simpler.

<details><summary>My opinions</summary>

- Why do we need `circleci-rust-dind.dockerfile`?
    - It is because
        1. Installing dependencies every time doesn't make sense
        1. there aren't any Docker images that contain Rust, musl with SSL support and Docker commands.
- Why are there so many changes?
    - It is because we are
        1. Testing markdowns
        1. Building Docker images, tag it and publish it
        1. Building binaries
        1. Auto-releasing the artifacts
    - and we definitely should do CI/CI. We should not do these manually because people forget to test markdowns, which makes always examples broken and forget to publish Docker images and binaries. That is also cumbersome. Why don't we just automate it?

</details>