### PR TITLE
test(two_nodes_btp): work-around for inserting account atomicity problem #464

### DIFF
--- a/crates/ilp-node/tests/btp.rs
+++ b/crates/ilp-node/tests/btp.rs
@@ -87,10 +87,10 @@ fn two_nodes_btp() {
     }))
     .expect("Error creating node_b.");
 
-    let alice_fut = join_all(vec![
-        create_account_on_node(node_a_http, alice_on_a, "admin"),
-        create_account_on_node(node_a_http, b_on_a, "admin"),
-    ]);
+    // FIXME This should be fixed after SQL store is implemented.
+    // https://github.com/interledger-rs/interledger-rs/issues/464
+    let alice_fut = create_account_on_node(node_a_http, alice_on_a, "admin")
+        .and_then(move |_| create_account_on_node(node_a_http, b_on_a, "admin"));
 
     runtime.spawn(
         node_a


### PR DESCRIPTION
The problem detail is here #464

The problemn is that `ilp_address` and the ILP address of an account that is being inserted are not
treated as fully atomic. It should be fixed later after SQL store is integrated. This fix is not an
essential solution and just a temporary work-around, not to let the test fail.

Signed-off-by: Taiga Nakayama <dora@dora-gt.jp>