### PR TITLE
fix(redis): delete the STATIC_ROUTES when removing an account

### DIFF
--- a/crates/interledger-store/src/redis/mod.rs
+++ b/crates/interledger-store/src/redis/mod.rs
@@ -1358,6 +1358,13 @@ impl AddressStore for RedisStore {
                                 RedisAccountId(account.id()),
                             )
                             .ignore();
+
+                            pipe.hset(
+                                STATIC_ROUTES_KEY,
+                                new_ilp_address.as_bytes(),
+                                RedisAccountId(account.id()),
+                            )
+                            .ignore();
                         }
                     }
                     pipe.query_async(connection.clone())

--- a/crates/interledger-store/src/redis/mod.rs
+++ b/crates/interledger-store/src/redis/mod.rs
@@ -580,6 +580,9 @@ impl RedisStore {
             pipe.hdel(ROUTES_KEY, account.ilp_address.to_bytes().to_vec())
                 .ignore();
 
+            pipe.hdel(STATIC_ROUTES_KEY, account.ilp_address.to_bytes().to_vec())
+                .ignore();
+
             pipe.del(uncredited_amount_key(id));
 
             pipe.query_async(connection)
@@ -1319,8 +1322,10 @@ impl AddressStore for RedisStore {
                         if account.routing_relation() != RoutingRelation::Parent
                             && account.routing_relation() != RoutingRelation::Peer
                         {
-                            // remove the old route
+                            // remove the old route and static route (if exists)
                             pipe.hdel(ROUTES_KEY, &account.ilp_address as &str).ignore();
+                            pipe.hdel(STATIC_ROUTES_KEY, &account.ilp_address as &str)
+                                .ignore();
 
                             // if the username of the account ends with the
                             // node's address, we're already configured so no


### PR DESCRIPTION
Closes https://github.com/interledger-rs/interledger-rs/issues/534.

Other than that, the routes are all deleted properly inside https://github.com/interledger-rs/interledger-rs/blob/1381e173dd70803a84551c64891346ea0336b0dc/crates/interledger-store/src/redis/mod.rs#L560-L586