### PR TITLE
Revive LeftoversStore's AccountId associated type 

### DIFF
--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -45,6 +45,7 @@ use tokio::spawn;
 use tracing::{debug, debug_span, error, info};
 use tracing_futures::Instrument;
 use url::Url;
+use uuid::Uuid;
 use warp::{
     self,
     http::{Response, StatusCode},
@@ -298,7 +299,7 @@ impl InterledgerNode {
             + RouterStore<Account = Account>
             + RouteManagerStore<Account = Account>
             + RateLimitStore<Account = Account>
-            + LeftoversStore<AssetType = BigUint>
+            + LeftoversStore<AccountId = Uuid, AssetType = BigUint>
             + IdempotentStore
             + AccountStore<Account = Account>
             + Clone

--- a/crates/interledger-settlement/src/api/node_api.rs
+++ b/crates/interledger-settlement/src/api/node_api.rs
@@ -37,7 +37,7 @@ pub fn create_settlements_filter<S, O, A>(
     outgoing_handler: O,
 ) -> warp::filters::BoxedFilter<(impl warp::Reply,)>
 where
-    S: LeftoversStore<AssetType = BigUint>
+    S: LeftoversStore<AccountId = Uuid, AssetType = BigUint>
         + SettlementStore<Account = A>
         + IdempotentStore
         + AccountStore<Account = A>
@@ -152,7 +152,7 @@ fn do_receive_settlement<S, A>(
     idempotency_key: Option<String>,
 ) -> Box<dyn Future<Item = ApiResponse, Error = ApiError> + Send>
 where
-    S: LeftoversStore<AssetType = BigUint>
+    S: LeftoversStore<AccountId = Uuid, AssetType = BigUint>
         + SettlementStore<Account = A>
         + IdempotentStore
         + AccountStore<Account = A>

--- a/crates/interledger-settlement/src/api/test_helpers.rs
+++ b/crates/interledger-settlement/src/api/test_helpers.rs
@@ -182,6 +182,7 @@ impl AccountStore for TestStore {
 }
 
 impl LeftoversStore for TestStore {
+    type AccountId = Uuid;
     type AssetType = BigUint;
 
     fn save_uncredited_settlement_amount(

--- a/crates/interledger-settlement/src/core/backends_common/redis/mod.rs
+++ b/crates/interledger-settlement/src/core/backends_common/redis/mod.rs
@@ -218,6 +218,7 @@ impl FromRedisValue for AmountWithScale {
 }
 
 impl LeftoversStore for EngineRedisStore {
+    type AccountId = Uuid;
     type AssetType = BigUint;
 
     fn get_uncredited_settlement_amount(

--- a/crates/interledger-settlement/src/core/types.rs
+++ b/crates/interledger-settlement/src/core/types.rs
@@ -110,13 +110,14 @@ pub trait SettlementStore {
 }
 
 pub trait LeftoversStore {
+    type AccountId: ToString;
     type AssetType: ToString;
 
     /// Saves the leftover data
     fn save_uncredited_settlement_amount(
         &self,
         // The account id that for which there was a precision loss
-        account_id: Uuid,
+        account_id: Self::AccountId,
         // The amount for which precision loss occurred, along with their scale
         uncredited_settlement_amount: (Self::AssetType, u8),
     ) -> Box<dyn Future<Item = (), Error = ()> + Send>;
@@ -126,20 +127,20 @@ pub trait LeftoversStore {
     /// the new leftover value.
     fn load_uncredited_settlement_amount(
         &self,
-        account_id: Uuid,
+        account_id: Self::AccountId,
         local_scale: u8,
     ) -> Box<dyn Future<Item = Self::AssetType, Error = ()> + Send>;
 
     /// Clears any uncredited settlement amount associated with the account
     fn clear_uncredited_settlement_amount(
         &self,
-        account_id: Uuid,
+        account_id: Self::AccountId,
     ) -> Box<dyn Future<Item = (), Error = ()> + Send>;
 
     // Gets the current amount of leftovers in the store
     fn get_uncredited_settlement_amount(
         &self,
-        account_id: Uuid,
+        account_id: Self::AccountId,
     ) -> Box<dyn Future<Item = (Self::AssetType, u8), Error = ()> + Send>;
 }
 

--- a/crates/interledger-store/src/redis/mod.rs
+++ b/crates/interledger-store/src/redis/mod.rs
@@ -1871,6 +1871,7 @@ impl FromRedisValue for AmountWithScale {
 }
 
 impl LeftoversStore for RedisStore {
+    type AccountId = Uuid;
     type AssetType = BigUint;
 
     fn get_uncredited_settlement_amount(


### PR DESCRIPTION
As title.

This was removed in https://github.com/interledger-rs/interledger-rs/pull/535. However, the same trait gets consumed by the Settlement Engines. We should not enforce any limitations on the type account id's engine implementers want to use.