### PR TITLE
feat(examples): fixed to use CLI arguments instead of ENV vars, etc

### DIFF
--- a/docker/CI/README.md
+++ b/docker/CI/README.md
@@ -18,7 +18,7 @@ In order to build new docker images, we build the source code once like `cargo b
 
 The docker images `node.dockerfile` and `ilp-cli.dockerfile` contain platform-agnostic (although it is not completely agnostic) binaries which means it does not rely on dynamic libraries and uses `musl` instead. So we have to provide `musl` environment for `Cargo`. That is why `circleci-rust-dind.dockerfile` contains `musl`.
 
-Also why `circleci-rust-dind.dockerfile` is an independent image is that there isn't any suitable image which contains `Cargo`, `musl` and `dind` (docker in docker). `dind` is required to test the Docker mode because `run-md.sh` runs docker commands such as `docker run`. It requires docker commands inside the docker image. CircleCI spins up a Docker environment somewhere outer the container. So it would be called rater "docker command in container" than "docker in docker".
+Also why `circleci-rust-dind.dockerfile` is an independent image is that there isn't any suitable image which contains `Cargo`, `musl` and `dind` (docker in docker). `dind` is required to test the Docker mode because `run-md.sh` runs docker commands such as `docker run`. It requires docker commands inside the docker image. CircleCI spins up a Docker environment somewhere outside the container. So it would be called rater "docker command in container" than "docker in docker".
 
 ![docker commands in container](./images/dind.svg)
 

--- a/docker/CI/README.md
+++ b/docker/CI/README.md
@@ -18,7 +18,7 @@ In order to build new docker images, we build the source code once like `cargo b
 
 The docker images `node.dockerfile` and `ilp-cli.dockerfile` contain platform-agnostic (although it is not completely agnostic) binaries which means it does not rely on dynamic libraries and uses `musl` instead. So we have to provide `musl` environment for `Cargo`. That is why `circleci-rust-dind.dockerfile` contains `musl`.
 
-Also why `circleci-rust-dind.dockerfile` is an independent image is that there isn't any suitable image which contains `Cargo`, `musl` and `dind` (docker in docker). `dind` is required to test the Docker mode because `run-md.sh` runs docker commands such as `docker run`. It requires docker commands inside the docker image. CircleCI spins up a Docker environment somewhere outside the container. So it would be called rater "docker command in container" than "docker in docker".
+Currently, there exists no Docker image which contains `Cargo`, `musl` and `dind` together. `dind` is required to test Docker mode because `run-md.sh` runs the tests using Docker inside CircleCI (hence requiring us to use "docker in docker")
 
 ![docker commands in container](./images/dind.svg)
 

--- a/examples/eth-settlement/README.md
+++ b/examples/eth-settlement/README.md
@@ -254,7 +254,7 @@ sleep 3
 ### 4. Launch Settlement Engines
 Because each node needs its own settlement engine, we need to launch both a settlement engine for Alice's node and another settlement engine for Bob's node.
 
-The engines are part of a [separate repository](https://github.com/interledger-rs/settlement-engines) so you have to clone and install them according to [the instructions](https://github.com/interledger-rs/settlement-engines/blob/master/README.md). In case you've never cloned `settlement-engine`, clone it first.
+The engines are part of a [separate repository](https://github.com/interledger-rs/settlement-engines) so you have to clone and install them according to [the instructions in `settlement-engines`](https://github.com/interledger-rs/settlement-engines/blob/master/README.md). In case you've never cloned `settlement-engines`, the first step would be to clone the repository.
 
 <!--!
 printf "\nStarting settlement engines...\n"
@@ -297,7 +297,7 @@ else
 -->
 
 ```bash #
-# Do this somewhere OUTER the interledger-rs directory otherwise you'll get an error.
+# This should be done outside of the interledger-rs directory, otherwise it will cause an error.
 git clone https://github.com/interledger-rs/settlement-engines
 cd settlement-engines
 ```
@@ -333,7 +333,7 @@ cargo run --features "ethereum" -- ethereum-ledger \
 --settlement_api_bind_address 127.0.0.1:3001 \
 &> logs/node-bob-settlement-engine.log &
 
-# Now go back to interledger-rs directory.
+# Now go back to the `interledger-rs` directory.
 ```
 
 <!--!
@@ -349,54 +349,63 @@ printf "\nStarting nodes...\n"
 if [ "$USE_DOCKER" -eq 1 ]; then
     # Start Alice's node
     $CMD_DOCKER run \
-        -e ILP_ADDRESS=example.alice \
-        -e ILP_SECRET_SEED=8852500887504328225458511465394229327394647958135038836332350604 \
-        -e ILP_ADMIN_AUTH_TOKEN=hi_alice \
-        -e ILP_REDIS_URL=redis://redis-alice_node:6379/ \
-        -e ILP_HTTP_BIND_ADDRESS=0.0.0.0:7770 \
-        -e ILP_SETTLEMENT_API_BIND_ADDRESS=0.0.0.0:7771 \
         -p 127.0.0.1:7770:7770 \
         -p 127.0.0.1:7771:7771 \
         --network=interledger \
         --name=interledger-rs-node_a \
         -td \
-        interledgerrs/node
+        interledgerrs/node \
+        --ilp_address example.alice \
+        --secret_seed 8852500887504328225458511465394229327394647958135038836332350604 \
+        --admin_auth_token hi_alice \
+        --redis_url redis://redis-alice_node:6379/ \
+        --http_bind_address 0.0.0.0:7770 \
+        --settlement_api_bind_address 0.0.0.0:7771
     
     # Start Bob's node
     $CMD_DOCKER run \
-        -e ILP_ADDRESS=example.bob \
-        -e ILP_SECRET_SEED=1604966725982139900555208458637022875563691455429373719368053354 \
-        -e ILP_ADMIN_AUTH_TOKEN=hi_bob \
-        -e ILP_REDIS_URL=redis://redis-bob_node:6379/ \
-        -e ILP_HTTP_BIND_ADDRESS=0.0.0.0:7770 \
-        -e ILP_SETTLEMENT_API_BIND_ADDRESS=0.0.0.0:7771 \
         -p 127.0.0.1:8770:7770 \
         -p 127.0.0.1:8771:7771 \
         --network=interledger \
         --name=interledger-rs-node_b \
         -td \
-        interledgerrs/node
+        interledgerrs/node \
+        --ilp_address example.bob \
+        --secret_seed 1604966725982139900555208458637022875563691455429373719368053354 \
+        --admin_auth_token hi_bob \
+        --redis_url redis://redis-bob_node:6379/ \
+        --http_bind_address 0.0.0.0:7770 \
+        --settlement_api_bind_address 0.0.0.0:7771
 else
 -->
 
 ```bash
+# Start both nodes.
+# Note that the configuration options can be passed as environment variables
+# or saved to a YAML, JSON or TOML file and passed to the node as a positional argument.
+# You can also pass it from STDIN.
+# Be aware that we are using `--` to differentiate arguments for `cargo` from `ilp-node`.
+# Arguments before `--` are used for `cargo`, after are used for `ilp-node`.
+
 # Start Alice's node
-ILP_ADDRESS=example.alice \
-ILP_SECRET_SEED=8852500887504328225458511465394229327394647958135038836332350604 \
-ILP_ADMIN_AUTH_TOKEN=hi_alice \
-ILP_REDIS_URL=redis://127.0.0.1:6379/ \
-ILP_HTTP_BIND_ADDRESS=127.0.0.1:7770 \
-ILP_SETTLEMENT_API_BIND_ADDRESS=127.0.0.1:7771 \
-cargo run --bin ilp-node &> logs/node-alice.log &
+cargo run --bin ilp-node -- \
+--ilp_address example.alice \
+--secret_seed 8852500887504328225458511465394229327394647958135038836332350604 \
+--admin_auth_token hi_alice \
+--redis_url redis://127.0.0.1:6379/ \
+--http_bind_address 127.0.0.1:7770 \
+--settlement_api_bind_address 127.0.0.1:7771 \
+&> logs/node-alice.log &
 
 # Start Bob's node
-ILP_ADDRESS=example.bob \
-ILP_SECRET_SEED=1604966725982139900555208458637022875563691455429373719368053354 \
-ILP_ADMIN_AUTH_TOKEN=hi_bob \
-ILP_REDIS_URL=redis://127.0.0.1:6381/ \
-ILP_HTTP_BIND_ADDRESS=127.0.0.1:8770 \
-ILP_SETTLEMENT_API_BIND_ADDRESS=127.0.0.1:8771 \
-cargo run --bin ilp-node &> logs/node-bob.log &
+cargo run --bin ilp-node -- \
+--ilp_address example.bob \
+--secret_seed 1604966725982139900555208458637022875563691455429373719368053354 \
+--admin_auth_token hi_bob \
+--redis_url redis://127.0.0.1:6381/ \
+--http_bind_address 127.0.0.1:8770 \
+--settlement_api_bind_address 127.0.0.1:8771 \
+&> logs/node-bob.log &
 ```
 
 <!--!

--- a/examples/eth-xrp-three-nodes/README.md
+++ b/examples/eth-xrp-three-nodes/README.md
@@ -450,76 +450,86 @@ printf "\nStarting nodes...\n"
 if [ "$USE_DOCKER" -eq 1 ]; then
     # Start Alice's node
     $CMD_DOCKER run \
-        -e ILP_ADDRESS=example.alice \
-        -e ILP_SECRET_SEED=8852500887504328225458511465394229327394647958135038836332350604 \
-        -e ILP_ADMIN_AUTH_TOKEN=hi_alice \
-        -e ILP_REDIS_URL=redis://redis-alice_node:6379/ \
-        -e ILP_HTTP_BIND_ADDRESS=0.0.0.0:7770 \
-        -e ILP_SETTLEMENT_API_BIND_ADDRESS=0.0.0.0:7771 \
         -p 127.0.0.1:7770:7770 \
         -p 127.0.0.1:7771:7771 \
         --network=interledger \
         --name=interledger-rs-node_a \
         -td \
-        interledgerrs/node
+        interledgerrs/node \
+        --ilp_address example.alice \
+        --secret_seed 8852500887504328225458511465394229327394647958135038836332350604 \
+        --admin_auth_token hi_alice \
+        --redis_url redis://redis-alice_node:6379/ \
+        --http_bind_address 0.0.0.0:7770 \
+        --settlement_api_bind_address 0.0.0.0:7771
 
     # Start Bob's node
     $CMD_DOCKER run \
-        -e ILP_ADDRESS=example.bob \
-        -e ILP_SECRET_SEED=1604966725982139900555208458637022875563691455429373719368053354 \
-        -e ILP_ADMIN_AUTH_TOKEN=hi_bob \
-        -e ILP_REDIS_URL=redis://redis-bob_node:6379/ \
-        -e ILP_HTTP_BIND_ADDRESS=0.0.0.0:7770 \
-        -e ILP_SETTLEMENT_API_BIND_ADDRESS=0.0.0.0:7771 \
         -p 127.0.0.1:8770:7770 \
         -p 127.0.0.1:8771:7771 \
         --network=interledger \
         --name=interledger-rs-node_b \
         -td \
-        interledgerrs/node
+        interledgerrs/node \
+        --ilp_address example.bob \
+        --secret_seed 1604966725982139900555208458637022875563691455429373719368053354 \
+        --admin_auth_token hi_bob \
+        --redis_url redis://redis-bob_node:6379/ \
+        --http_bind_address 0.0.0.0:7770 \
+        --settlement_api_bind_address 0.0.0.0:7771
 
     # Start Charlie's node
     $CMD_DOCKER run \
-        -e ILP_SECRET_SEED=1232362131122139900555208458637022875563691455429373719368053354 \
-        -e ILP_ADMIN_AUTH_TOKEN=hi_charlie \
-        -e ILP_REDIS_URL=redis://redis-charlie_node:6379/ \
-        -e ILP_HTTP_BIND_ADDRESS=0.0.0.0:7770 \
-        -e ILP_SETTLEMENT_API_BIND_ADDRESS=0.0.0.0:7771 \
         -p 127.0.0.1:9770:7770 \
         -p 127.0.0.1:9771:7771 \
         --network=interledger \
         --name=interledger-rs-node_c \
         -td \
-        interledgerrs/node
+        interledgerrs/node \
+        --secret_seed 1232362131122139900555208458637022875563691455429373719368053354 \
+        --admin_auth_token hi_charlie \
+        --redis_url redis://redis-charlie_node:6379/ \
+        --http_bind_address 0.0.0.0:7770 \
+        --settlement_api_bind_address 0.0.0.0:7771
 else
 -->
 
 ```bash
+# Start nodes.
+# Note that the configuration options can be passed as environment variables
+# or saved to a YAML, JSON or TOML file and passed to the node as a positional argument.
+# You can also pass it from STDIN.
+# Be aware that we are using `--` to differentiate arguments for `cargo` from `ilp-node`.
+# Arguments before `--` are used for `cargo`, after are used for `ilp-node`.
+
 # Start Alice's node
-ILP_ADDRESS=example.alice \
-ILP_SECRET_SEED=8852500887504328225458511465394229327394647958135038836332350604 \
-ILP_ADMIN_AUTH_TOKEN=hi_alice \
-ILP_REDIS_URL=redis://127.0.0.1:6379/ \
-ILP_HTTP_BIND_ADDRESS=127.0.0.1:7770 \
-ILP_SETTLEMENT_API_BIND_ADDRESS=127.0.0.1:7771 \
-cargo run --bin ilp-node &> logs/node-alice.log &
+cargo run --bin ilp-node -- \
+--ilp_address example.alice \
+--secret_seed 8852500887504328225458511465394229327394647958135038836332350604 \
+--admin_auth_token hi_alice \
+--redis_url redis://127.0.0.1:6379/ \
+--http_bind_address 127.0.0.1:7770 \
+--settlement_api_bind_address 127.0.0.1:7771 \
+&> logs/node-alice.log &
 
 # Start Bob's node
-ILP_ADDRESS=example.bob \
-ILP_SECRET_SEED=1604966725982139900555208458637022875563691455429373719368053354 \
-ILP_ADMIN_AUTH_TOKEN=hi_bob \
-ILP_REDIS_URL=redis://127.0.0.1:6381/ \
-ILP_HTTP_BIND_ADDRESS=127.0.0.1:8770 \
-ILP_SETTLEMENT_API_BIND_ADDRESS=127.0.0.1:8771 \
-cargo run --bin ilp-node &> logs/node-bob.log &
+cargo run --bin ilp-node -- \
+--ilp_address example.bob \
+--secret_seed 1604966725982139900555208458637022875563691455429373719368053354 \
+--admin_auth_token hi_bob \
+--redis_url redis://127.0.0.1:6381/ \
+--http_bind_address 127.0.0.1:8770 \
+--settlement_api_bind_address 127.0.0.1:8771 \
+&> logs/node-bob.log &
 
 # Start Charlie's node
-ILP_SECRET_SEED=1232362131122139900555208458637022875563691455429373719368053354 \
-ILP_ADMIN_AUTH_TOKEN=hi_charlie \
-ILP_REDIS_URL=redis://127.0.0.1:6384/ \
-ILP_HTTP_BIND_ADDRESS=127.0.0.1:9770 \
-ILP_SETTLEMENT_API_BIND_ADDRESS=127.0.0.1:9771 \
-cargo run --bin ilp-node &> logs/node-charlie.log &
+cargo run --bin ilp-node -- \
+--secret_seed 1232362131122139900555208458637022875563691455429373719368053354 \
+--admin_auth_token hi_charlie \
+--redis_url redis://127.0.0.1:6384/ \
+--http_bind_address 127.0.0.1:9770 \
+--settlement_api_bind_address 127.0.0.1:9771 \
+&> logs/node-charlie.log &
 ```
 
 <!--!

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -194,32 +194,32 @@ When you want to watch logs, use the `tail` command. You can use the command lik
 printf "\n\nStarting Interledger nodes...\n"
 if [ "$USE_DOCKER" -eq 1 ]; then
     $CMD_DOCKER run \
-        -e ILP_ADDRESS=example.node_a \
-        -e ILP_SECRET_SEED=8852500887504328225458511465394229327394647958135038836332350604 \
-        -e ILP_ADMIN_AUTH_TOKEN=admin-a \
-        -e ILP_REDIS_URL=redis://redis-alice_node:6379/ \
-        -e ILP_HTTP_BIND_ADDRESS=0.0.0.0:7770 \
-        -e ILP_SETTLEMENT_API_BIND_ADDRESS=0.0.0.0:7771 \
         -p 127.0.0.1:7770:7770 \
         -p 127.0.0.1:7771:7771 \
         --network=interledger \
         --name=interledger-rs-node_a \
         -td \
-        interledgerrs/node
+        interledgerrs/node \
+        --ilp_address example.node_a \
+        --secret_seed 8852500887504328225458511465394229327394647958135038836332350604 \
+        --admin_auth_token admin-a \
+        --redis_url redis://redis-alice_node:6379/ \
+        --http_bind_address 0.0.0.0:7770 \
+        --settlement_api_bind_address 0.0.0.0:7771
     
     $CMD_DOCKER run \
-        -e ILP_ADDRESS=example.node_b \
-        -e ILP_SECRET_SEED=1604966725982139900555208458637022875563691455429373719368053354 \
-        -e ILP_ADMIN_AUTH_TOKEN=admin-b \
-        -e ILP_REDIS_URL=redis://redis-bob_node:6379/ \
-        -e ILP_HTTP_BIND_ADDRESS=0.0.0.0:7770 \
-        -e ILP_SETTLEMENT_API_BIND_ADDRESS=0.0.0.0:7771 \
         -p 127.0.0.1:8770:7770 \
         -p 127.0.0.1:8771:7771 \
         --network=interledger \
         --name=interledger-rs-node_b \
         -td \
-        interledgerrs/node
+        interledgerrs/node \
+        --ilp_address example.node_b \
+        --secret_seed 1604966725982139900555208458637022875563691455429373719368053354 \
+        --admin_auth_token admin-b \
+        --redis_url redis://redis-bob_node:6379/ \
+        --http_bind_address 0.0.0.0:7770 \
+        --settlement_api_bind_address 0.0.0.0:7771
 else
 -->
 
@@ -231,21 +231,25 @@ export RUST_LOG=interledger=debug
 # Note that the configuration options can be passed as environment variables
 # or saved to a YAML, JSON or TOML file and passed to the node as a positional argument.
 # You can also pass it from STDIN.
-ILP_ADDRESS=example.node_a \
-ILP_SECRET_SEED=8852500887504328225458511465394229327394647958135038836332350604 \
-ILP_ADMIN_AUTH_TOKEN=admin-a \
-ILP_REDIS_URL=redis://127.0.0.1:6379/ \
-ILP_HTTP_BIND_ADDRESS=127.0.0.1:7770 \
-ILP_SETTLEMENT_API_BIND_ADDRESS=127.0.0.1:7771 \
-cargo run --bin ilp-node &> logs/node_a.log &
+# Be aware that we are using `--` to differentiate arguments for `cargo` from `ilp-node`.
+# Arguments before `--` are used for `cargo`, after are used for `ilp-node`.
+cargo run --bin ilp-node -- \
+--ilp_address example.node_a \
+--secret_seed 8852500887504328225458511465394229327394647958135038836332350604 \
+--admin_auth_token admin-a \
+--redis_url redis://127.0.0.1:6379/ \
+--http_bind_address 127.0.0.1:7770 \
+--settlement_api_bind_address 127.0.0.1:7771 \
+&> logs/node_a.log &
 
-ILP_ADDRESS=example.node_b \
-ILP_SECRET_SEED=1604966725982139900555208458637022875563691455429373719368053354 \
-ILP_ADMIN_AUTH_TOKEN=admin-b \
-ILP_REDIS_URL=redis://127.0.0.1:6380/ \
-ILP_HTTP_BIND_ADDRESS=127.0.0.1:8770 \
-ILP_SETTLEMENT_API_BIND_ADDRESS=127.0.0.1:8771 \
-cargo run --bin ilp-node &> logs/node_b.log &
+cargo run --bin ilp-node -- \
+--ilp_address example.node_b \
+--secret_seed 1604966725982139900555208458637022875563691455429373719368053354 \
+--admin_auth_token admin-b \
+--redis_url redis://127.0.0.1:6380/ \
+--http_bind_address 127.0.0.1:8770 \
+--settlement_api_bind_address 127.0.0.1:8771 \
+&> logs/node_b.log &
 ```
 
 <!--!

--- a/examples/xrp-settlement/README.md
+++ b/examples/xrp-settlement/README.md
@@ -296,54 +296,63 @@ printf "\n\nStarting Interledger nodes...\n"
 if [ "$USE_DOCKER" -eq 1 ]; then
     # Start Alice's node
     $CMD_DOCKER run \
-        -e ILP_ADDRESS=example.alice \
-        -e ILP_SECRET_SEED=8852500887504328225458511465394229327394647958135038836332350604 \
-        -e ILP_ADMIN_AUTH_TOKEN=hi_alice \
-        -e ILP_REDIS_URL=redis://redis-alice_node:6379/ \
-        -e ILP_HTTP_BIND_ADDRESS=0.0.0.0:7770 \
-        -e ILP_SETTLEMENT_API_BIND_ADDRESS=0.0.0.0:7771 \
         -p 127.0.0.1:7770:7770 \
         -p 127.0.0.1:7771:7771 \
         --network=interledger \
         --name=interledger-rs-node_a \
         -td \
-        interledgerrs/node
+        interledgerrs/node \
+        --ilp_address example.alice \
+        --secret_seed 8852500887504328225458511465394229327394647958135038836332350604 \
+        --admin_auth_token hi_alice \
+        --redis_url redis://redis-alice_node:6379/ \
+        --http_bind_address 0.0.0.0:7770 \
+        --settlement_api_bind_address 0.0.0.0:7771
 
     # Start Bob's node
     $CMD_DOCKER run \
-        -e ILP_ADDRESS=example.bob \
-        -e ILP_SECRET_SEED=1604966725982139900555208458637022875563691455429373719368053354 \
-        -e ILP_ADMIN_AUTH_TOKEN=hi_bob \
-        -e ILP_REDIS_URL=redis://redis-bob_node:6379/ \
-        -e ILP_HTTP_BIND_ADDRESS=0.0.0.0:7770 \
-        -e ILP_SETTLEMENT_API_BIND_ADDRESS=0.0.0.0:7771 \
         -p 127.0.0.1:8770:7770 \
         -p 127.0.0.1:8771:7771 \
         --network=interledger \
         --name=interledger-rs-node_b \
         -td \
-        interledgerrs/node
+        interledgerrs/node \
+        --ilp_address example.bob \
+        --secret_seed 1604966725982139900555208458637022875563691455429373719368053354 \
+        --admin_auth_token hi_bob \
+        --redis_url redis://redis-bob_node:6379/ \
+        --http_bind_address 0.0.0.0:7770 \
+        --settlement_api_bind_address 0.0.0.0:7771
 else
 -->
 
 ```bash
+# Start both nodes.
+# Note that the configuration options can be passed as environment variables
+# or saved to a YAML, JSON or TOML file and passed to the node as a positional argument.
+# You can also pass it from STDIN.
+# Be aware that we are using `--` to differentiate arguments for `cargo` from `ilp-node`.
+# Arguments before `--` are used for `cargo`, after are used for `ilp-node`.
+
 # Start Alice's node
-ILP_ADDRESS=example.alice \
-ILP_SECRET_SEED=8852500887504328225458511465394229327394647958135038836332350604 \
-ILP_ADMIN_AUTH_TOKEN=hi_alice \
-ILP_REDIS_URL=redis://127.0.0.1:6379/ \
-ILP_HTTP_BIND_ADDRESS=127.0.0.1:7770 \
-ILP_SETTLEMENT_API_BIND_ADDRESS=127.0.0.1:7771 \
-cargo run --bin ilp-node &> logs/node-alice.log &
+cargo run --bin ilp-node -- \
+--ilp_address example.alice \
+--secret_seed 8852500887504328225458511465394229327394647958135038836332350604 \
+--admin_auth_token hi_alice \
+--redis_url redis://127.0.0.1:6379/ \
+--http_bind_address 127.0.0.1:7770 \
+--settlement_api_bind_address 127.0.0.1:7771 \
+&> logs/node-alice.log &
 
 # Start Bob's node
-ILP_ADDRESS=example.bob \
-ILP_SECRET_SEED=1604966725982139900555208458637022875563691455429373719368053354 \
-ILP_ADMIN_AUTH_TOKEN=hi_bob \
-ILP_REDIS_URL=redis://127.0.0.1:6381/ \
-ILP_HTTP_BIND_ADDRESS=127.0.0.1:8770 \
-ILP_SETTLEMENT_API_BIND_ADDRESS=127.0.0.1:8771 \
-cargo run --bin ilp-node &> logs/node-bob.log &
+cargo run --bin ilp-node -- \
+--ilp_address example.bob \
+--secret_seed 1604966725982139900555208458637022875563691455429373719368053354 \
+--admin_auth_token hi_bob \
+--redis_url redis://127.0.0.1:6381/ \
+--http_bind_address 127.0.0.1:8770 \
+--settlement_api_bind_address 127.0.0.1:8771 \
+&> logs/node-bob.log &
 ```
 
 <!--!


### PR DESCRIPTION
[Separated PR](https://github.com/interledger-rs/interledger-rs/pull/305#pullrequestreview-310992490) of #305 "Enables `run-md-test.sh` on CircleCI". The following PRs should be merged at once, because latter PRs optimize some of former PRs (e.g. cache).

- #492 ci(circleci): enables run-md-test.sh on CircleCI
- #493 feat(examples): fixed to use CLI arguments instead of ENV vars, etc
- #494 feat(.circleci): tag docker images
- #495 ci(ci): publish binaries when tags are pushed

Note that some of these will be simplified when examples start using binaries. Some of docker images will be removed, examples get simpler.

<details><summary>My opinions</summary>

- Why do we need `circleci-rust-dind.dockerfile`?
    - It is because
        1. Installing dependencies every time doesn't make sense
        1. there aren't any Docker images that contain Rust, musl with SSL support and Docker commands.
- Why are there so many changes?
    - It is because we are
        1. Testing markdowns
        1. Building Docker images, tag it and publish it
        1. Building binaries
        1. Auto-releasing the artifacts
    - and we definitely should do CI/CI. We should not do these manually because people forget to test markdowns, which makes always examples broken and forget to publish Docker images and binaries. That is also cumbersome. Why don't we just automate it?

</details>