### PR TITLE
Optional feature to publish packets to Google PubSub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: circleci/rust
         environment:
           CARGO_HOME: /home/circleci/.cargo
-    resource_class: medium+
+    resource_class: large
     steps:
       - checkout
       - restore_cache:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-logs"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +665,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ct-logs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-rustls 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki-roots 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +733,7 @@ dependencies = [
  "approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -720,6 +745,7 @@ dependencies = [
  "metrics-core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "metrics-runtime 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -735,6 +761,7 @@ dependencies = [
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "warp 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yup-oauth2 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1132,6 +1159,14 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1800,6 +1835,7 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1818,6 +1854,18 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustls"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1851,6 +1899,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "scopeguard"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sct"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "secrecy"
@@ -2230,6 +2287,19 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2694,6 +2764,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "weedle"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2764,6 +2851,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "yup-oauth2"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-rustls 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,6 +2925,7 @@ dependencies = [
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37519ccdfd73a75821cac9319d4fce15a81b9fcf75f951df5b9988aa3a0af87d"
 "checksum csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
+"checksum ct-logs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
@@ -2847,6 +2958,7 @@ dependencies = [
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)" = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
+"checksum hyper-rustls 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "719d85c7df4a7f309a77d145340a063ea929dcb2e025bae46a80345cffec2952"
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
@@ -2862,6 +2974,7 @@ dependencies = [
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
+"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matchers 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
@@ -2934,11 +3047,13 @@ dependencies = [
 "checksum ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+"checksum rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
 "checksum scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
+"checksum sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 "checksum secrecy 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "374ba6afc5023f0499cd29a0449bca2c8792c1ed2817006fb856c8a2646aa2de"
 "checksum security-framework 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eee63d0f4a9ec776eeb30e220f0bc1e092c3ad744b2a379e3993070364d3adc2"
 "checksum security-framework-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9636f8989cbf61385ae4824b98c1aaa54c994d7d8b41f11c601ed799f0549a56"
@@ -2980,6 +3095,7 @@ dependencies = [
 "checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
 "checksum tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c56391be9805bc80163151c0b9e5164ee64f4b0200962c346fea12773158f22d"
 "checksum tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c03755b956458582182941061def32b8123a26c98b08fc6ddcf49ae89d18f33"
+"checksum tokio-rustls 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1df2fa53ac211c136832f530ccb081af9af891af22d685a9493e232c7a359bc2"
 "checksum tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d06554cce1ae4a50f42fba8023918afa931413aded705b560e29600ccf7c6d76"
 "checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
 "checksum tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2bd2c6a3885302581f4401c82af70d792bb9df1700e7437b0aeb4ada94d5388c"
@@ -3028,6 +3144,8 @@ dependencies = [
 "checksum wasm-bindgen-shared 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)" = "7493fe67ad99672ef3de3e6ba513fb03db276358c8cc9588ce5a008c6e48ad68"
 "checksum wasm-bindgen-webidl 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)" = "8272d9a8831be66b30908996b71b3eaf9b83de050f89e4dc34826a19980eb59d"
 "checksum web-sys 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)" = "0232f38e5c66384edaedaa726ae2d6313e3ed3ae860693c497a3193af3e161ce"
+"checksum webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7e664e770ac0110e2384769bcc59ed19e329d81f555916a6e072714957b81b4"
+"checksum webpki-roots 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a262ae37dd9d60f60dd473d1158f9fbebf110ba7b6a5051c8160460f6043718b"
 "checksum weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
@@ -3038,4 +3156,5 @@ dependencies = [
 "checksum winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
+"checksum yup-oauth2 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "687c1c52bf66691f1e7426e7520aecec25bf659835179095280a4acfcb24f63f"
 "checksum zeroize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cdc979d9b5ead18184c357c4d8a3f81b579aae264e32507223032e64715462d3"

--- a/crates/ilp-cli/Cargo.toml
+++ b/crates/ilp-cli/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 clap = { version = "2.33.0", default-features = false }
 thiserror = { version = "1.0.4", default-features = false }
 http = { version = "0.1.18", default-features = false }
-reqwest = { version = "0.9.21", default-features = false, features = ["default-tls"] }
+reqwest = { version = "0.9.22", default-features = false, features = ["default-tls"] }
 serde = { version = "1.0.101", default-features = false }
 serde_json = { version = "1.0.41", default-features = false }
 tungstenite = { version = "0.9.1", default-features = false, features = ["tls"] }

--- a/crates/ilp-node/Cargo.toml
+++ b/crates/ilp-node/Cargo.toml
@@ -11,6 +11,9 @@ default-run = "ilp-node"
 [features]
 default = ["balance-tracking"]
 balance-tracking = []
+# This is an experimental feature that enables submitting packet
+# records to Google Cloud PubSub. This may be removed in the future.
+google-pubsub = ["base64", "chrono", "parking_lot", "reqwest", "serde_json", "yup-oauth2"]
 
 [dependencies]
 bytes = { version = "0.4.12", default-features = false }
@@ -34,6 +37,14 @@ libc = { version = "0.2.62", default-features = false }
 warp = { version = "0.1.20", default-features = false, features = ["websocket"] }
 secrecy = { version = "0.5.0", default-features = false, features = ["alloc", "serde"] }
 uuid = { version = "0.8.1", default-features = false, features = ["v4"] }
+
+# For google-pubsub
+base64 = { version = "0.10.1", default-features = false, optional = true }
+chrono = { version = "0.4.9", default-features = false, features = [], optional = true}
+parking_lot = { version = "0.9.0", default-features = false, optional = true }
+reqwest = { version = "0.9.22", default-features = false, features = ["default-tls"], optional = true }
+serde_json = { version = "1.0.41", default-features = false, optional = true }
+yup-oauth2 = { version = "3.1.1", default-features = false, optional = true }
 
 [dev-dependencies]
 approx = { version = "0.3.2", default-features = false }

--- a/crates/ilp-node/src/google_pubsub.rs
+++ b/crates/ilp-node/src/google_pubsub.rs
@@ -1,0 +1,186 @@
+use base64;
+use chrono::Utc;
+use futures::{
+    future::{ok, Either},
+    Future,
+};
+use interledger::{
+    packet::Address,
+    service::{Account, BoxedIlpFuture, OutgoingRequest, OutgoingService, Username},
+};
+use parking_lot::Mutex;
+use reqwest::r#async::Client;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, sync::Arc};
+use tokio::spawn;
+use tracing::{error, info};
+use yup_oauth2::{service_account_key_from_file, GetToken, ServiceAccountAccess};
+
+static TOKEN_SCOPES: Option<&str> = Some("https://www.googleapis.com/auth/pubsub");
+
+/// Configuration for the Google PubSub packet publisher
+#[derive(Deserialize, Clone, Debug)]
+pub struct PubsubConfig {
+    /// Path to the Service Account Key JSON file.
+    /// You can obtain this file by logging into [console.cloud.google.com](https://console.cloud.google.com/)
+    service_account_credentials: String,
+    project_id: String,
+    topic: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PubsubMessage {
+    message_id: Option<String>,
+    data: Option<String>,
+    attributes: Option<HashMap<String, String>>,
+    publish_time: Option<String>,
+}
+
+#[derive(Serialize)]
+struct PubsubRequest {
+    messages: Vec<PubsubMessage>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PacketRecord {
+    prev_hop_account: Username,
+    prev_hop_asset_code: String,
+    prev_hop_asset_scale: u8,
+    prev_hop_amount: u64,
+    next_hop_account: Username,
+    next_hop_asset_code: String,
+    next_hop_asset_scale: u8,
+    next_hop_amount: u64,
+    destination_ilp_address: Address,
+    fulfillment: String,
+    timestamp: String,
+}
+
+/// Create an Interledger service wrapper that publishes records
+/// of fulfilled packets to Google Cloud PubSub.
+///
+/// This is an experimental feature that may be removed in the future.
+pub fn create_google_pubsub_wrapper<
+    A: Account + 'static,
+    O: OutgoingService<A> + Clone + Send + 'static,
+>(
+    config: Option<PubsubConfig>,
+) -> impl Fn(OutgoingRequest<A>, O) -> BoxedIlpFuture + Clone {
+    // If Google credentials were passed in, create an HTTP client and
+    // OAuth2 client that will automatically fetch and cache access tokens
+    let utilities = if let Some(config) = config {
+        let key = service_account_key_from_file(config.service_account_credentials.as_str())
+            .expect("Unable to load Google Cloud credentials from file");
+        let access = ServiceAccountAccess::new(key);
+        // This needs to be wrapped in a Mutex because the .token()
+        // method takes a mutable reference to self and we want to
+        // reuse the same fetcher so that it caches the tokens
+        let token_fetcher = Arc::new(Mutex::new(access.build()));
+
+        // TODO make sure the client uses HTTP/2
+        let client = Client::new();
+        let api_endpoint = Arc::new(format!(
+            "https://pubsub.googleapis.com/v1/projects/{}/topics/{}:publish",
+            config.project_id, config.topic
+        ));
+        info!("Fulfilled packets will be submitted to Google Cloud Pubsub (project ID: {}, topic: {})", config.project_id, config.topic);
+        Some((client, api_endpoint, token_fetcher))
+    } else {
+        None
+    };
+
+    move |request: OutgoingRequest<A>, mut next: O| -> BoxedIlpFuture {
+        match &utilities {
+            // Just pass the request on if no Google Pubsub details were configured
+            None => Box::new(next.send_request(request)),
+            Some((client, api_endpoint, token_fetcher)) => {
+                let prev_hop_account = request.from.username().clone();
+                let prev_hop_asset_code = request.from.asset_code().to_string();
+                let prev_hop_asset_scale = request.from.asset_scale();
+                let prev_hop_amount = request.original_amount;
+                let next_hop_account = request.to.username().clone();
+                let next_hop_asset_code = request.to.asset_code().to_string();
+                let next_hop_asset_scale = request.to.asset_scale();
+                let next_hop_amount = request.prepare.amount();
+                let destination_ilp_address = request.prepare.destination();
+                let client = client.clone();
+                let api_endpoint = api_endpoint.clone();
+                let token_fetcher = token_fetcher.clone();
+
+                Box::new(next.send_request(request).map(move |fulfill| {
+                    // Only fulfilled packets are published for now
+                    let fulfillment = base64::encode(fulfill.fulfillment());
+
+                    let get_token_future = token_fetcher.lock()
+                        .token(TOKEN_SCOPES)
+                        .map_err(|err| {
+                            error!("Error fetching OAuth token for Google PubSub: {:?}", err)
+                        });
+                    // Spawn a task to submit the packet to PubSub so we
+                    // don't block returning the fulfillment
+                    // Note this means that if there is a problem submitting the
+                    // packet record to PubSub, it will only log an error
+                    spawn(
+                        get_token_future
+                            .and_then(move |token| {
+                                let record = PacketRecord {
+                                    prev_hop_account,
+                                    prev_hop_asset_code,
+                                    prev_hop_asset_scale,
+                                    prev_hop_amount,
+                                    next_hop_account,
+                                    next_hop_asset_code,
+                                    next_hop_asset_scale,
+                                    next_hop_amount,
+                                    destination_ilp_address,
+                                    fulfillment,
+                                    timestamp: Utc::now().to_rfc3339(),
+                                };
+                                let data = base64::encode(&serde_json::to_string(&record).unwrap());
+
+                                client
+                                    .post(api_endpoint.as_str())
+                                    .bearer_auth(token.access_token)
+                                    .json(&PubsubRequest {
+                                        messages: vec![PubsubMessage {
+                                            // TODO should there be an ID?
+                                            message_id: None,
+                                            data: Some(data),
+                                            attributes: None,
+                                            publish_time: None,
+                                        }],
+                                    })
+                                    .send()
+                                    .map_err(|err| {
+                                        error!(
+                                            "Error sending packet details to Google PubSub: {:?}",
+                                            err
+                                        )
+                                    })
+                                    .and_then(|mut res| {
+                                        if res.status().is_success() {
+                                            Either::A(ok(()))
+                                        } else {
+                                            let status = res.status();
+                                            Either::B(res.text()
+                                                .map_err(|err| error!("Error getting response body: {:?}", err))
+                                                .and_then(move |body| {
+                                                    error!(
+                                                        %status,
+                                                        "Error sending packet details to Google PubSub: {}",
+                                                        body
+                                                    );
+                                                    Ok(())
+                                                }))
+                                        }
+                                    })
+                            }),
+                    );
+                    fulfill
+                }))
+            }
+        }
+    }
+}

--- a/crates/ilp-node/src/lib.rs
+++ b/crates/ilp-node/src/lib.rs
@@ -1,3 +1,7 @@
+#![type_length_limit = "1119051"]
+
+#[cfg(feature = "google-pubsub")]
+mod google_pubsub;
 mod metrics;
 mod node;
 mod trace;

--- a/crates/ilp-node/src/main.rs
+++ b/crates/ilp-node/src/main.rs
@@ -1,3 +1,5 @@
+#![type_length_limit = "1119051"]
+
 use clap::{crate_version, App, Arg, ArgMatches};
 use config::{Config, Source};
 use config::{FileFormat, Value};
@@ -12,6 +14,8 @@ use tracing_subscriber::{
     fmt::{time::ChronoUtc, Subscriber},
 };
 
+#[cfg(feature = "google-pubsub")]
+mod google_pubsub;
 mod metrics;
 mod node;
 mod trace;

--- a/crates/interledger-service-util/Cargo.toml
+++ b/crates/interledger-service-util/Cargo.toml
@@ -18,7 +18,7 @@ interledger-service = { path = "../interledger-service", version = "^0.3.0", def
 interledger-settlement = { path = "../interledger-settlement", version = "^0.2.0", default-features = false, features = ["settlement_api"] }
 lazy_static = { version = "1.4.0", default-features = false }
 log = { version = "0.4.8", default-features = false }
-reqwest = { version = "0.9.21", default-features = false, features = ["default-tls"] }
+reqwest = { version = "0.9.22", default-features = false, features = ["default-tls"] }
 ring = { version = "0.16.9", default-features = false }
 secrecy = { version = "0.5.0", default-features = false, features = ["alloc", "serde"] }
 serde = { version = "1.0.101", default-features = false, features = ["derive"]}


### PR DESCRIPTION
This is an experimental feature for publishing fulfilled packets to a message queue (in this case, Google's hosted PubSub service). This can be used as an alternative to real-time balance tracking because the amounts of the fulfilled packets can be summed up later to determine the balances with specific peers.

It's possible this will be removed later or we may abstract the behavior more so it's not so tied to Google Cloud.