### PR TITLE
docs(config, codeowners): fixed to use ilp-settlement-ethereum insted of settlement-engines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
 *       @emschwartz
 
 # Settlement
-/crates/interledger-settlement-engines @gakonst @emschwartz
 /crates/interledger-settlement @gakonst @emschwartz
 
 # Examples and Docs

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To run the Interledger.rs components by themselves (rather than the `testnet-bun
 ```bash #
 docker pull interledgerrs/node
 docker pull interledgerrs/ilp-cli
-docker pull interledgerrs/settlement-engines
+docker pull interledgerrs/ilp-settlement-ethereum
 ```
 
 #### Run
@@ -48,8 +48,8 @@ docker run -it interledgerrs/node
 # This is a simple CLI for interacting with the node's HTTP API
 docker run -it --rm interledgerrs/ilp-cli
 
-# This includes the Settlement Engines written in Rust
-docker run -it interledgerrs/settlement-engines
+# This includes the Ethereum Settlement Engines written in Rust
+docker run -it interledgerrs/ilp-settlement-ethereum
 ```
 
 ### Building From Source

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 ## How to Specify Configurations
 
-Interledger.rs binaries such as `ilp-node` and `interledger-settlement-engines` accept configuration options in the following ways:
+Interledger.rs binaries such as `ilp-node` and `ilp-settlement-ethereum` accept configuration options in the following ways:
 
 ### Environment variables
 

--- a/docs/manual-config.md
+++ b/docs/manual-config.md
@@ -147,10 +147,14 @@ Note that we have to spin up a Redis which the settlement engine is going to con
 To spin up a Ethereum settlement engine,
 
 ```bash
+# This should be done outside of the interledger-rs directory, otherwise it will cause an error.
+git clone https://github.com/interledger-rs/settlement-engines
+cd settlement-engines
+
 mkdir -p logs
 redis-server --port 6380 &> logs/redis_se.log &
 
-cargo run --all-features --bin interledger-settlement-engines -- ethereum-ledger \
+cargo run --bin ilp-settlement-ethereum -- \
 --private_key "${SE_ETH_SECRET}" \
 --chain_id 4 \
 --confirmations 0 \


### PR DESCRIPTION
- Remove `interledger-settlement-engines` from CODEOWNERS
- Fix README to use the `ilp-settlement-ethereum` docker image
- Fix manual testnet config docs to use `ilp-settlement-ethereum`