### PR TITLE
fix(exchange-rates-service): remove service provider aliases

### DIFF
--- a/crates/ilp-node/tests/redis/exchange_rates.rs
+++ b/crates/ilp-node/tests/redis/exchange_rates.rs
@@ -34,7 +34,7 @@ fn coincap() {
         "route_broadcast_interval": 200,
         "exchange_rate": {
             "poll_interval": 60000,
-            "provider": "CoinCap",
+            "provider": "coincap",
         },
     }))
     .unwrap();
@@ -112,7 +112,7 @@ fn cryptocompare() {
         "exchange_rate": {
             "poll_interval": 60000,
             "provider": {
-                "crypto_compare": api_key
+                "cryptocompare": api_key
             },
             "spread": 0.0,
         },

--- a/crates/interledger-service-util/src/exchange_rates_service.rs
+++ b/crates/interledger-service-util/src/exchange_rates_service.rs
@@ -212,10 +212,10 @@ pub enum ExchangeRateProvider {
     /// Use the [CoinCap] API.
     ///
     /// Note that when configured with YAML, this MUST be specified as
-    /// "CoinCap", not "coin_cap".
+    /// "CoinCap", not "coincap".
     ///
     /// [CoinCap]: https://coincap.io/
-    #[serde(alias = "coin_cap", alias = "coincap", alias = "Coincap")]
+    #[serde(alias = "coincap")]
     CoinCap,
     /// Use the [CryptoCompare] API. Note this service requires an
     /// API key (but the free tier supports 100,000 requests / month at the
@@ -225,11 +225,7 @@ pub enum ExchangeRateProvider {
     /// "CryptoCompare", not "crypto_compare".
     ///
     /// [CryptoCompare]: https://cryptocompare.com
-    #[serde(
-        alias = "crypto_compare",
-        alias = "cryptocompare",
-        alias = "Cryptocompare"
-    )]
+    #[serde(alias = "cryptocompare")]
     CryptoCompare(SecretString),
 }
 


### PR DESCRIPTION
Closes https://github.com/interledger-rs/interledger-rs/issues/485

IMO it makes more sense to keep things simple and allow only 1 intuitive format, rather than try to support multiple 