### PR TITLE
feat(http api): accepts content-type with arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,6 +897,7 @@ dependencies = [
  "interledger-service 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/interledger-http/Cargo.toml
+++ b/crates/interledger-http/Cargo.toml
@@ -23,3 +23,4 @@ http = { version = "0.1.18", default-features = false }
 chrono = { version = "0.4.9", features = ["clock"], default-features = false }
 regex = { version ="1.3.1", default-features = false, features = ["std"] }
 lazy_static = { version ="1.4.0", default-features = false }
+mime = { version ="0.3.14", default-features = false }

--- a/crates/interledger-http/src/lib.rs
+++ b/crates/interledger-http/src/lib.rs
@@ -6,6 +6,7 @@ use bytes::Buf;
 use error::*;
 use futures::Future;
 use interledger_service::{Account, Username};
+use mime::Mime;
 use serde::de::DeserializeOwned;
 use url::Url;
 use warp::{self, filters::body::FullBody, Filter, Rejection};
@@ -40,9 +41,28 @@ pub trait HttpStore: Clone + Send + Sync + 'static {
 
 pub fn deserialize_json<T: DeserializeOwned + Send>(
 ) -> impl Filter<Extract = (T,), Error = Rejection> + Copy {
-    warp::header::exact("content-type", "application/json")
+    warp::header::<String>("content-type")
         .and(warp::body::concat())
-        .and_then(|buf: FullBody| {
+        .and_then(|content_type: String, buf: FullBody| {
+            let mime_type: Mime = content_type.parse().map_err::<Rejection, _>(|_| {
+                error::ApiError::bad_request()
+                    .detail("Invalid content-type header.")
+                    .into()
+            })?;
+            if mime_type.type_() != mime::APPLICATION_JSON.type_() {
+                return Err(error::ApiError::bad_request()
+                    .detail("Invalid content-type.")
+                    .into());
+            } else if let Some(charset) = mime_type.get_param("charset") {
+                // Charset should be UTF-8
+                // https://tools.ietf.org/html/rfc8259#section-8.1
+                if charset != mime::UTF_8 {
+                    return Err(error::ApiError::bad_request()
+                        .detail("Charset should be UTF-8.")
+                        .into());
+                }
+            }
+
             let deserializer = &mut serde_json::Deserializer::from_slice(&buf.bytes());
             serde_path_to_error::deserialize(deserializer).map_err(|err| {
                 warp::reject::custom(JsonDeserializeError {
@@ -52,4 +72,79 @@ pub fn deserialize_json<T: DeserializeOwned + Send>(
                 })
             })
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::deserialize_json;
+    use serde::Deserialize;
+    use warp::test::request;
+
+    #[derive(Deserialize, Clone)]
+    struct TestJsonStruct {
+        string_value: String,
+    }
+
+    #[test]
+    fn deserialize_json_header() {
+        let json_filter = deserialize_json::<TestJsonStruct>();
+        let body_correct = r#"{"string_value": "some string value"}"#;
+        let body_incorrect = r#"{"other_key": 0}"#;
+
+        // `content-type` should be provided.
+        assert_eq!(request().body(body_correct).matches(&json_filter), false);
+
+        // Should accept only "application/json" or "application/json; charset=utf-8"
+        assert_eq!(
+            request()
+                .body(body_correct)
+                .header("content-type", "text/plain")
+                .matches(&json_filter),
+            false
+        );
+        assert_eq!(
+            request()
+                .body(body_correct)
+                .header("content-type", "application/json")
+                .matches(&json_filter),
+            true
+        );
+        assert_eq!(
+            request()
+                .body(body_correct)
+                .header("content-type", "application/json; charset=ascii")
+                .matches(&json_filter),
+            false
+        );
+        assert_eq!(
+            request()
+                .body(body_correct)
+                .header("content-type", "application/json; charset=utf-8")
+                .matches(&json_filter),
+            true
+        );
+        assert_eq!(
+            request()
+                .body(body_correct)
+                .header("content-type", "application/json; charset=UTF-8")
+                .matches(&json_filter),
+            true
+        );
+
+        // Should accept only bodies that can be deserialized
+        assert_eq!(
+            request()
+                .body(body_incorrect)
+                .header("content-type", "application/json")
+                .matches(&json_filter),
+            false
+        );
+        assert_eq!(
+            request()
+                .body(body_incorrect)
+                .header("content-type", "application/json; charset=utf-8")
+                .matches(&json_filter),
+            false
+        );
+    }
 }


### PR DESCRIPTION
Fix: #498 

Now the `deserialize_json` filter accepts `content-type` header with `charset` arguments.