### PR TITLE
fix(testnet-bundle): fixed to use the ilp-settlement-ethereum binary

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,13 +8,13 @@ COPY ./crates /usr/src/interledger-rs/crates
 
 # TODO: investigate using a method like https://whitfin.io/speeding-up-rust-docker-builds/
 # to ensure that the dependencies are cached so the build doesn't take as long
-# RUN cargo build --all-features --package ilp-node --package interledger-settlement-engines --package ilp-cli
+# RUN cargo build --all-features --package ilp-node --package ilp-cli
 RUN cargo build --release --all-features --package ilp-node --package ilp-cli
 
 WORKDIR /usr/src/
 RUN git clone https://github.com/interledger-rs/settlement-engines.git
 WORKDIR /usr/src/settlement-engines
-RUN cargo build --release --all-features --package interledger-settlement-engines
+RUN cargo build --release --all-features --package ilp-settlement-ethereum
 
 FROM node:12-alpine
 
@@ -40,8 +40,8 @@ COPY --from=rust \
     /usr/src/interledger-rs/target/x86_64-unknown-linux-musl/release/ilp-cli \
     /usr/local/bin/ilp-cli
 COPY --from=rust \
-    /usr/src/settlement-engines/target/x86_64-unknown-linux-musl/release/interledger-settlement-engines \
-    /usr/local/bin/interledger-settlement-engines
+    /usr/src/settlement-engines/target/x86_64-unknown-linux-musl/release/ilp-settlement-ethereum \
+    /usr/local/bin/ilp-settlement-ethereum
 # COPY --from=rust \
 #     /usr/src/interledger-rs/target/x86_64-unknown-linux-musl/debug/ilp-node \
 #     /usr/local/bin/ilp-node
@@ -49,8 +49,8 @@ COPY --from=rust \
 #     /usr/src/interledger-rs/target/x86_64-unknown-linux-musl/debug/ilp-cli \
 #     /usr/local/bin/ilp-cli
 # COPY --from=rust \
-#     /usr/src/settlement-engines/target/x86_64-unknown-linux-musl/debug/interledger-settlement-engines \
-#     /usr/local/bin/interledger-settlement-engines
+#     /usr/src/settlement-engines/target/x86_64-unknown-linux-musl/debug/ilp-settlement-ethereum \
+#     /usr/local/bin/ilp-settlement-ethereum
 
 WORKDIR /opt/app
 
@@ -60,7 +60,7 @@ COPY ./docker/redis.conf redis.conf
 COPY ./docker/run-testnet-bundle.js run-testnet-bundle.js
 
 # ENV RUST_BACKTRACE=1
-ENV RUST_LOG=interledger=debug
+ENV RUST_LOG=interledger=debug,ilp_settlement_ethereum=debug
 
 # In order for the node to access the config file, you need to mount
 # the directory with the node's config.yml file as a Docker volume

--- a/docker/run-testnet-bundle.js
+++ b/docker/run-testnet-bundle.js
@@ -163,8 +163,7 @@ function runXrpSettlementEngine() {
 
 function runEthSettlementEngine({ ethKey, ethUrl }) {
     console.log('Starting ETH settlement engine...')
-    const eth = spawn('interledger-settlement-engines', [
-        'ethereum-ledger',
+    const eth = spawn('ilp-settlement-ethereum', [
         '--settlement_api_bind_address=127.0.0.1:3002',
         `--ethereum_url=${ethUrl}`,
         `--private_key=${ethKey}`,
@@ -174,7 +173,7 @@ function runEthSettlementEngine({ ethKey, ethUrl }) {
         '--chain_id=4'
     ], {
         env: {
-            'RUST_LOG': process.env.RUST_LOG || 'interledger=debug',
+            'RUST_LOG': process.env.RUST_LOG || 'interledger=debug,ilp_settlement_ethereum=debug',
             'RUST_BACKTRACE': process.env.RUST_BACKTRACE || '1'
         },
         stdio: 'inherit'


### PR DESCRIPTION
Fix to use `ilp-settlement-ethereum` binary for the testnet-bundle docker image.
Also add settings to output logs of settlement-engines because it currently does not.

We should consider https://github.com/interledger-rs/settlement-engines/issues/23 later.