### PR TITLE
fix(cryptocompare): ignore currencies that don't have the RAW field

### DIFF
--- a/crates/interledger-service-util/src/exchange_rate_providers/cryptocompare.rs
+++ b/crates/interledger-service-util/src/exchange_rate_providers/cryptocompare.rs
@@ -79,8 +79,11 @@ pub fn query_cryptocompare(
             let rates = res
                 .data
                 .into_iter()
-                .filter(|asset| asset.raw.is_some())
-                .map(|asset| (asset.coin_info.name.to_uppercase(), asset.raw.unwrap().usd.price))
+                .filter_map(|asset| if let Some(raw) = asset.raw {
+                    Some((asset.coin_info.name.to_uppercase(), raw.usd.price))
+                  } else {
+                    None
+                  })
                 .chain(once(("USD".to_string(), 1.0)));
             Ok(HashMap::from_iter(rates))
         })

--- a/crates/interledger-service-util/src/exchange_rate_providers/cryptocompare.rs
+++ b/crates/interledger-service-util/src/exchange_rate_providers/cryptocompare.rs
@@ -38,7 +38,7 @@ struct Record {
     #[serde(rename = "CoinInfo")]
     coin_info: CoinInfo,
     #[serde(rename = "RAW")]
-    raw: Raw,
+    raw: Option<Raw>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -79,7 +79,8 @@ pub fn query_cryptocompare(
             let rates = res
                 .data
                 .into_iter()
-                .map(|asset| (asset.coin_info.name.to_uppercase(), asset.raw.usd.price))
+                .filter(|asset| asset.raw.is_some())
+                .map(|asset| (asset.coin_info.name.to_uppercase(), asset.raw.unwrap().usd.price))
                 .chain(once(("USD".to_string(), 1.0)));
             Ok(HashMap::from_iter(rates))
         })


### PR DESCRIPTION
Currently the `exchange_rates` test fails because `MEXC` doesn't have the `RAW` field.

```
2019-11-06T02:31:55.616780071+00:00 ERROR interledger_service_util::exchange_rate_providers::cryptocompare: Error getting exchange rate response body from CryptoCompare, incorrect type: Error(Json(Error("missing field `RAW`", line: 1, column: 104464)))    
```

https://circleci.com/gh/interledger-rs/interledger-rs/3188