### PR TITLE
fix(store): make uuid a non-optional dependency

### DIFF
--- a/crates/interledger-store/Cargo.toml
+++ b/crates/interledger-store/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 
 [features]
 default = ["redis"]
-redis = ["redis_crate", "uuid"]
+redis = ["redis_crate"]
 
 [lib]
 name = "interledger_store"
@@ -46,10 +46,10 @@ http = { version = "0.1.18", default-features = false }
 secrecy = { version = "0.5.0", default-features = false, features = ["serde", "bytes"] }
 zeroize = { version = "1.0.0", default-features = false, features = ["bytes"] }
 num-bigint = { version = "0.2.3", default-features = false, features = ["std"]}
+uuid = { version = "0.8.1", default-features = false, features = ["serde"] }
 
-# store-redis feature
+# redis feature
 redis_crate = { package = "redis", version = "0.13.0", default-features = false, features = ["executor"], optional = true }
-uuid = { version = "0.8.1", default-features = false, features = ["serde"], optional = true }
 
 [dev-dependencies]
 env_logger = { version = "0.7.0", default-features = false }

--- a/crates/interledger/Cargo.toml
+++ b/crates/interledger/Cargo.toml
@@ -49,7 +49,7 @@ interledger-service-util = { path = "../interledger-service-util", version = "^0
 interledger-settlement = { path = "../interledger-settlement", version = "^0.3.0", optional = true, default-features = false }
 interledger-spsp = { path = "../interledger-spsp", version = "^0.4.0", optional = true, default-features = false }
 interledger-stream = { path = "../interledger-stream", version = "^0.4.0", optional = true, default-features = false }
-interledger-store = { path = "../interledger-store", version = "^0.4.0", optional = true, default-features = false }
+interledger-store = { path = "../interledger-store", version = "^0.4.0", optional = true, default-features = false, features = ["redis"] }
 
 [badges]
 circle-ci = { repository = "interledger-rs/interledger-rs" }


### PR DESCRIPTION
uuid is no longer an optional dep since it's used in the Account struct in the store

Building from the root directory would work, but if you specified `--bin ilp-node` or tried to compile inside the `ilp-node` directory, It'd fail.