### PR TITLE
feat: SQLite database backend, foundation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,14 +33,14 @@ jobs:
           # do not run for more than 10 minutes under any circumstances
           # (We have had issues with bugs causing the tests to "run"
           # for 5 hours, wasting a ton of compute credits)
-          command: timeout 10m cargo test --all --all-features
+          command: timeout 10m cargo test --workspace --all-features
           environment:
             - RUST_LOG: "interledger=trace"
             - RUST_BACKTRACE: "full"
       - run:
           name: Check Style
           command: |
-            cargo fmt --all -- --check
+            cargo fmt -- --check
             cargo clippy --all-targets --all-features -- -D warnings
       - run:
           name: Audit Dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,14 +26,14 @@ jobs:
           command: printf "[profile.dev]\ncodegen-units = 1\n" >> Cargo.toml
       - run:
           name: Build
-          command: cargo build --all-features --all-targets
+          command: cargo build --features 'balance-tracking redis google-pubsub' --all-targets
       - run:
           name: Test
           # Note the timeout is included to make sure that they
           # do not run for more than 10 minutes under any circumstances
           # (We have had issues with bugs causing the tests to "run"
           # for 5 hours, wasting a ton of compute credits)
-          command: timeout 10m cargo test --workspace --all-features
+          command: timeout 10m cargo test --workspace --features 'balance-tracking redis google-pubsub'
           environment:
             - RUST_LOG: "interledger=trace"
             - RUST_BACKTRACE: "full"
@@ -41,7 +41,7 @@ jobs:
           name: Check Style
           command: |
             cargo fmt -- --check
-            cargo clippy --all-targets --all-features -- -D warnings
+            cargo clippy --all-targets --features 'balance-tracking redis google-pubsub' -- -D warnings
       - run:
           name: Audit Dependencies
           command: cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,6 +458,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "flate2"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1084,7 @@ dependencies = [
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1162,6 +1173,15 @@ version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,6 +1208,14 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1854,6 +1882,20 @@ dependencies = [
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "web-sys 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fallible-streaming-iterator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2949,6 +2991,8 @@ dependencies = [
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+"checksum fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+"checksum fallible-streaming-iterator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 "checksum flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ad3c5233c9a940c8719031b423d7e6c16af66e031cb0420b0896f5245bf181d3"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
@@ -2985,10 +3029,12 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
+"checksum libsqlite3-sys 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7a8223ba845dde334ce739a90b554ad3ce75f888b968cc93a11176cad2e58f2"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 "checksum matchers 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
@@ -3058,6 +3104,7 @@ dependencies = [
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)" = "2c2064233e442ce85c77231ebd67d9eca395207dec2127fe0bbedde4bd29a650"
 "checksum ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac"
+"checksum rusqlite 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "64a656821bb6317a84b257737b7934f79c0dbb7eb694710475908280ebad3e64"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"

--- a/crates/ilp-node/Cargo.toml
+++ b/crates/ilp-node/Cargo.toml
@@ -15,6 +15,7 @@ balance-tracking = []
 # records to Google Cloud PubSub. This may be removed in the future.
 google-pubsub = ["base64", "chrono", "parking_lot", "reqwest", "serde_json", "yup-oauth2"]
 redis = ["redis_crate", "interledger/redis"]
+sqlite = ["interledger/sqlite"]
 
 [[test]]
 name = "redis_tests"

--- a/crates/ilp-node/src/lib.rs
+++ b/crates/ilp-node/src/lib.rs
@@ -8,8 +8,7 @@ mod trace;
 mod google_pubsub;
 #[cfg(feature = "redis")]
 mod redis_store;
+#[cfg(feature = "sqlite")]
+mod sqlite_store;
 
 pub use node::*;
-#[allow(deprecated)]
-#[cfg(feature = "redis")]
-pub use redis_store::insert_account_with_redis_store;

--- a/crates/ilp-node/src/main.rs
+++ b/crates/ilp-node/src/main.rs
@@ -8,6 +8,8 @@ mod trace;
 mod google_pubsub;
 #[cfg(feature = "redis")]
 mod redis_store;
+#[cfg(feature = "sqlite")]
+mod sqlite_store;
 
 use clap::{crate_version, App, Arg, ArgMatches};
 use config::{Config, Source};
@@ -66,7 +68,7 @@ pub fn main() {
             .long("secret_seed")
             .takes_value(true)
             .required(true)
-            .help("Root secret used to derive encryption keys. This MUST NOT be changed after once you started up the node. You can generate a random secret by running `openssl rand -hex 32`"),
+            .help("Root secret used to derive encryption keys. This MUST NOT be changed once the node has been started. You can generate a random secret by running `openssl rand -hex 32`"),
         Arg::with_name("admin_auth_token")
             .long("admin_auth_token")
             .takes_value(true)
@@ -77,8 +79,8 @@ pub fn main() {
             // temporary alias for backwards compatibility
             .alias("redis_url")
             .takes_value(true)
-            .default_value("redis://127.0.0.1:6379")
-            .help("Redis URI (for example, \"redis://127.0.0.1:6379\" or \"unix:/tmp/redis.sock\")"),
+            .default_value(node::default_database_str())
+            .help(r#"Database URI (for example, "redis://127.0.0.1:6379" or "unix:/tmp/redis.sock")"#),
         Arg::with_name("http_bind_address")
             .long("http_bind_address")
             .takes_value(true)

--- a/crates/ilp-node/src/redis_store.rs
+++ b/crates/ilp-node/src/redis_store.rs
@@ -1,23 +1,13 @@
 #![cfg(feature = "redis")]
 
-use crate::node::InterledgerNode;
-use futures::{future::result, Future};
-pub use interledger::{
-    api::{AccountDetails, NodeStore},
-    packet::Address,
-    service::Account,
-    store::redis::RedisStoreBuilder,
-};
+use crate::node::{generate_database_secret, InterledgerNode};
+use futures::Future;
+use interledger::{packet::Address, store::redis::RedisStoreBuilder};
 pub use redis_crate::{ConnectionInfo, IntoConnectionInfo};
-use ring::hmac;
-use tracing::{debug, error};
-use uuid::Uuid;
+use tracing::error;
 
-static REDIS_SECRET_GENERATION_STRING: &str = "ilp_redis_secret";
-
-pub fn default_redis_url() -> String {
-    String::from("redis://127.0.0.1:6379")
-}
+pub const DEFAULT_REDIS_URL: &str = "redis://127.0.0.1:6379";
+const REDIS_SECRET_GENERATION_STRING: &str = "ilp_redis_secret";
 
 // This function could theoretically be defined as an inherent method on InterledgerNode itself.
 // However, we define it in this module in order to consolidate conditionally-compiled code
@@ -28,45 +18,10 @@ pub fn serve_redis_node(
 ) -> impl Future<Item = (), Error = ()> {
     let redis_connection_info = node.database_url.clone().into_connection_info().unwrap();
     let redis_addr = redis_connection_info.addr.clone();
-    let redis_secret = generate_redis_secret(&node.secret_seed);
+    let redis_secret = generate_database_secret(&node.secret_seed, REDIS_SECRET_GENERATION_STRING);
     Box::new(RedisStoreBuilder::new(redis_connection_info, redis_secret)
     .node_ilp_address(ilp_address.clone())
     .connect()
     .map_err(move |err| error!(target: "interledger-node", "Error connecting to Redis: {:?} {:?}", redis_addr, err))
     .and_then(move |store| node.chain_services(store, ilp_address)))
-}
-
-pub fn generate_redis_secret(secret_seed: &[u8; 32]) -> [u8; 32] {
-    let mut redis_secret: [u8; 32] = [0; 32];
-    let sig = hmac::sign(
-        &hmac::Key::new(hmac::HMAC_SHA256, secret_seed),
-        REDIS_SECRET_GENERATION_STRING.as_bytes(),
-    );
-    redis_secret.copy_from_slice(sig.as_ref());
-    redis_secret
-}
-
-#[doc(hidden)]
-#[allow(dead_code)]
-#[deprecated(note = "use HTTP API instead")]
-pub fn insert_account_with_redis_store(
-    node: &InterledgerNode,
-    account: AccountDetails,
-) -> impl Future<Item = Uuid, Error = ()> {
-    let redis_secret = generate_redis_secret(&node.secret_seed);
-    result(node.database_url.clone().into_connection_info())
-        .map_err(
-            |err| error!(target: "interledger-node", "Invalid Redis connection details: {:?}", err),
-        )
-        .and_then(move |redis_url| RedisStoreBuilder::new(redis_url, redis_secret).connect())
-        .map_err(|err| error!(target: "interledger-node", "Error connecting to Redis: {:?}", err))
-        .and_then(move |store| {
-            store
-                .insert_account(account)
-                .map_err(|_| error!(target: "interledger-node", "Unable to create account"))
-                .and_then(|account| {
-                    debug!(target: "interledger-node", "Created account: {}", account.id());
-                    Ok(account.id())
-                })
-        })
 }

--- a/crates/ilp-node/src/sqlite_store.rs
+++ b/crates/ilp-node/src/sqlite_store.rs
@@ -1,0 +1,26 @@
+#![cfg(feature = "sqlite")]
+
+use crate::node::{generate_database_secret, InterledgerNode};
+use futures::Future;
+use interledger::{packet::Address, store::sqlite::SqliteStoreBuilder};
+use tracing::error;
+
+pub const DEFAULT_SQLITE_URL: &str = "sqlite:ilp-node.sqlite3";
+const SQLITE_SECRET_GENERATION_STRING: &str = "ilp_sqlite_secret";
+
+// This function could theoretically be defined as an inherent method on InterledgerNode itself.
+// However, we define it in this module in order to consolidate conditionally-compiled code
+// into as few discrete units as possible.
+pub fn serve_sqlite_node(
+    node: InterledgerNode,
+    ilp_address: Address,
+) -> impl Future<Item = (), Error = ()> {
+    let sqlite_addr = node.database_url.clone();
+    let sqlite_secret =
+        generate_database_secret(&node.secret_seed, SQLITE_SECRET_GENERATION_STRING);
+    Box::new(SqliteStoreBuilder::new(node.database_url.clone(), sqlite_secret)
+    .node_ilp_address(ilp_address.clone())
+    .connect()
+    .map_err(move |err| error!(target: "interledger-node", "Error connecting to SQLite: {:?} {:?}", sqlite_addr, err))
+    .and_then(move |store| node.chain_services(store, ilp_address)))
+}

--- a/crates/interledger-store/Cargo.toml
+++ b/crates/interledger-store/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 [features]
 default = []
 redis = ["redis_crate"]
+sqlite = ["rusqlite"]
 
 [lib]
 name = "interledger_store"
@@ -50,6 +51,9 @@ uuid = { version = "0.8.1", default-features = false, features = ["serde"] }
 
 # redis feature
 redis_crate = { package = "redis", version = "0.13.0", default-features = false, features = ["executor"], optional = true }
+
+# sqlite feature
+rusqlite = { version = "0.21.0", default-features = false, optional = true }
 
 [dev-dependencies]
 env_logger = { version = "0.7.0", default-features = false }

--- a/crates/interledger-store/src/lib.rs
+++ b/crates/interledger-store/src/lib.rs
@@ -6,3 +6,5 @@ pub mod account;
 pub mod crypto;
 #[cfg(feature = "redis")]
 pub mod redis;
+#[cfg(feature = "sqlite")]
+pub mod sqlite;

--- a/crates/interledger-store/src/sqlite/mod.rs
+++ b/crates/interledger-store/src/sqlite/mod.rs
@@ -1,0 +1,506 @@
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+//! Data store for Interledger.rs using SQLite
+
+use super::account::{Account, AccountWithEncryptedTokens};
+use super::crypto::{encrypt_token, generate_keys, DecryptionKey, EncryptionKey};
+use bytes::Bytes;
+use futures::{
+    future::{err, ok, result, Either},
+    sync::mpsc::UnboundedSender,
+    Future, Stream,
+};
+use http::StatusCode;
+use interledger_api::{AccountDetails, AccountSettings, EncryptedAccountSettings, NodeStore};
+use interledger_btp::BtpStore;
+use interledger_ccp::{CcpRoutingAccount, RouteManagerStore, RoutingRelation};
+use interledger_http::HttpStore;
+use interledger_packet::Address;
+use interledger_router::RouterStore;
+use interledger_service::{Account as AccountTrait, AccountStore, AddressStore, Username};
+use interledger_service_util::{
+    BalanceStore, ExchangeRateStore, RateLimitError, RateLimitStore, DEFAULT_ROUND_TRIP_TIME,
+};
+use interledger_settlement::core::{
+    idempotency::{IdempotentData, IdempotentStore},
+    scale_with_precision_loss,
+    types::{Convert, ConvertDetails, LeftoversStore, SettlementStore},
+};
+use interledger_stream::{PaymentNotification, StreamNotificationsStore};
+use lazy_static::lazy_static;
+use log::{debug, error, trace, warn};
+use num_bigint::BigUint;
+use parking_lot::RwLock;
+use rusqlite::Connection;
+use secrecy::{ExposeSecret, Secret, SecretBytes};
+use serde::{Deserialize, Serialize};
+use serde_json;
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Display,
+};
+use std::{
+    iter::{self, FromIterator},
+    str,
+    str::FromStr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tokio_executor::spawn;
+use tokio_timer::Interval;
+use url::Url;
+use uuid::Uuid;
+use zeroize::Zeroize;
+
+/*const ACCOUNT_DETAILS_FIELDS: usize = 21;
+
+static PARENT_ILP_KEY: &str = "parent_node_account_address";
+static ROUTES_KEY: &str = "routes:current";
+static STATIC_ROUTES_KEY: &str = "routes:static";
+static DEFAULT_ROUTE_KEY: &str = "routes:default";
+static STREAM_NOTIFICATIONS_PREFIX: &str = "stream_notifications:";
+static SETTLEMENT_ENGINES_KEY: &str = "settlement_engines";
+
+fn uncredited_amount_key(account_id: impl ToString) -> String {
+    format!("uncredited-amount:{}", account_id.to_string())
+}
+
+fn prefixed_idempotency_key(idempotency_key: String) -> String {
+    format!("idempotency-key:{}", idempotency_key)
+}
+
+fn accounts_key(account_id: Uuid) -> String {
+    format!("accounts:{}", account_id)
+}*/
+
+lazy_static! {
+    static ref DEFAULT_ILP_ADDRESS: Address = Address::from_str("local.host").unwrap();
+}
+
+pub struct SqliteStoreBuilder {
+    sqlite_url: Url,
+    secret: [u8; 32],
+    //poll_interval: u64, // TODO: if this store is for single-node use cases, do we need to poll at all?
+    node_ilp_address: Address,
+}
+
+impl SqliteStoreBuilder {
+    pub fn new(sqlite_url: Url, secret: [u8; 32]) -> Self {
+        SqliteStoreBuilder {
+            sqlite_url,
+            secret,
+            node_ilp_address: DEFAULT_ILP_ADDRESS.clone(),
+        }
+    }
+
+    pub fn node_ilp_address(&mut self, node_ilp_address: Address) -> &mut Self {
+        self.node_ilp_address = node_ilp_address;
+        self
+    }
+
+    pub fn connect(&mut self) -> impl Future<Item = SqliteStore, Error = ()> {
+        let (encryption_key, decryption_key) = generate_keys(&self.secret[..]);
+        self.secret.zeroize(); // clear the secret after it has been used for key generation
+        let ilp_address = self.node_ilp_address.clone();
+        let sqlite_path = self.sqlite_url.path();
+        let store = SqliteStore {
+            ilp_address: Arc::new(RwLock::new(ilp_address)),
+            connection: SqliteConnection {
+                path: format!("file:{}?mode=memory&cache=shared", sqlite_path),
+            },
+            subscriptions: Arc::new(RwLock::new(HashMap::new())),
+            exchange_rates: Arc::new(RwLock::new(HashMap::new())),
+            routes: Arc::new(RwLock::new(Arc::new(HashMap::new()))),
+            encryption_key: Arc::new(encryption_key),
+            decryption_key: Arc::new(decryption_key),
+        };
+
+        // TODO: use parent address if found
+        // TODO: poll for routing table updates
+        // TODO: pub/sub listener for outgoing notifications over websockets
+        ok(store)
+    }
+}
+
+#[derive(Clone)]
+struct SqliteConnection {
+    path: String,
+}
+
+/*
+impl SqliteConnection {
+    // TODO: using a connection pool would prevent us from needing to create a new connection every time,
+    // but creating a cached connection to an in-memory store might be fast enough in practice?
+    fn get(&self) -> rusqlite::Result<Connection> {
+        Connection::open(&self.path)
+    }
+}
+*/
+
+/// A Store that uses SQLite as its underlying database.
+///
+/// This store leverages atomic SQLite transactions to do operations such as balance updates.
+///
+/// Currently the SQLiteStore polls the database for the routing table and rate updates, but
+/// future versions of it will use PubSub to subscribe to updates.
+#[derive(Clone)]
+pub struct SqliteStore {
+    ilp_address: Arc<RwLock<Address>>,
+    // TODO: use an async connection pool, none of which yet support rusqlite
+    connection: SqliteConnection,
+    subscriptions: Arc<RwLock<HashMap<Uuid, UnboundedSender<PaymentNotification>>>>,
+    exchange_rates: Arc<RwLock<HashMap<String, f64>>>,
+    /// The store keeps the routing table in memory so that it can be returned
+    /// synchronously while the Router is processing packets.
+    /// The outer `Arc<RwLock>` is used so that we can update the stored routing
+    /// table after polling the store for updates.
+    /// The inner `Arc<HashMap>` is used so that the `routing_table` method can
+    /// return a reference to the routing table without cloning the underlying data.
+    routes: Arc<RwLock<Arc<HashMap<String, Uuid>>>>,
+    encryption_key: Arc<Secret<EncryptionKey>>,
+    decryption_key: Arc<Secret<DecryptionKey>>,
+}
+
+impl SqliteStore {
+    // TODO: all of this
+}
+
+impl AccountStore for SqliteStore {
+    type Account = Account;
+
+    fn get_accounts(
+        &self,
+        account_ids: Vec<Uuid>,
+    ) -> Box<dyn Future<Item = Vec<Account>, Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn get_account_id_from_username(
+        &self,
+        username: &Username,
+    ) -> Box<dyn Future<Item = Uuid, Error = ()> + Send> {
+        unimplemented!()
+    }
+}
+
+impl StreamNotificationsStore for SqliteStore {
+    type Account = Account;
+
+    fn add_payment_notification_subscription(
+        &self,
+        id: Uuid,
+        sender: UnboundedSender<PaymentNotification>,
+    ) {
+        unimplemented!()
+    }
+
+    fn publish_payment_notification(&self, payment: PaymentNotification) {
+        unimplemented!()
+    }
+}
+
+impl BalanceStore for SqliteStore {
+    /// Returns the balance **from the account holder's perspective**, meaning the sum of
+    /// the Payable Balance and Pending Outgoing minus the Receivable Balance and the Pending Incoming.
+    fn get_balance(&self, account: Account) -> Box<dyn Future<Item = i64, Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn update_balances_for_prepare(
+        &self,
+        from_account: Account, // TODO: Make this take only the id
+        incoming_amount: u64,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn update_balances_for_fulfill(
+        &self,
+        to_account: Account, // TODO: Make this take only the id
+        outgoing_amount: u64,
+    ) -> Box<dyn Future<Item = (i64, u64), Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn update_balances_for_reject(
+        &self,
+        from_account: Account, // TODO: Make this take only the id
+        incoming_amount: u64,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        unimplemented!()
+    }
+}
+
+impl ExchangeRateStore for SqliteStore {
+    fn get_exchange_rates(&self, asset_codes: &[&str]) -> Result<Vec<f64>, ()> {
+        unimplemented!()
+    }
+
+    fn get_all_exchange_rates(&self) -> Result<HashMap<String, f64>, ()> {
+        unimplemented!()
+    }
+
+    fn set_exchange_rates(&self, rates: HashMap<String, f64>) -> Result<(), ()> {
+        unimplemented!()
+    }
+}
+
+impl BtpStore for SqliteStore {
+    type Account = Account;
+
+    fn get_account_from_btp_auth(
+        &self,
+        username: &Username,
+        token: &str,
+    ) -> Box<dyn Future<Item = Self::Account, Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn get_btp_outgoing_accounts(
+        &self,
+    ) -> Box<dyn Future<Item = Vec<Self::Account>, Error = ()> + Send> {
+        // TODO: non-stub implementation
+        Box::new(ok(Vec::new()))
+    }
+}
+
+impl HttpStore for SqliteStore {
+    type Account = Account;
+
+    /// Checks if the stored token for the provided account id matches the
+    /// provided token, and if so, returns the account associated with that token
+    fn get_account_from_http_auth(
+        &self,
+        username: &Username,
+        token: &str,
+    ) -> Box<dyn Future<Item = Self::Account, Error = ()> + Send> {
+        unimplemented!()
+    }
+}
+
+impl RouterStore for SqliteStore {
+    fn routing_table(&self) -> Arc<HashMap<String, Uuid>> {
+        unimplemented!()
+    }
+}
+
+impl NodeStore for SqliteStore {
+    type Account = Account;
+
+    fn insert_account(
+        &self,
+        account: AccountDetails,
+    ) -> Box<dyn Future<Item = Account, Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn delete_account(&self, id: Uuid) -> Box<dyn Future<Item = Account, Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn update_account(
+        &self,
+        id: Uuid,
+        account: AccountDetails,
+    ) -> Box<dyn Future<Item = Self::Account, Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn modify_account_settings(
+        &self,
+        id: Uuid,
+        settings: AccountSettings,
+    ) -> Box<dyn Future<Item = Self::Account, Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    // TODO limit the number of results and page through them
+    fn get_all_accounts(&self) -> Box<dyn Future<Item = Vec<Self::Account>, Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn set_static_routes<R>(&self, routes: R) -> Box<dyn Future<Item = (), Error = ()> + Send>
+    where
+        R: IntoIterator<Item = (String, Uuid)>,
+    {
+        unimplemented!()
+    }
+
+    fn set_static_route(
+        &self,
+        prefix: String,
+        account_id: Uuid,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn set_default_route(&self, account_id: Uuid) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn set_settlement_engines(
+        &self,
+        asset_to_url_map: impl IntoIterator<Item = (String, Url)>,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn get_asset_settlement_engine(
+        &self,
+        asset_code: &str,
+    ) -> Box<dyn Future<Item = Option<Url>, Error = ()> + Send> {
+        unimplemented!()
+    }
+}
+
+impl AddressStore for SqliteStore {
+    // Updates the ILP address of the store & iterates over all children and
+    // updates their ILP Address to match the new address.
+    fn set_ilp_address(
+        &self,
+        ilp_address: Address,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn clear_ilp_address(&self) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn get_ilp_address(&self) -> Address {
+        // read consumes the Arc<RwLock<T>> so we cannot return a reference
+        self.ilp_address.read().clone()
+    }
+}
+
+type RoutingTable<A> = HashMap<String, A>;
+
+impl RouteManagerStore for SqliteStore {
+    type Account = Account;
+
+    fn get_accounts_to_send_routes_to(
+        &self,
+        ignore_accounts: Vec<Uuid>,
+    ) -> Box<dyn Future<Item = Vec<Account>, Error = ()> + Send> {
+        // TODO: non-stub implementation
+        Box::new(ok(Vec::new()))
+    }
+
+    fn get_accounts_to_receive_routes_from(
+        &self,
+    ) -> Box<dyn Future<Item = Vec<Account>, Error = ()> + Send> {
+        // TODO: non-stub implementation
+        Box::new(ok(Vec::new()))
+    }
+
+    fn get_local_and_configured_routes(
+        &self,
+    ) -> Box<dyn Future<Item = (RoutingTable<Account>, RoutingTable<Account>), Error = ()> + Send>
+    {
+        // TODO: non-stub implementation
+        Box::new(ok((HashMap::new(), HashMap::new())))
+    }
+
+    fn set_routes(
+        &mut self,
+        routes: impl IntoIterator<Item = (String, Account)>,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        unimplemented!()
+    }
+}
+
+impl RateLimitStore for SqliteStore {
+    type Account = Account;
+
+    /// Apply rate limits for number of packets per minute and amount of money per minute
+    fn apply_rate_limits(
+        &self,
+        account: Account,
+        prepare_amount: u64,
+    ) -> Box<dyn Future<Item = (), Error = RateLimitError> + Send> {
+        unimplemented!()
+    }
+
+    fn refund_throughput_limit(
+        &self,
+        account: Account,
+        prepare_amount: u64,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        unimplemented!()
+    }
+}
+
+impl IdempotentStore for SqliteStore {
+    fn load_idempotent_data(
+        &self,
+        idempotency_key: String,
+    ) -> Box<dyn Future<Item = Option<IdempotentData>, Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn save_idempotent_data(
+        &self,
+        idempotency_key: String,
+        input_hash: [u8; 32],
+        status_code: StatusCode,
+        data: Bytes,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        unimplemented!()
+    }
+}
+
+impl SettlementStore for SqliteStore {
+    type Account = Account;
+
+    fn update_balance_for_incoming_settlement(
+        &self,
+        account_id: Uuid,
+        amount: u64,
+        idempotency_key: Option<String>,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn refund_settlement(
+        &self,
+        account_id: Uuid,
+        settle_amount: u64,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        unimplemented!()
+    }
+}
+
+impl LeftoversStore for SqliteStore {
+    type AccountId = Uuid;
+    type AssetType = BigUint;
+
+    fn get_uncredited_settlement_amount(
+        &self,
+        account_id: Self::AccountId,
+    ) -> Box<dyn Future<Item = (Self::AssetType, u8), Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn save_uncredited_settlement_amount(
+        &self,
+        account_id: Self::AccountId,
+        uncredited_settlement_amount: (Self::AssetType, u8),
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn load_uncredited_settlement_amount(
+        &self,
+        account_id: Self::AccountId,
+        local_scale: u8,
+    ) -> Box<dyn Future<Item = Self::AssetType, Error = ()> + Send> {
+        unimplemented!()
+    }
+
+    fn clear_uncredited_settlement_amount(
+        &self,
+        account_id: Self::AccountId,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        unimplemented!()
+    }
+}

--- a/crates/interledger/Cargo.toml
+++ b/crates/interledger/Cargo.toml
@@ -36,6 +36,7 @@ store = ["interledger-store"]
 stream = ["interledger-stream", "ildcp"]
 trace = ["interledger-service/trace"]
 redis = ["interledger-store/redis"]
+sqlite = ["interledger-store/sqlite"]
 
 [dependencies]
 interledger-api = { path = "../interledger-api", version = "^0.3.0", optional = true, default-features = false }
@@ -50,7 +51,7 @@ interledger-service-util = { path = "../interledger-service-util", version = "^0
 interledger-settlement = { path = "../interledger-settlement", version = "^0.3.0", optional = true, default-features = false }
 interledger-spsp = { path = "../interledger-spsp", version = "^0.4.0", optional = true, default-features = false }
 interledger-stream = { path = "../interledger-stream", version = "^0.4.0", optional = true, default-features = false }
-interledger-store = { path = "../interledger-store", version = "^0.4.0", optional = true, default-features = false, features = ["redis"] }
+interledger-store = { path = "../interledger-store", version = "^0.4.0", optional = true, default-features = false }
 
 [badges]
 circle-ci = { repository = "interledger-rs/interledger-rs" }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,13 +8,13 @@ COPY ./crates /usr/src/interledger-rs/crates
 
 # TODO: investigate using a method like https://whitfin.io/speeding-up-rust-docker-builds/
 # to ensure that the dependencies are cached so the build doesn't take as long
-# RUN cargo build --all-features --package ilp-node --package ilp-cli
-RUN cargo build --release --all-features --package ilp-node --package ilp-cli
+# RUN cargo build --features 'balance-tracking redis google-pubsub' --package ilp-node --package ilp-cli
+RUN cargo build --release --features 'balance-tracking redis google-pubsub' --package ilp-node --package ilp-cli
 
 WORKDIR /usr/src/
 RUN git clone https://github.com/interledger-rs/settlement-engines.git
 WORKDIR /usr/src/settlement-engines
-RUN cargo build --release --all-features --package ilp-settlement-ethereum
+RUN cargo build --release --features 'balance-tracking redis google-pubsub' --package ilp-settlement-ethereum
 
 FROM node:12-alpine
 

--- a/docker/ilp-cli.dockerfile
+++ b/docker/ilp-cli.dockerfile
@@ -8,8 +8,8 @@ COPY ./crates /usr/src/crates
 
 # TODO: investigate using a method like https://whitfin.io/speeding-up-rust-docker-builds/
 # to ensure that the dependencies are cached so the build doesn't take as long
-# RUN cargo build --all-features --package ilp-node --package interledger-settlement-engines --package ilp-cli
-RUN cargo build --release --all-features --package ilp-cli
+# RUN cargo build --features 'balance-tracking redis google-pubsub' --package ilp-node --package interledger-settlement-engines --package ilp-cli
+RUN cargo build --release --features 'balance-tracking redis google-pubsub' --package ilp-cli
 
 FROM alpine
 

--- a/docs/manual-config.md
+++ b/docs/manual-config.md
@@ -195,7 +195,7 @@ Then try:
 
 ```bash
 redis-server --port 6379 &> logs/redis.log &
-cargo run --all-features --bin ilp-node -- config.json &> logs/node.log &
+cargo run --features redis --bin ilp-node -- config.json &> logs/node.log &
 ```
 
 Now you have your own node running locally🎉


### PR DESCRIPTION
This commit adds the ability to run a server backed by an SqliteStore as
opposed to a RedisStore, although currently all the necessary Store
trait methods are doing the least amount of work necessary and all the
_un_necessary Store trait methods are simply stubbed out with
`unimplemented!()`. The result is that the running node is able to
successfully respond to the status endpoint, "GET /".

---

The SQLite store is going to involve a lot of code, so as I get it all ready I'm splitting it out into individual PRs to make it tractable to review. This first PR involves a few small additional changes made to ilp-node in order to better accommodate the new database. It also introduces the `interledger-store::sqlite` module, in which will live all the code in subsequent PRs.

The contents of this PR are largely straightforward, but there are some important things to discuss. In particular we need to confront two things:

1. Our driver's query API is synchronous, not async. The driver we're using is the most popular and well-developed SQLite driver in Rust, and in any case there aren't any SQLite drivers that I can find with async support. This problem is hopefully mitigated by the fact that, for the time being, the database itself is stored in-memory within our process rather than on-disk. Therefore reading and writing involves no file I/O, although synchronization is still capable of blocking the thread if multiple connections try to access the same tables. Which brings us to...
2. Unlike Redis, SQLite (the database software itself, not just our driver) doesn't allow the same connection to be shared among multiple threads. To quote [the docs](https://www.sqlite.org/threadsafe.html), "In [the mode we want to be using], SQLite can be safely used by multiple threads provided that no single database connection is used simultaneously in two or more threads." In Rust terms, this means that an SQLite connection is `Send` but not `Sync`. This is the sort of scenario that a connection pool would solve, and indeed for our driver (rusqlite) there exists an adapter for the popular r2d2 connection pool library. However, r2d2 is itself synchronous, not async; there exist async connection pools in Rust (e.g. bb8, deadpool), but as of right now neither of those have rusqlite adapters.

For expedience, for the time being my approaches to these problems are:

1. Ignore the synchronous aspect of the query API and hope that queries are fast enough and that the number of simultaneous tasks is low. Depending on the roles that we see each supported database backend playing, it may suffice to tell users in high-contention scenarios to use the redis backend for the time being. The alternative to this approach would be to add async support to rusqlite ourselves.
2. Open a new connection in each context that a connection is called for. This may not be as bad as it sounds, since (as noted previously), we're currently using an in-memory database rather than an on-disk database, which means that opening a new connection involves no file I/O. Furthermore, by leveraging SQLite's support for sharing caches among connections, we reduce the amount of work that is required each time a new connection is created. The alternative to this approach would be to add rusqlite support to an async connection pool, or else to fork rusqlite and replace the internal `Rc` in each `Connection` with a `Sync` type like `RwLock` (and I'm far from 100% sure that this latter approach is safe, depending on the invariants that SQLite demands).

(And in case you're wondering about the ramifications of using an in-memory database, it should be possible to both write the in-memory database to disk and to load an in-memory database from disk, although I have yet to try doing so.)

Progress towards #474.