### PR TITLE
ci(circleci): fix to make a release when the branch is `master`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,7 +246,7 @@ jobs:
 
             # latest release, only if on the master branch
             # tag the current commit as (crate_name)-latest, and release it
-            if [ "${CIRCLE_TAG}" == "master" ]; then
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
               tag_name="${crate_name}-latest"
               LOG_DIR=logs/${tag_name} ./.circleci/release/github_tag.sh \
                 ${tag_name} \


### PR DESCRIPTION
I'm sorry but there was a bug in CI.

Currently the variable is referring to `CIRCLE_TAG`, which is not correct. It should be
`CIRCLE_BRANCH` if we want to make a release on the `master` branch.