### PR TITLE
Update Settlement API to master RFC

### DIFF
--- a/crates/interledger-settlement/src/api/test_helpers.rs
+++ b/crates/interledger-settlement/src/api/test_helpers.rs
@@ -260,6 +260,13 @@ impl LeftoversStore for TestStore {
             (BigUint::from(0u32), 1)
         }))
     }
+
+    fn clear_uncredited_settlement_amount(
+        &self,
+        _account_id: u64,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        unreachable!()
+    }
 }
 
 impl TestStore {

--- a/crates/interledger-settlement/src/core/backends_common/redis/mod.rs
+++ b/crates/interledger-settlement/src/core/backends_common/redis/mod.rs
@@ -298,6 +298,22 @@ impl LeftoversStore for EngineRedisStore {
                 }),
         )
     }
+
+    fn clear_uncredited_settlement_amount(
+        &self,
+        account_id: Self::AccountId,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        trace!("Clearing uncredited_settlement_amount {:?}", account_id,);
+        Box::new(
+            cmd("DEL")
+                .arg(uncredited_amount_key(account_id))
+                .query_async(self.connection.clone())
+                .map_err(move |err| {
+                    error!("Error clearing uncredited_settlement_amount: {:?}", err)
+                })
+                .and_then(move |(_conn, _ret): (_, Value)| Ok(())),
+        )
+    }
 }
 
 #[cfg(test)]

--- a/crates/interledger-settlement/src/core/engines_api.rs
+++ b/crates/interledger-settlement/src/core/engines_api.rs
@@ -264,6 +264,13 @@ mod tests {
         ) -> Box<dyn Future<Item = ApiResponse, Error = ApiError> + Send> {
             Box::new(ok(ApiResponse::Default))
         }
+
+        fn delete_account(
+            &self,
+            _account_id: String,
+        ) -> Box<dyn Future<Item = ApiResponse, Error = ApiError> + Send> {
+            Box::new(ok(ApiResponse::Default))
+        }
     }
 
     #[test]

--- a/crates/interledger-settlement/src/core/idempotency.rs
+++ b/crates/interledger-settlement/src/core/idempotency.rs
@@ -1,3 +1,4 @@
+use super::types::ApiResponse;
 use bytes::Bytes;
 use futures::executor::spawn;
 use futures::{
@@ -85,9 +86,14 @@ pub fn make_idempotent_call<S, F>(
     non_idempotent_function: F,
     input_hash: [u8; 32],
     idempotency_key: Option<String>,
+    // As per the spec, the success status code is independent of the
+    // implemented engine's functionality
+    status_code: StatusCode,
+    // The default value is used when the engine returns a default return type
+    default_return_value: Bytes,
 ) -> impl Future<Item = (StatusCode, Bytes), Error = ApiError>
 where
-    F: FnOnce() -> Box<dyn Future<Item = (StatusCode, Bytes), Error = ApiError> + Send>,
+    F: FnOnce() -> Box<dyn Future<Item = ApiResponse, Error = ApiError> + Send>,
     S: IdempotentStore + Clone + Send + Sync + 'static,
 {
     if let Some(idempotency_key) = idempotency_key {
@@ -128,7 +134,13 @@ where
                                     ).map_err(move |_| error!("Failed to connect to the store! The request will not be idempotent if retried.")));
                                     ret
                                 }})
-                            .and_then(
+                            .map(move |ret| {
+                                let data = match ret {
+                                    ApiResponse::Default => default_return_value,
+                                    ApiResponse::Data(d) => d,
+                                };
+                                (status_code, data)
+                            }).and_then(
                                 move |ret: (StatusCode, Bytes)| {
                                     store
                                         .save_idempotent_data(
@@ -152,7 +164,15 @@ where
     } else {
         // otherwise just make the call w/o any idempotency saves
         Either::B(
-            non_idempotent_function().and_then(move |ret: (StatusCode, Bytes)| Ok((ret.0, ret.1))),
+            non_idempotent_function()
+                .map(move |ret| {
+                    let data = match ret {
+                        ApiResponse::Default => default_return_value,
+                        ApiResponse::Data(d) => d,
+                    };
+                    (status_code, data)
+                })
+                .and_then(move |ret: (StatusCode, Bytes)| Ok((ret.0, ret.1))),
         )
     }
 }

--- a/crates/interledger-settlement/src/core/types.rs
+++ b/crates/interledger-settlement/src/core/types.rs
@@ -53,6 +53,16 @@ pub enum ApiResponse {
 /// Trait consumed by the Settlement Engine HTTP API. Every settlement engine
 /// MUST implement this trait, so that it can be then be exposed over the API.
 pub trait SettlementEngine {
+    fn create_account(
+        &self,
+        account_id: String,
+    ) -> Box<dyn Future<Item = ApiResponse, Error = ApiError> + Send>;
+
+    fn delete_account(
+        &self,
+        account_id: String,
+    ) -> Box<dyn Future<Item = ApiResponse, Error = ApiError> + Send>;
+
     fn send_money(
         &self,
         account_id: String,
@@ -63,11 +73,6 @@ pub trait SettlementEngine {
         &self,
         account_id: String,
         message: Vec<u8>,
-    ) -> Box<dyn Future<Item = ApiResponse, Error = ApiError> + Send>;
-
-    fn create_account(
-        &self,
-        account_id: String,
     ) -> Box<dyn Future<Item = ApiResponse, Error = ApiError> + Send>;
 }
 

--- a/crates/interledger-settlement/src/core/types.rs
+++ b/crates/interledger-settlement/src/core/types.rs
@@ -11,8 +11,6 @@ use std::ops::{Div, Mul};
 use std::str::FromStr;
 use url::Url;
 
-pub type ApiResponse = (StatusCode, Bytes);
-
 // Account without an engine error
 pub const NO_ENGINE_CONFIGURED_ERROR_TYPE: ApiErrorType = ApiErrorType {
     r#type: &ProblemType::Default,
@@ -44,6 +42,12 @@ impl Quantity {
             scale,
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub enum ApiResponse {
+    Default,
+    Data(Bytes),
 }
 
 /// Trait consumed by the Settlement Engine HTTP API. Every settlement engine

--- a/crates/interledger-settlement/src/core/types.rs
+++ b/crates/interledger-settlement/src/core/types.rs
@@ -130,6 +130,12 @@ pub trait LeftoversStore {
         local_scale: u8,
     ) -> Box<dyn Future<Item = Self::AssetType, Error = ()> + Send>;
 
+    /// Clears any uncredited settlement amount associated with the account
+    fn clear_uncredited_settlement_amount(
+        &self,
+        account_id: Self::AccountId,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send>;
+
     // Gets the current amount of leftovers in the store
     fn get_uncredited_settlement_amount(
         &self,


### PR DESCRIPTION
- The StatusCode does not depend on the engine implementation. As a result we remove it from the engines trait
- The only settlement functions which return data is the message-related ones. We abstract over the return type with an enum, and make the idempotent.
- Taking the above into account, we add a status code & default return data to the idempotent call
- All tests are adjusted to take that into account

Depends on #497.