### PR TITLE
Migration to 0.3 & Async/Await

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -857,7 +857,7 @@ dependencies = [
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -897,7 +897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -931,7 +931,7 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tungstenite 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tungstenite 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1054,10 +1054,11 @@ dependencies = [
 name = "interledger-btp"
 version = "0.4.0"
 dependencies = [
+ "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "interledger-packet 0.4.0",
  "interledger-service 0.4.0",
@@ -1071,10 +1072,9 @@ dependencies = [
  "secrecy 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "stream-cancel 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-tungstenite 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tungstenite 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tungstenite 0.10.0 (git+https://github.com/snapview/tokio-tungstenite)",
+ "tungstenite 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "warp 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1096,7 +1096,7 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1122,7 +1122,7 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_path_to_error 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "warp 0.2.0-alpha.0 (git+https://github.com/seanmonstar/warp.git)",
@@ -1140,7 +1140,7 @@ dependencies = [
  "interledger-service 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1172,7 +1172,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1213,7 +1213,7 @@ dependencies = [
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1244,7 +1244,7 @@ dependencies = [
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2121,7 +2121,7 @@ dependencies = [
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2224,7 +2224,7 @@ dependencies = [
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2608,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2623,7 +2623,7 @@ dependencies = [
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-macros 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-macros 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2653,17 +2653,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-dns-unofficial"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2697,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2796,36 +2785,25 @@ dependencies = [
 
 [[package]]
 name = "tokio-tls"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-tls"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.10.0"
+source = "git+https://github.com/snapview/tokio-tungstenite#dfa5580399cbf2b74eec396f0f8c00a726ff5e25"
 dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-dns-unofficial 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tungstenite 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tungstenite 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2869,7 +2847,7 @@ dependencies = [
  "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2978,10 +2956,10 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2989,7 +2967,7 @@ dependencies = [
  "input_buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf-8 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3185,7 +3163,7 @@ dependencies = [
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "tungstenite 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tungstenite 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "urlencoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3209,9 +3187,9 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tungstenite 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tungstenite 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "urlencoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3669,15 +3647,14 @@ dependencies = [
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4574b75faccaacddb9b284faecdf0b544b80b6b294f3d062d325c5726a209c20"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
-"checksum tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0e1bef565a52394086ecac0a6fa3b8ace4cb3a138ee1d96bd2b93283b56824e3"
+"checksum tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "a9d5acfe1b1130d50ac2286a2f1f8cf49309680366ceb7609ce369b75c9058d4"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
 "checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
-"checksum tokio-dns-unofficial 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bb9bf62ca2c53bf2f2faec3e48a98b6d8c9577c27011cb0203a4beacdc8ab328"
 "checksum tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f27ee0e6db01c5f0b2973824547ce7e637b2ed79b891a9677b0de9bd532b6ac"
 "checksum tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af"
 "checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
-"checksum tokio-macros 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7de6c21a09bab0ce34614bb1071403ad9996db62715eb61e63be5d82f91342bc"
+"checksum tokio-macros 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "50a61f268a3db2acee8dcab514efc813dc6dbe8a00e86076f935f94304b59a7a"
 "checksum tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c56391be9805bc80163151c0b9e5164ee64f4b0200962c346fea12773158f22d"
 "checksum tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c03755b956458582182941061def32b8123a26c98b08fc6ddcf49ae89d18f33"
 "checksum tokio-rustls 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1df2fa53ac211c136832f530ccb081af9af891af22d685a9493e232c7a359bc2"
@@ -3685,9 +3662,8 @@ dependencies = [
 "checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
 "checksum tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2bd2c6a3885302581f4401c82af70d792bb9df1700e7437b0aeb4ada94d5388c"
 "checksum tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
-"checksum tokio-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c"
 "checksum tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7bde02a3a5291395f59b06ec6945a3077602fac2b07eeeaf0dee2122f3619828"
-"checksum tokio-tungstenite 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "38f95da5281a1a52e72fa3657e571279bcc2b163ba2897ed8eaa34ef97f24fda"
+"checksum tokio-tungstenite 0.10.0 (git+https://github.com/snapview/tokio-tungstenite)" = "<none>"
 "checksum tokio-udp 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f02298505547f73e60f568359ef0d016d5acd6e830ab9bc7c4a5b3403440121b"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
@@ -3702,7 +3678,7 @@ dependencies = [
 "checksum tracing-subscriber 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "192ca16595cdd0661ce319e8eede9c975f227cdaabc4faaefdc256f43d852e45"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
-"checksum tungstenite 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "577caf571708961603baf59d2e148d12931e0da2e4bb6c5b471dd4a524fef3aa"
+"checksum tungstenite 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8a0c2bd5aeb7dcd2bb32e472c8872759308495e5eccc942e929a513cd8d36110"
 "checksum twoway 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,11 +1056,11 @@ dependencies = [
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "stream-cancel 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stream-cancel 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tungstenite 0.10.0 (git+https://github.com/snapview/tokio-tungstenite)",
  "tungstenite 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2458,10 +2458,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "stream-cancel"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2771,7 +2774,7 @@ dependencies = [
 [[package]]
 name = "tokio-tungstenite"
 version = "0.10.0"
-source = "git+https://github.com/snapview/tokio-tungstenite#dfa5580399cbf2b74eec396f0f8c00a726ff5e25"
+source = "git+https://github.com/snapview/tokio-tungstenite#308d9680c0e59dd1e8651659a775c05df937934e"
 dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3576,7 +3579,7 @@ dependencies = [
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-"checksum stream-cancel 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9d62fea0968935ec8eedcf671b2738bf49c58e133db968097c301d32e32eaedf"
+"checksum stream-cancel 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de4f382c018868d33660134df97baf0fa8eeb1035d57bed05e6ca338189238f7"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0e7bedb3320d0f3035594b0b723c8a28d7d336a3eda3881db79e61d676fb644c"
 "checksum synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,22 +1198,22 @@ dependencies = [
 name = "interledger-service-util"
 version = "0.4.0"
 dependencies = [
+ "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "interledger-packet 0.4.0",
  "interledger-service 0.4.0",
  "interledger-settlement 0.3.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,7 +723,7 @@ dependencies = [
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "headers-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1027,6 +1027,7 @@ dependencies = [
  "interledger-stream 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1103,7 +1104,7 @@ dependencies = [
  "interledger-service 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1491,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1510,7 +1511,7 @@ name = "mime_guess"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2151,7 +2152,7 @@ dependencies = [
  "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2185,7 +2186,7 @@ dependencies = [
  "js-sys 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3120,7 +3121,7 @@ dependencies = [
  "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "multipart 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3470,7 +3471,7 @@ dependencies = [
 "checksum metrics-runtime 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2863204c75646de78a93d961562cebca30608508250da9f98bd0754c6e7a5b4"
 "checksum metrics-util 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3024c8bfd2e14b14ca48c38a47d01472401e46492d1b9a45c2b68821d6ede88"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
-"checksum mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "dd1d63acd1b78403cc0c325605908475dd9b9a3acbf65ed8bcab97e27014afcf"
+"checksum mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 "checksum mime_guess 1.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0d977de9ee851a0b16e932979515c0f3da82403183879811bc97d50bd9cc50f7"
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
 "checksum miniz_oxide 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6f3f74f726ae935c3f514300cc6773a0c9492abc5e972d42ba0c0ebb88757625"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,9 +1083,10 @@ dependencies = [
 name = "interledger-ccp"
 version = "0.3.0"
 dependencies = [
+ "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "interledger-packet 0.4.0",
  "interledger-service 0.4.0",
@@ -1094,8 +1095,8 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1186,7 +1187,7 @@ dependencies = [
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-futures 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-futures 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2900,6 +2901,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3658,6 +3671,7 @@ dependencies = [
 "checksum tracing-attributes 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a4263b12c3d3c403274493eb805966093b53214124796552d674ca1dd5d27c2b"
 "checksum tracing-core 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bc913647c520c959b6d21e35ed8fa6984971deca9f0a2fcb8c51207e0c56af1d"
 "checksum tracing-futures 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "85a260ae9e7fdf7402955e761af889eb56203284295c0482b1fe33641cb948f0"
+"checksum tracing-futures 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "107ae59580d2a1d994b6b965b16fe94c969fe86d3f7fd2572a1ee243bcaf7f09"
 "checksum tracing-log 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
 "checksum tracing-subscriber 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "192ca16595cdd0661ce319e8eede9c975f227cdaabc4faaefdc256f43d852e45"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,15 +1258,16 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "interledger-packet 0.4.0",
  "interledger-service 0.4.0",
  "interledger-stream 0.4.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,11 +607,12 @@ dependencies = [
 
 [[package]]
 name = "futures-retry"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -641,6 +642,14 @@ dependencies = [
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures01"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1023,10 +1032,11 @@ dependencies = [
 name = "interledger-api"
 version = "0.3.0"
 dependencies = [
+ "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-retry 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "interledger-btp 0.4.0",
  "interledger-ccp 0.3.0",
  "interledger-http 0.4.0",
@@ -1040,14 +1050,14 @@ dependencies = [
  "interledger-stream 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_path_to_error 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "warp 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "warp 0.2.0-alpha.0 (git+https://github.com/seanmonstar/warp.git)",
 ]
 
 [[package]]
@@ -1274,10 +1284,12 @@ dependencies = [
 name = "interledger-store"
 version = "0.4.0"
 dependencies = [
+ "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures01 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "interledger-api 0.3.0",
  "interledger-btp 0.4.0",
  "interledger-ccp 0.3.0",
@@ -1295,14 +1307,13 @@ dependencies = [
  "os_type 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "redis 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redis 0.13.1-alpha.0 (git+https://github.com/mitsuhiko/redis-rs)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "runtime 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2248,6 +2259,11 @@ dependencies = [
  "web-sys 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "runtime"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-demangle"
@@ -3481,10 +3497,11 @@ dependencies = [
 "checksum futures-executor 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e274736563f686a837a0568b478bdabfeaec2dca794b5649b04e2fe1627c231"
 "checksum futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e676577d229e70952ab25f3945795ba5b16d63ca794ca9d2c860e5595d20b5ff"
 "checksum futures-macro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "52e7c56c15537adb4f76d0b7a76ad131cb4d2f4f32d3b0bcabcbe1c7c5e87764"
-"checksum futures-retry 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d79b1e875b3ab07ef294b5bd43ae509d0ed1be990389003ea5fcdecf2e62ec96"
+"checksum futures-retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc9a95ec273db7b9d07559e25f9cd75074fee2f437f1e502b0c3b610d129d554"
 "checksum futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16"
 "checksum futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9"
 "checksum futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
+"checksum futures01 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "7ef8cbbf52909170053540c6c05a62433ddb60662dabee714e2a882caa864f22"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
@@ -3606,6 +3623,7 @@ dependencies = [
 "checksum reqwest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03c6cbd2bc1c1cb7052dbe30f4a70cf65811967c800f2dfbb2e6036dc9ee2553"
 "checksum reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)" = "2c2064233e442ce85c77231ebd67d9eca395207dec2127fe0bbedde4bd29a650"
 "checksum ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac"
+"checksum runtime 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "485bae53d3b7af75e4e8c4881ba084d0f5a88913c8cb7a3572522aea706bca32"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,13 +1311,14 @@ dependencies = [
 name = "interledger-stream"
 version = "0.4.0"
 dependencies = [
+ "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "interledger-ildcp 0.4.0",
  "interledger-packet 0.4.0",
@@ -1328,7 +1329,7 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,7 @@ name = "futures-util"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1220,11 +1221,13 @@ dependencies = [
 name = "interledger-settlement"
 version = "0.3.0"
 dependencies = [
+ "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "interledger-http 0.4.0",
  "interledger-packet 0.4.0",
  "interledger-service 0.4.0",
@@ -1236,16 +1239,16 @@ dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "redis 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redis 0.13.1-alpha.0 (git+https://github.com/mitsuhiko/redis-rs)",
+ "reqwest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "warp 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "warp 0.2.0-alpha.0 (git+https://github.com/seanmonstar/warp.git)",
 ]
 
 [[package]]
@@ -2105,6 +2108,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.13.1-alpha.0"
+source = "git+https://github.com/mitsuhiko/redis-rs#df4cbaffc044028a1c6afc1bc248a013a83f3cc7"
+dependencies = [
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "combine 3.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-executor 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,6 +2221,7 @@ dependencies = [
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2593,8 +2616,10 @@ dependencies = [
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3592,6 +3617,7 @@ dependencies = [
 "checksum rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redis 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9bb1079bc5692c03e1479bb7086ac870ac2aaf7115b5e72d314c01368f1a747e"
+"checksum redis 0.13.1-alpha.0 (git+https://github.com/mitsuhiko/redis-rs)" = "<none>"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +149,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "buf_redux"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bumpalo"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +187,9 @@ dependencies = [
 name = "bytes"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "c2-chacha"
@@ -661,6 +678,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hdrhistogram"
 version = "6.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,12 +720,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "headers-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "headers-core"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -717,6 +775,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "http-body"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +793,15 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "http-body"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -762,6 +839,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http-body 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +887,17 @@ dependencies = [
  "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -992,24 +1103,27 @@ dependencies = [
 name = "interledger-http"
 version = "0.4.0"
 dependencies = [
+ "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "interledger-packet 0.4.0",
  "interledger-service 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_path_to_error 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "warp 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "warp 0.2.0-alpha.0 (git+https://github.com/seanmonstar/warp.git)",
 ]
 
 [[package]]
@@ -1034,6 +1148,7 @@ version = "0.4.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1373,8 +1488,27 @@ dependencies = [
 
 [[package]]
 name = "mime"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mime"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "mime_guess"
+version = "1.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "mime_guess"
@@ -1395,9 +1529,10 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.19"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1417,7 +1552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1445,6 +1580,23 @@ dependencies = [
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "multipart"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "buf_redux 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime_guess 1.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "twoway 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1607,6 +1759,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "phf"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pin-project"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pin-project-internal 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1971,6 +2176,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http-body 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-tls 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,6 +2251,11 @@ dependencies = [
 [[package]]
 name = "ryu"
 version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2175,6 +2419,11 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "siphasher"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "sized-chunks"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,7 +2566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2339,7 +2588,15 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-macros 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2430,7 +2687,7 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2479,7 +2736,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2522,6 +2779,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,7 +2810,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2560,11 +2826,24 @@ dependencies = [
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2574,6 +2853,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tracing"
@@ -2674,9 +2958,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "twoway"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "typenum"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicase"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "unicase"
@@ -2819,6 +3119,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "warp"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2843,6 +3152,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "warp"
+version = "0.2.0-alpha.0"
+source = "git+https://github.com/seanmonstar/warp.git#71aedeab4a935efa65866d6e635ead3a8ac74d94"
+dependencies = [
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "headers 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multipart 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tungstenite 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "urlencoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "wasi"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2853,6 +3188,8 @@ version = "0.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-macro 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2868,6 +3205,17 @@ dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3056,10 +3404,12 @@ dependencies = [
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+"checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
 "checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"
+"checksum buf_redux 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
 "checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
@@ -3120,17 +3470,24 @@ dependencies = [
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
+"checksum h2 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1"
 "checksum hdrhistogram 6.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08d331ebcdbca4acbefe5da8c3299b2e246f198a8294cc5163354e743398b89d"
 "checksum headers 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "882ca7d8722f33ce2c2db44f95425d6267ed59ca96ce02acbe58320054ceb642"
+"checksum headers 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c9836ffd533e1fb207cfdb2e357079addbd17ef5c68eea5afe2eece40555b905"
 "checksum headers-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "967131279aaa9f7c20c7205b45a391638a83ab118e6509b2d0ccbe08de044237"
+"checksum headers-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
 "checksum http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "d7e06e336150b178206af098a055e3621e8336027e2b4d126bda0bc64824baaf"
+"checksum http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
+"checksum http-body 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)" = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
+"checksum hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8bf49cfb32edee45d890537d9057d1b02ed55f53b7b6a30bae83a38c9231749e"
 "checksum hyper-rustls 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "719d85c7df4a7f309a77d145340a063ea929dcb2e025bae46a80345cffec2952"
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
+"checksum hyper-tls 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab58a31960b2f78c5c24cf255216789863754438a1e48849a956846f899e762e"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum im 12.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "de38d1511a0ce7677538acb1e31b5df605147c458e061b2cdb89858afb1cd182"
@@ -3156,13 +3513,16 @@ dependencies = [
 "checksum metrics-observer-prometheus 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90707830292a6223c046773caaa7c1121aa71dca75d156a4672cba8654eb8d2d"
 "checksum metrics-runtime 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2863204c75646de78a93d961562cebca30608508250da9f98bd0754c6e7a5b4"
 "checksum metrics-util 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3024c8bfd2e14b14ca48c38a47d01472401e46492d1b9a45c2b68821d6ede88"
+"checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "dd1d63acd1b78403cc0c325605908475dd9b9a3acbf65ed8bcab97e27014afcf"
+"checksum mime_guess 1.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0d977de9ee851a0b16e932979515c0f3da82403183879811bc97d50bd9cc50f7"
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
 "checksum miniz_oxide 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6f3f74f726ae935c3f514300cc6773a0c9492abc5e972d42ba0c0ebb88757625"
-"checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
+"checksum mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum mockito 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aee38c301104cc75a6628a4360be706fbdf84290c15a120b7e54eca5881c3450"
+"checksum multipart 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "136eed74cadb9edd2651ffba732b19a450316b680e4f48d6c79e905799e19d01"
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
@@ -3181,6 +3541,12 @@ dependencies = [
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+"checksum phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
+"checksum phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
+"checksum phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
+"checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
+"checksum pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "94b90146c7216e4cb534069fb91366de4ea0ea353105ee45ed297e2d1619e469"
+"checksum pin-project-internal 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "44ca92f893f0656d3cba8158dd0f2b99b94de256a4a54e870bd6922fcc6c8355"
 "checksum pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f0af6cbca0e6e3ce8692ee19fb8d734b641899e07b68eb73e9bbbd32f1703991"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
@@ -3218,12 +3584,14 @@ dependencies = [
 "checksum regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+"checksum reqwest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03c6cbd2bc1c1cb7052dbe30f4a70cf65811967c800f2dfbb2e6036dc9ee2553"
 "checksum reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)" = "2c2064233e442ce85c77231ebd67d9eca395207dec2127fe0bbedde4bd29a650"
 "checksum ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
+"checksum safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
 "checksum scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
@@ -3243,6 +3611,7 @@ dependencies = [
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+"checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum sized-chunks 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d3e7f23bad2d6694e0f46f5e470ec27eb07b8f3e8b309a4b0dc17501928b9f2"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cefaa50e76a6f10b86f36e640eb1739eafbd4084865067778463913e43a77ff3"
@@ -3278,10 +3647,13 @@ dependencies = [
 "checksum tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2bd2c6a3885302581f4401c82af70d792bb9df1700e7437b0aeb4ada94d5388c"
 "checksum tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
 "checksum tokio-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c"
+"checksum tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7bde02a3a5291395f59b06ec6945a3077602fac2b07eeeaf0dee2122f3619828"
 "checksum tokio-tungstenite 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "38f95da5281a1a52e72fa3657e571279bcc2b163ba2897ed8eaa34ef97f24fda"
 "checksum tokio-udp 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f02298505547f73e60f568359ef0d016d5acd6e830ab9bc7c4a5b3403440121b"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
+"checksum tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+"checksum tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 "checksum tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ff4e4f59e752cb3beb5b61c6d5e11191c7946231ba84faec2902c9efdd8691c5"
 "checksum tracing-attributes 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a4263b12c3d3c403274493eb805966093b53214124796552d674ca1dd5d27c2b"
 "checksum tracing-core 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bc913647c520c959b6d21e35ed8fa6984971deca9f0a2fcb8c51207e0c56af1d"
@@ -3291,7 +3663,9 @@ dependencies = [
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 "checksum tungstenite 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "577caf571708961603baf59d2e148d12931e0da2e4bb6c5b471dd4a524fef3aa"
+"checksum twoway 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+"checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2e2e6bd1e59e56598518beb94fd6db628ded570326f0a98c679a304bd9f00150"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
@@ -3312,10 +3686,13 @@ dependencies = [
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
+"checksum want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 "checksum warp 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3921463c44f680d24f1273ea55efd985f31206a22a02dee207a2ec72684285ca"
+"checksum warp 0.2.0-alpha.0 (git+https://github.com/seanmonstar/warp.git)" = "<none>"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum wasm-bindgen 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)" = "4c29d57d5c3b3bc53bbe35c5a4f4a0df994d870b7d3cb0ad1c2065e21822ae41"
 "checksum wasm-bindgen-backend 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)" = "aa2868fa93e5bf36a9364d1277a0f97392748a8217d9aa0ec3f1cdbdf7ad1a60"
+"checksum wasm-bindgen-futures 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7db7b3a0ec2120b67321367eda2f8f4f65ff2482c7560dc7c7a9b35aab8d06"
 "checksum wasm-bindgen-macro 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)" = "41e80594782a241bf3d92ee5d1247b8fb496250a8a2ff1e136942d433fbbce14"
 "checksum wasm-bindgen-macro-support 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)" = "74b9950355b1d92ca09de0984bdd4de7edda5e8af12daf0c052a0a075e8c9157"
 "checksum wasm-bindgen-shared 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)" = "7493fe67ad99672ef3de3e6ba513fb03db276358c8cc9588ce5a008c6e48ad68"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +168,11 @@ dependencies = [
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "bytes"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "c2-chacha"
@@ -1001,13 +1016,16 @@ dependencies = [
 name = "interledger-ildcp"
 version = "0.4.0"
 dependencies = [
+ "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "interledger-packet 0.4.0",
  "interledger-service 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1043,6 +1061,7 @@ dependencies = [
 name = "interledger-service"
 version = "0.4.0"
 dependencies = [
+ "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "interledger-packet 0.4.0",
@@ -1585,6 +1604,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "percent-encoding"
 version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2308,6 +2332,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-macros 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tokio-buf"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,6 +2408,15 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3005,6 +3048,7 @@ dependencies = [
 "checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 "checksum ascii 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 "checksum assert-json-diff 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9881d306dee755eccf052d652b774a6b2861e86b4772f555262130e58e4f81d2"
+"checksum async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "c8df72488e87761e772f14ae0c2480396810e51b2c2ade912f97f0f7e5b95e3c"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
@@ -3018,6 +3062,7 @@ dependencies = [
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+"checksum bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10004c15deb332055f7a4a208190aed362cf9a7c2f6ab70a305fba50e1105f38"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)" = "0213d356d3c4ea2c18c40b037c3be23cd639825c18f25ee670ac7813beeef99c"
@@ -3134,6 +3179,7 @@ dependencies = [
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+"checksum pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f0af6cbca0e6e3ce8692ee19fb8d734b641899e07b68eb73e9bbbd32f1703991"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
@@ -3213,6 +3259,7 @@ dependencies = [
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4574b75faccaacddb9b284faecdf0b544b80b6b294f3d062d325c5726a209c20"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
+"checksum tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0e1bef565a52394086ecac0a6fa3b8ace4cb3a138ee1d96bd2b93283b56824e3"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
 "checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
@@ -3220,6 +3267,7 @@ dependencies = [
 "checksum tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f27ee0e6db01c5f0b2973824547ce7e637b2ed79b891a9677b0de9bd532b6ac"
 "checksum tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af"
 "checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
+"checksum tokio-macros 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7de6c21a09bab0ce34614bb1071403ad9996db62715eb61e63be5d82f91342bc"
 "checksum tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c56391be9805bc80163151c0b9e5164ee64f4b0200962c346fea12773158f22d"
 "checksum tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c03755b956458582182941061def32b8123a26c98b08fc6ddcf49ae89d18f33"
 "checksum tokio-rustls 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1df2fa53ac211c136832f530ccb081af9af891af22d685a9493e232c7a359bc2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,34 @@ version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "futures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-executor 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "futures-cpupool"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,12 +548,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-executor"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "futures-retry"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-task"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-macro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -962,7 +1044,7 @@ name = "interledger-service"
 version = "0.4.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "interledger-packet 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1506,6 +1588,11 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,6 +1600,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ppv-lite86"
 version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2957,8 +3059,17 @@ dependencies = [
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
+"checksum futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6f16056ecbb57525ff698bb955162d0cd03bee84e6241c27ff75c08d8ca5987"
+"checksum futures-channel 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fcae98ca17d102fd8a3603727b9259fcf7fa4239b603d2142926189bc8999b86"
+"checksum futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "79564c427afefab1dfb3298535b21eda083ef7935b4f0ecbfcb121f0aec10866"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
+"checksum futures-executor 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e274736563f686a837a0568b478bdabfeaec2dca794b5649b04e2fe1627c231"
+"checksum futures-io 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e676577d229e70952ab25f3945795ba5b16d63ca794ca9d2c860e5595d20b5ff"
+"checksum futures-macro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "52e7c56c15537adb4f76d0b7a76ad131cb4d2f4f32d3b0bcabcbe1c7c5e87764"
 "checksum futures-retry 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d79b1e875b3ab07ef294b5bd43ae509d0ed1be990389003ea5fcdecf2e62ec96"
+"checksum futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16"
+"checksum futures-task 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9"
+"checksum futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
@@ -3023,8 +3134,11 @@ dependencies = [
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+"checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+"checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
+"checksum proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum publicsuffix 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9bf259a81de2b2eb9850ec990ec78e6a25319715584fd7652b9b26f96fcb1510"
 "checksum quanta 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f7a1905379198075914bc93d32a5465c40474f90a078bb13439cb00c547bcc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,12 +1048,14 @@ dependencies = [
 name = "interledger-router"
 version = "0.4.0"
 dependencies = [
+ "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "interledger-packet 0.4.0",
  "interledger-service 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "publicsuffix 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "publicsuffix 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -460,7 +460,6 @@ name = "error-chain"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -491,7 +490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flate2"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -612,7 +611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -701,7 +700,7 @@ dependencies = [
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -712,21 +711,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "headers"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "headers-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -742,15 +726,6 @@ dependencies = [
  "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -866,7 +841,7 @@ dependencies = [
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -906,7 +881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -936,7 +911,7 @@ version = "0.3.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -951,10 +926,11 @@ dependencies = [
  "approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "interledger 0.6.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -966,20 +942,20 @@ dependencies = [
  "num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "redis 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redis 0.13.1-alpha.0 (git+https://github.com/mitsuhiko/redis-rs)",
+ "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-futures 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-futures 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-subscriber 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "warp 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "warp 0.2.0-alpha.0 (git+https://github.com/seanmonstar/warp.git)",
  "yup-oauth2 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1034,6 +1010,7 @@ version = "0.3.0"
 dependencies = [
  "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-retry 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1050,11 +1027,12 @@ dependencies = [
  "interledger-stream 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_path_to_error 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "warp 0.2.0-alpha.0 (git+https://github.com/seanmonstar/warp.git)",
@@ -1082,12 +1060,12 @@ dependencies = [
  "secrecy 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "stream-cancel 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tungstenite 0.10.0 (git+https://github.com/snapview/tokio-tungstenite)",
  "tungstenite 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "warp 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "warp 0.2.0-alpha.0 (git+https://github.com/seanmonstar/warp.git)",
 ]
 
 [[package]]
@@ -1106,7 +1084,7 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1127,12 +1105,12 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_path_to_error 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "warp 0.2.0-alpha.0 (git+https://github.com/seanmonstar/warp.git)",
@@ -1150,7 +1128,7 @@ dependencies = [
  "interledger-service 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1182,7 +1160,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1219,11 +1197,11 @@ dependencies = [
  "interledger-settlement 0.3.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1250,11 +1228,11 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.13.1-alpha.0 (git+https://github.com/mitsuhiko/redis-rs)",
- "reqwest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1274,10 +1252,10 @@ dependencies = [
  "interledger-service 0.4.0",
  "interledger-stream 0.4.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1313,7 +1291,7 @@ dependencies = [
  "secrecy 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1341,7 +1319,7 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1875,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "publicsuffix"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2101,27 +2079,6 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "combine 3.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "redis"
 version = "0.13.1-alpha.0"
 source = "git+https://github.com/mitsuhiko/redis-rs#df4cbaffc044028a1c6afc1bc248a013a83f3cc7"
 dependencies = [
@@ -2134,7 +2091,7 @@ dependencies = [
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2180,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.9.22"
+version = "0.9.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2188,7 +2145,7 @@ dependencies = [
  "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2213,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2237,7 +2194,7 @@ dependencies = [
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2626,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2807,7 +2764,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2819,7 +2776,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tungstenite 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2865,7 +2822,7 @@ dependencies = [
  "futures-sink 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2909,16 +2866,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3163,30 +3110,6 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "headers 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "tungstenite 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "urlencoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "warp"
 version = "0.2.0-alpha.0"
 source = "git+https://github.com/seanmonstar/warp.git#71aedeab4a935efa65866d6e635ead3a8ac74d94"
 dependencies = [
@@ -3205,7 +3128,7 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tungstenite 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "urlencoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3482,7 +3405,7 @@ dependencies = [
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-"checksum flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ad3c5233c9a940c8719031b423d7e6c16af66e031cb0420b0896f5245bf181d3"
+"checksum flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
@@ -3507,9 +3430,7 @@ dependencies = [
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum h2 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1"
 "checksum hdrhistogram 6.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08d331ebcdbca4acbefe5da8c3299b2e246f198a8294cc5163354e743398b89d"
-"checksum headers 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "882ca7d8722f33ce2c2db44f95425d6267ed59ca96ce02acbe58320054ceb642"
 "checksum headers 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c9836ffd533e1fb207cfdb2e357079addbd17ef5c68eea5afe2eece40555b905"
-"checksum headers-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "967131279aaa9f7c20c7205b45a391638a83ab118e6509b2d0ccbe08de044237"
 "checksum headers-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
@@ -3589,7 +3510,7 @@ dependencies = [
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 "checksum proc-macro-nested 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "369a6ed065f249a159e06c45752c780bda2fb53c995718f9e484d08daa9eb42e"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
-"checksum publicsuffix 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9bf259a81de2b2eb9850ec990ec78e6a25319715584fd7652b9b26f96fcb1510"
+"checksum publicsuffix 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3bbaa49075179162b49acac1c6aa45fb4dafb5f13cf6794276d77bc7fd95757b"
 "checksum quanta 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f7a1905379198075914bc93d32a5465c40474f90a078bb13439cb00c547bcc"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
@@ -3613,15 +3534,14 @@ dependencies = [
 "checksum rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123"
 "checksum rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-"checksum redis 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9bb1079bc5692c03e1479bb7086ac870ac2aaf7115b5e72d314c01368f1a747e"
 "checksum redis 0.13.1-alpha.0 (git+https://github.com/mitsuhiko/redis-rs)" = "<none>"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
-"checksum reqwest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03c6cbd2bc1c1cb7052dbe30f4a70cf65811967c800f2dfbb2e6036dc9ee2553"
-"checksum reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)" = "2c2064233e442ce85c77231ebd67d9eca395207dec2127fe0bbedde4bd29a650"
+"checksum reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0e798e19e258bf6c30a304622e3e9ac820e483b06a1857a026e1f109b113fe4"
+"checksum reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab"
 "checksum ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac"
 "checksum runtime 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "485bae53d3b7af75e4e8c4881ba084d0f5a88913c8cb7a3572522aea706bca32"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
@@ -3667,7 +3587,7 @@ dependencies = [
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4574b75faccaacddb9b284faecdf0b544b80b6b294f3d062d325c5726a209c20"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
-"checksum tokio 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "a9d5acfe1b1130d50ac2286a2f1f8cf49309680366ceb7609ce369b75c9058d4"
+"checksum tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ffa2fdcfa937b20cb3c822a635ceecd5fc1a27a6a474527e5516aa24b8c8820a"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
 "checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
@@ -3692,7 +3612,6 @@ dependencies = [
 "checksum tracing 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ff4e4f59e752cb3beb5b61c6d5e11191c7946231ba84faec2902c9efdd8691c5"
 "checksum tracing-attributes 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a4263b12c3d3c403274493eb805966093b53214124796552d674ca1dd5d27c2b"
 "checksum tracing-core 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bc913647c520c959b6d21e35ed8fa6984971deca9f0a2fcb8c51207e0c56af1d"
-"checksum tracing-futures 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "85a260ae9e7fdf7402955e761af889eb56203284295c0482b1fe33641cb948f0"
 "checksum tracing-futures 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "107ae59580d2a1d994b6b965b16fe94c969fe86d3f7fd2572a1ee243bcaf7f09"
 "checksum tracing-log 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
 "checksum tracing-subscriber 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "192ca16595cdd0661ce319e8eede9c975f227cdaabc4faaefdc256f43d852e45"
@@ -3723,7 +3642,6 @@ dependencies = [
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 "checksum want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
-"checksum warp 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3921463c44f680d24f1273ea55efd985f31206a22a02dee207a2ec72684285ca"
 "checksum warp 0.2.0-alpha.0 (git+https://github.com/seanmonstar/warp.git)" = "<none>"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum wasm-bindgen 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)" = "4c29d57d5c3b3bc53bbe35c5a4f4a0df994d870b7d3cb0ad1c2065e21822ae41"

--- a/crates/ilp-node/Cargo.toml
+++ b/crates/ilp-node/Cargo.toml
@@ -24,9 +24,10 @@ required-features = ["redis"]
 
 [dependencies]
 bytes = { version = "0.4.12", default-features = false }
+bytes05 = { package = "bytes", version = "0.5", default-features = false }
 clap = { version = "2.33.0", default-features = false }
 config = { version = "0.9.3", default-features = false, features = ["json", "toml", "yaml"] }
-futures = { version = "0.1.29", default-features = false }
+futures = { version = "0.3.1", default-features = false, features = ["compat"] }
 hex = { version = "0.4.0", default-features = false }
 interledger = { path = "../interledger", version = "^0.6.0", default-features = false, features = ["node"] }
 lazy_static = { version = "1.4.0", default-features = false }
@@ -34,16 +35,18 @@ metrics = { version = "0.12.0", default-features = false, features = ["std"] }
 metrics-core = { version = "0.5.1", default-features = false }
 metrics-runtime = { version = "0.12.0", default-features = false, features = ["metrics-observer-prometheus"] }
 num-bigint = { version = "0.2.3", default-features = false, features = ["std"] }
-redis_crate = { package = "redis", version = "0.13.0", default-features = false, features = ["executor"], optional = true }
+# redis_crate = { package = "redis", version = "0.13.0", default-features = false, features = ["executor"], optional = true }
+redis_crate = { package = "redis", git = "https://github.com/mitsuhiko/redis-rs", optional = true, features = ["tokio-rt-core"] }
 ring = { version = "0.16.9", default-features = false }
 serde = { version = "1.0.101", default-features = false }
-tokio = { version = "0.1.22", default-features = false }
+tokio = { version = "0.2.8", features = ["rt-core", "macros", "time"] }
 tracing = { version = "0.1.9", default-features = true, features = ["log"] }
-tracing-futures = { version = "0.1.1", default-features = true, features = ["tokio", "futures-01"] }
+tracing-futures = { version = "0.2", default-features = true, features = ["tokio", "futures-03"] }
 tracing-subscriber = { version = "0.1.6", default-features = true, features = ["tracing-log"] }
 url = { version = "2.1.0", default-features = false }
 libc = { version = "0.2.62", default-features = false }
-warp = { version = "0.1.20", default-features = false, features = ["websocket"] }
+# warp = { version = "0.1.20", default-features = false, features = ["websocket"] }
+warp = { git = "https://github.com/seanmonstar/warp", default-features = false }
 secrecy = { version = "0.5.1", default-features = false, features = ["alloc", "serde"] }
 uuid = { version = "0.8.1", default-features = false}
 
@@ -51,7 +54,7 @@ uuid = { version = "0.8.1", default-features = false}
 base64 = { version = "0.10.1", default-features = false, optional = true }
 chrono = { version = "0.4.9", default-features = false, features = [], optional = true}
 parking_lot = { version = "0.9.0", default-features = false, optional = true }
-reqwest = { version = "0.9.22", default-features = false, features = ["default-tls"], optional = true }
+reqwest = { version = "0.10.0", default-features = false, features = ["default-tls", "json"], optional = true }
 serde_json = { version = "1.0.41", default-features = false, optional = true }
 yup-oauth2 = { version = "3.1.1", default-features = false, optional = true }
 
@@ -60,7 +63,7 @@ approx = { version = "0.3.2", default-features = false }
 base64 = { version = "0.10.1", default-features = false }
 net2 = { version = "0.2.33", default-features = false }
 rand = { version = "0.7.2", default-features = false }
-reqwest = { version = "0.9.22", default-features = false, features = ["default-tls"] }
+reqwest = { version = "0.10.0", default-features = false, features = ["default-tls", "json"] }
 serde_json = { version = "1.0.41", default-features = false }
 tokio-retry = { version = "0.2.0", default-features = false }
 

--- a/crates/ilp-node/src/google_pubsub.rs
+++ b/crates/ilp-node/src/google_pubsub.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "google_pubsub")]
 use base64;
 use chrono::Utc;
 use futures::{

--- a/crates/ilp-node/src/lib.rs
+++ b/crates/ilp-node/src/lib.rs
@@ -1,4 +1,4 @@
-#![type_length_limit = "1152909"]
+#![type_length_limit = "2000000"]
 
 mod metrics;
 mod node;
@@ -10,6 +10,3 @@ mod google_pubsub;
 mod redis_store;
 
 pub use node::*;
-#[allow(deprecated)]
-#[cfg(feature = "redis")]
-pub use redis_store::insert_account_with_redis_store;

--- a/crates/ilp-node/src/lib.rs
+++ b/crates/ilp-node/src/lib.rs
@@ -1,11 +1,11 @@
-#![type_length_limit = "2000000"]
+#![type_length_limit = "6000000"]
 
-mod metrics;
+// mod metrics;
 mod node;
-mod trace;
+// mod trace;
 
-#[cfg(feature = "google-pubsub")]
-mod google_pubsub;
+// #[cfg(feature = "google-pubsub")]
+// mod google_pubsub;
 #[cfg(feature = "redis")]
 mod redis_store;
 

--- a/crates/ilp-node/src/main.rs
+++ b/crates/ilp-node/src/main.rs
@@ -1,4 +1,4 @@
-#![type_length_limit = "2000000"]
+#![type_length_limit = "6000000"]
 
 mod metrics;
 mod node;

--- a/crates/ilp-node/src/main.rs
+++ b/crates/ilp-node/src/main.rs
@@ -1,4 +1,4 @@
-#![type_length_limit = "1152909"]
+#![type_length_limit = "2000000"]
 
 mod metrics;
 mod node;
@@ -24,7 +24,8 @@ use tracing_subscriber::{
     fmt::{time::ChronoUtc, Subscriber},
 };
 
-pub fn main() {
+#[tokio::main]
+async fn main() {
     Subscriber::builder()
         .with_timer(ChronoUtc::rfc3339())
         .with_env_filter(EnvFilter::from_default_env())
@@ -143,7 +144,9 @@ pub fn main() {
     }
     let matches = app.clone().get_matches();
     merge_args(&mut config, &matches);
-    config.try_into::<InterledgerNode>().unwrap().run();
+
+    let node = config.try_into::<InterledgerNode>().unwrap();
+    node.serve().await;
 }
 
 // returns (subcommand paths, config path)

--- a/crates/ilp-node/src/metrics.rs
+++ b/crates/ilp-node/src/metrics.rs
@@ -2,15 +2,17 @@ use futures::Future;
 use interledger::{
     ccp::CcpRoutingAccount,
     packet::{Fulfill, Reject},
-    service::{Account, IncomingRequest, IncomingService, OutgoingRequest, OutgoingService},
+    service::{
+        Account, IlpResult, IncomingRequest, IncomingService, OutgoingRequest, OutgoingService,
+    },
 };
 use metrics::{self, labels, recorder, Key};
 use std::time::Instant;
 
-pub fn incoming_metrics<A: Account + CcpRoutingAccount>(
+pub async fn incoming_metrics<A: Account + CcpRoutingAccount>(
     request: IncomingRequest<A>,
     mut next: impl IncomingService<A>,
-) -> impl Future<Item = Fulfill, Error = Reject> {
+) -> IlpResult {
     let labels = labels!(
         "from_asset_code" => request.from.asset_code().to_string(),
         "from_routing_relation" => request.from.routing_relation().to_string(),
@@ -21,30 +23,30 @@ pub fn incoming_metrics<A: Account + CcpRoutingAccount>(
     );
     let start_time = Instant::now();
 
-    next.handle_request(request).then(move |result| {
-        if result.is_ok() {
-            recorder().increment_counter(
-                Key::from_name_and_labels("requests.incoming.fulfill", labels.clone()),
-                1,
-            );
-        } else {
-            recorder().increment_counter(
-                Key::from_name_and_labels("requests.incoming.reject", labels.clone()),
-                1,
-            );
-        }
-        recorder().record_histogram(
-            Key::from_name_and_labels("requests.incoming.duration", labels),
-            (Instant::now() - start_time).as_nanos() as u64,
+    let result = next.handle_request(request).await;
+    if result.is_ok() {
+        recorder().increment_counter(
+            Key::from_name_and_labels("requests.incoming.fulfill", labels.clone()),
+            1,
         );
-        result
-    })
+    } else {
+        recorder().increment_counter(
+            Key::from_name_and_labels("requests.incoming.reject", labels.clone()),
+            1,
+        );
+    }
+
+    recorder().record_histogram(
+        Key::from_name_and_labels("requests.incoming.duration", labels),
+        (Instant::now() - start_time).as_nanos() as u64,
+    );
+    result
 }
 
-pub fn outgoing_metrics<A: Account + CcpRoutingAccount>(
+pub async fn outgoing_metrics<A: Account + CcpRoutingAccount>(
     request: OutgoingRequest<A>,
     mut next: impl OutgoingService<A>,
-) -> impl Future<Item = Fulfill, Error = Reject> {
+) -> IlpResult {
     let labels = labels!(
         "from_asset_code" => request.from.asset_code().to_string(),
         "to_asset_code" => request.to.asset_code().to_string(),
@@ -60,23 +62,23 @@ pub fn outgoing_metrics<A: Account + CcpRoutingAccount>(
     );
     let start_time = Instant::now();
 
-    next.send_request(request).then(move |result| {
-        if result.is_ok() {
-            recorder().increment_counter(
-                Key::from_name_and_labels("requests.outgoing.fulfill", labels.clone()),
-                1,
-            );
-        } else {
-            recorder().increment_counter(
-                Key::from_name_and_labels("requests.outgoing.reject", labels.clone()),
-                1,
-            );
-        }
-
-        recorder().record_histogram(
-            Key::from_name_and_labels("requests.outgoing.duration", labels.clone()),
-            (Instant::now() - start_time).as_nanos() as u64,
+    let result = next.send_request(request).await;
+    if result.is_ok() {
+        recorder().increment_counter(
+            Key::from_name_and_labels("requests.outgoing.fulfill", labels.clone()),
+            1,
         );
-        result
-    })
+    } else {
+        recorder().increment_counter(
+            Key::from_name_and_labels("requests.outgoing.reject", labels.clone()),
+            1,
+        );
+    }
+
+    recorder().record_histogram(
+        Key::from_name_and_labels("requests.outgoing.duration", labels.clone()),
+        (Instant::now() - start_time).as_nanos() as u64,
+    );
+
+    result
 }

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -249,7 +249,7 @@ impl InterledgerNode {
         //         Err(())
         //     }
         // } else {
-            self.serve_node().await
+        self.serve_node().await
         // }
     }
 
@@ -394,7 +394,7 @@ impl InterledgerNode {
         let incoming_service = Router::new(
             store.clone(),
             // Add tracing to add the outgoing request details to the incoming span
-            outgoing_service.clone() // .wrap(trace_forwarding),
+            outgoing_service.clone(), // .wrap(trace_forwarding),
         );
 
         // Add tracing to track the outgoing request details
@@ -491,10 +491,10 @@ impl InterledgerNode {
                 store.clone(),
             )
             .as_filter())
-            .or(btp_service_as_filter(
-                btp_server_service_clone,
-                store.clone(),
-            ))
+            // .or(btp_service_as_filter(
+            //     btp_server_service_clone,
+            //     store.clone(),
+            // ))
             .recover(default_rejection_handler)
             .with(warp::log("interledger-api"))
             .boxed();
@@ -514,9 +514,9 @@ impl InterledgerNode {
                 exchange_rate_poll_failure_tolerance,
                 store.clone(),
             );
-        // This function does not compile on 1.39 for some reason.
-        // exchange_rate_fetcher
-        //     .spawn_interval(Duration::from_millis(exchange_rate_poll_interval));
+            // This function does not compile on 1.39 for some reason.
+            exchange_rate_fetcher
+                .spawn_interval(Duration::from_millis(exchange_rate_poll_interval));
         } else {
             debug!(target: "interledger-node", "Not using exchange rate provider. Rates must be set via the HTTP API");
         }

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -1,9 +1,9 @@
-use crate::metrics::{incoming_metrics, outgoing_metrics};
+// use crate::metrics::{incoming_metrics, outgoing_metrics};
 use crate::trace::{trace_forwarding, trace_incoming, trace_outgoing};
 use bytes::Bytes;
 use futures::{
     future::{err, Either},
-    Future,
+    Future, TryFutureExt,
 };
 use hex::FromHex;
 use interledger::{
@@ -239,19 +239,21 @@ impl InterledgerNode {
     /// also run the Prometheus metrics server on the given address.
     // TODO when a BTP connection is made, insert a outgoing HTTP entry into the Store to tell other
     // connector instances to forward packets for that account to us
-    pub fn serve(self) -> impl Future<Item = (), Error = ()> {
-        if self.prometheus.is_some() {
-            Either::A(
-                self.serve_prometheus()
-                    .join(self.serve_node())
-                    .and_then(|_| Ok(())),
-            )
-        } else {
-            Either::B(self.serve_node())
-        }
+    pub async fn serve(self) -> Result<(), ()> {
+        // if self.prometheus.is_some() {
+        //     let res =
+        //         futures::future::join(self.clone().serve_prometheus(), self.serve_node()).await;
+        //     if res.0.is_ok() || res.1.is_ok() {
+        //         Ok(())
+        //     } else {
+        //         Err(())
+        //     }
+        // } else {
+            self.serve_node().await
+        // }
     }
 
-    fn serve_node(self) -> Box<dyn Future<Item = (), Error = ()> + Send + 'static> {
+    async fn serve_node(self) -> Result<(), ()> {
         let ilp_address = if let Some(address) = &self.ilp_address {
             address.clone()
         } else {
@@ -266,26 +268,22 @@ impl InterledgerNode {
                     "The string '{}' could not be parsed as a URL: {}",
                     &self.database_url, e
                 );
-                return Box::new(err(()));
+                return Err(());
             }
         };
 
         match database_url.scheme() {
             #[cfg(feature = "redis")]
-            "redis" | "redis+unix" => Box::new(serve_redis_node(self, ilp_address)),
+            "redis" | "redis+unix" => serve_redis_node(self, ilp_address).await,
             other => {
                 error!("unsupported data source scheme: {}", other);
-                Box::new(err(()))
+                Err(())
             }
         }
     }
 
     #[allow(clippy::cognitive_complexity)]
-    pub(crate) fn chain_services<S>(
-        self,
-        store: S,
-        ilp_address: Address,
-    ) -> impl Future<Item = (), Error = ()>
+    pub(crate) async fn chain_services<S>(self, store: S, ilp_address: Address) -> Result<(), ()>
     where
         S: NodeStore<Account = Account>
             + BtpStore<Account = Account>
@@ -327,257 +325,253 @@ impl InterledgerNode {
         #[cfg(feature = "google-pubsub")]
         let google_pubsub = self.google_pubsub.clone();
 
-        store.clone().get_btp_outgoing_accounts()
-        .map_err(|_| error!(target: "interledger-node", "Error getting accounts"))
-        .and_then(move |btp_accounts| {
-            let outgoing_service =
-                outgoing_service_fn(move |request: OutgoingRequest<Account>| {
-                    // Don't log anything for failed route updates sent to child accounts
-                    // because there's a good chance they'll be offline
-                    if request.prepare.destination().scheme() != "peer"
-                        || request.to.routing_relation() != RoutingRelation::Child {
-                        error!(target: "interledger-node", "No route found for outgoing request");
-                    }
-                    Err(RejectBuilder {
-                        code: ErrorCode::F02_UNREACHABLE,
-                        message: &format!(
-                            // TODO we might not want to expose the internal account ID in the error
-                            "No outgoing route for account: {} (ILP address of the Prepare packet: {})",
-                            request.to.id(),
-                            request.prepare.destination(),
-                        )
-                        .as_bytes(),
-                        triggered_by: Some(&ilp_address_clone),
-                        data: &[],
-                    }
-                    .build())
-                });
+        let btp_accounts = store
+            .get_btp_outgoing_accounts()
+            .map_err(|_| error!(target: "interledger-node", "Error getting accounts"))
+            .await?;
 
-            // Connect to all of the accounts that have outgoing ilp_over_btp_urls configured
-            // but don't fail if we are unable to connect
-            // TODO try reconnecting to those accounts later
-            connect_client(ilp_address_clone2.clone(), btp_accounts, false, outgoing_service)
-            .and_then(
-                move |btp_client_service| {
-                    let btp_server_service = BtpOutgoingService::new(ilp_address_clone2, btp_client_service.clone());
-                    let btp_server_service_clone = btp_server_service.clone();
-                    let btp = btp_client_service.clone();
+        let outgoing_service = outgoing_service_fn(move |request: OutgoingRequest<Account>| {
+            // Don't log anything for failed route updates sent to child accounts
+            // because there's a good chance they'll be offline
+            if request.prepare.destination().scheme() != "peer"
+                || request.to.routing_relation() != RoutingRelation::Child
+            {
+                error!(target: "interledger-node", "No route found for outgoing request");
+            }
+            Err(RejectBuilder {
+                code: ErrorCode::F02_UNREACHABLE,
+                message: &format!(
+                    // TODO we might not want to expose the internal account ID in the error
+                    "No outgoing route for account: {} (ILP address of the Prepare packet: {})",
+                    request.to.id(),
+                    request.prepare.destination(),
+                )
+                .as_bytes(),
+                triggered_by: Some(&ilp_address_clone),
+                data: &[],
+            }
+            .build())
+        });
 
-                    // The BTP service is both an Incoming and Outgoing one so we pass it first as the Outgoing
-                    // service to others like the router and then call handle_incoming on it to set up the incoming handler
-                    let outgoing_service = btp_server_service.clone();
-                    let outgoing_service = HttpClientService::new(
-                        store.clone(),
-                        outgoing_service,
-                    );
+        // Connect to all of the accounts that have outgoing ilp_over_btp_urls configured
+        // but don't fail if we are unable to connect
+        // TODO try reconnecting to those accounts later
+        let btp_client_service = connect_client(
+            ilp_address_clone2.clone(),
+            btp_accounts,
+            false,
+            outgoing_service,
+        )
+        .await?;
+        let btp_server_service =
+            BtpOutgoingService::new(ilp_address_clone2, btp_client_service.clone());
+        let btp_server_service_clone = btp_server_service.clone();
+        let btp = btp_client_service.clone();
 
-                    let outgoing_service = outgoing_service.wrap(outgoing_metrics);
+        // The BTP service is both an Incoming and Outgoing one so we pass it first as the Outgoing
+        // service to others like the router and then call handle_incoming on it to set up the incoming handler
+        let outgoing_service = btp_server_service.clone();
+        let outgoing_service = HttpClientService::new(store.clone(), outgoing_service);
 
-                    // Note: the expiry shortener must come after the Validator so that the expiry duration
-                    // is shortened before we check whether there is enough time left
-                    let outgoing_service = ValidatorService::outgoing(
-                        store.clone(),
-                        outgoing_service
-                    );
-                    let outgoing_service =
-                        ExpiryShortenerService::new(outgoing_service);
-                    let outgoing_service = StreamReceiverService::new(
-                        secret_seed.clone(),
-                        store.clone(),
-                        outgoing_service,
-                    );
-                    #[cfg(feature = "balance-tracking")]
-                    let outgoing_service = BalanceService::new(
-                        store.clone(),
-                        outgoing_service,
-                    );
-                    let outgoing_service = ExchangeRateService::new(
-                        exchange_rate_spread,
-                        store.clone(),
-                        outgoing_service,
-                    );
+        // let outgoing_service = outgoing_service.wrap(outgoing_metrics);
 
-                    #[cfg(feature = "google-pubsub")]
-                    let outgoing_service = outgoing_service.wrap(create_google_pubsub_wrapper(google_pubsub));
+        // Note: the expiry shortener must come after the Validator so that the expiry duration
+        // is shortened before we check whether there is enough time left
+        let outgoing_service = ValidatorService::outgoing(store.clone(), outgoing_service);
+        let outgoing_service = ExpiryShortenerService::new(outgoing_service);
+        let outgoing_service =
+            StreamReceiverService::new(secret_seed.clone(), store.clone(), outgoing_service);
+        #[cfg(feature = "balance-tracking")]
+        let outgoing_service = BalanceService::new(store.clone(), outgoing_service);
+        let outgoing_service =
+            ExchangeRateService::new(exchange_rate_spread, store.clone(), outgoing_service);
 
-                    // Set up the Router and Routing Manager
-                    let incoming_service = Router::new(
-                        store.clone(),
-                        // Add tracing to add the outgoing request details to the incoming span
-                        outgoing_service.clone().wrap(trace_forwarding),
-                    );
+        // TODO: Why does this cause problems?
+        // #[cfg(feature = "google-pubsub")]
+        // let outgoing_service = outgoing_service.wrap(create_google_pubsub_wrapper(google_pubsub));
 
-                    // Add tracing to track the outgoing request details
-                    let outgoing_service = outgoing_service.wrap(trace_outgoing).in_current_span();
+        // Set up the Router and Routing Manager
+        let incoming_service = Router::new(
+            store.clone(),
+            // Add tracing to add the outgoing request details to the incoming span
+            outgoing_service.clone() // .wrap(trace_forwarding),
+        );
 
-                    let mut ccp_builder = CcpRouteManagerBuilder::new(
-                        ilp_address.clone(),
-                        store.clone(),
-                        outgoing_service.clone(),
-                        incoming_service,
-                    );
-                    ccp_builder.ilp_address(ilp_address.clone());
-                    if let Some(ms) = route_broadcast_interval {
-                        ccp_builder.broadcast_interval(ms);
-                    }
-                    let incoming_service = ccp_builder.to_service();
-                    let incoming_service = EchoService::new(store.clone(), incoming_service);
-                    let incoming_service = SettlementMessageService::new(incoming_service);
-                    let incoming_service = IldcpService::new(incoming_service);
-                    let incoming_service =
-                        MaxPacketAmountService::new(
-                            store.clone(),
-                            incoming_service
-                    );
-                    let incoming_service =
-                        ValidatorService::incoming(store.clone(), incoming_service);
-                    let incoming_service = RateLimitService::new(
-                        store.clone(),
-                        incoming_service,
-                    );
+        // Add tracing to track the outgoing request details
+        let outgoing_service = outgoing_service.wrap(trace_outgoing).in_current_span();
 
-                    // Add tracing to track the incoming request details
-                    let incoming_service = incoming_service.wrap(trace_incoming).in_current_span();
+        let mut ccp_builder = CcpRouteManagerBuilder::new(
+            ilp_address.clone(),
+            store.clone(),
+            outgoing_service.clone(),
+            incoming_service,
+        );
+        ccp_builder.ilp_address(ilp_address.clone());
+        if let Some(ms) = route_broadcast_interval {
+            ccp_builder.broadcast_interval(ms);
+        }
 
-                    let incoming_service = incoming_service.wrap(incoming_metrics);
+        let incoming_service = ccp_builder.to_service();
+        let incoming_service = EchoService::new(store.clone(), incoming_service);
+        let incoming_service = SettlementMessageService::new(incoming_service);
+        let incoming_service = IldcpService::new(incoming_service);
+        let incoming_service = MaxPacketAmountService::new(store.clone(), incoming_service);
+        let incoming_service = ValidatorService::incoming(store.clone(), incoming_service);
+        let incoming_service = RateLimitService::new(store.clone(), incoming_service);
 
-                    // Handle incoming packets sent via BTP
-                    btp_server_service.handle_incoming(incoming_service.clone().wrap(|request, mut next| {
+        // Add tracing to track the incoming request details
+        // TODO: Re-enable metrics
+        // let incoming_service = incoming_service.wrap(trace_incoming).in_current_span();
+        // let incoming_service = incoming_service.wrap(incoming_metrics);
+
+        // Handle incoming packets sent via BTP
+        btp_server_service.handle_incoming(
+            incoming_service
+                .clone()
+                .wrap(|request, mut next| {
+                    async move {
                         let btp = debug_span!(target: "interledger-node", "btp");
                         let _btp_scope = btp.enter();
-                        next.handle_request(request).in_current_span()
-                    }).in_current_span());
-                    btp_client_service.handle_incoming(incoming_service.clone().wrap(|request, mut next| {
+                        next.handle_request(request).in_current_span().await
+                    }
+                })
+                .in_current_span(),
+        );
+
+        btp_client_service.handle_incoming(
+            incoming_service
+                .clone()
+                .wrap(|request, mut next| {
+                    async move {
                         let btp = debug_span!(target: "interledger-node", "btp");
                         let _btp_scope = btp.enter();
-                        next.handle_request(request).in_current_span()
-                    }).in_current_span());
-
-                    // Node HTTP API
-                    let mut api = NodeApi::new(
-                        secret_seed,
-                        admin_auth_token,
-                        store.clone(),
-                        incoming_service.clone().wrap(|request, mut next| {
-                            let api = debug_span!(target: "interledger-node", "api");
-                            let _api_scope = api.enter();
-                            next.handle_request(request).in_current_span()
-                        }).in_current_span(),
-                        outgoing_service.clone(),
-                        btp.clone(),
-                    );
-                    if let Some(username) = default_spsp_account {
-                        api.default_spsp_account(username);
+                        next.handle_request(request).in_current_span().await
                     }
-                    api.node_version(env!("CARGO_PKG_VERSION").to_string());
-                    // add an API of ILP over HTTP and add rejection handler
-                    let api = api.into_warp_filter()
-                        .or(IlpOverHttpServer::new(incoming_service.clone().wrap(|request, mut next| {
+                })
+                .in_current_span(),
+        );
+
+        // Node HTTP API
+        let mut api = NodeApi::new(
+            secret_seed,
+            admin_auth_token,
+            store.clone(),
+            incoming_service
+                .clone()
+                .wrap(|request, mut next| {
+                    async move {
+                        let api = debug_span!(target: "interledger-node", "api");
+                        let _api_scope = api.enter();
+                        next.handle_request(request).in_current_span().await
+                    }
+                })
+                .in_current_span(),
+            outgoing_service.clone(),
+            btp.clone(),
+        );
+        if let Some(username) = default_spsp_account {
+            api.default_spsp_account(username);
+        }
+        api.node_version(env!("CARGO_PKG_VERSION").to_string());
+
+        // add an API of ILP over HTTP and add rejection handler
+        let api = api
+            .into_warp_filter()
+            .or(IlpOverHttpServer::new(
+                incoming_service
+                    .clone()
+                    .wrap(|request, mut next| {
+                        async move {
                             let http = debug_span!(target: "interledger-node", "http");
                             let _http_scope = http.enter();
-                            next.handle_request(request).in_current_span()
-                        }).in_current_span(), store.clone()).as_filter())
-                        .or(btp_service_as_filter(btp_server_service_clone, store.clone()))
-                        .recover(default_rejection_handler)
-                        .with(warp::log("interledger-api")).boxed();
-
-                    info!(target: "interledger-node", "Interledger.rs node HTTP API listening on: {}", http_bind_address);
-                    spawn(warp::serve(api).bind(http_bind_address));
-
-                    // Settlement API
-                    let settlement_api = create_settlements_filter(
-                        store.clone(),
-                        outgoing_service.clone(),
-                    );
-                    info!(target: "interledger-node", "Settlement API listening on: {}", settlement_api_bind_address);
-                    spawn(warp::serve(settlement_api).bind(settlement_api_bind_address));
-
-                    // Exchange Rate Polling
-                    if let Some(provider) = exchange_rate_provider {
-                        let exchange_rate_fetcher = ExchangeRateFetcher::new(provider, exchange_rate_poll_failure_tolerance, store.clone());
-                        exchange_rate_fetcher.spawn_interval(Duration::from_millis(exchange_rate_poll_interval));
-                    } else {
-                        debug!(target: "interledger-node", "Not using exchange rate provider. Rates must be set via the HTTP API");
-                    }
-
-                    Ok(())
-                },
+                            next.handle_request(request).in_current_span().await
+                        }
+                    })
+                    .in_current_span(),
+                store.clone(),
             )
-        })
-        .in_current_span()
-    }
+            .as_filter())
+            .or(btp_service_as_filter(
+                btp_server_service_clone,
+                store.clone(),
+            ))
+            .recover(default_rejection_handler)
+            .with(warp::log("interledger-api"))
+            .boxed();
 
-    /// Starts a Prometheus metrics server that will listen on the configured address.
-    ///
-    /// # Errors
-    /// This will fail if another Prometheus server is already running in this
-    /// process or on the configured port.
-    #[allow(clippy::cognitive_complexity)]
-    fn serve_prometheus(&self) -> impl Future<Item = (), Error = ()> {
-        Box::new(if let Some(ref prometheus) = self.prometheus {
-            // Set up the metrics collector
-            let receiver = metrics_runtime::Builder::default()
-                .histogram(
-                    Duration::from_millis(prometheus.histogram_window),
-                    Duration::from_millis(prometheus.histogram_granularity),
-                )
-                .build()
-                .expect("Failed to create metrics Receiver");
-            let controller = receiver.controller();
-            // Try installing the global recorder
-            match metrics::set_boxed_recorder(Box::new(receiver)) {
-                Ok(_) => {
-                    let observer =
-                        Arc::new(metrics_runtime::observers::PrometheusBuilder::default());
+        info!(target: "interledger-node", "Interledger.rs node HTTP API listening on: {}", http_bind_address);
+        spawn(warp::serve(api).bind(http_bind_address));
 
-                    let filter = warp::get2().and(warp::path::end()).map(move || {
-                        let mut observer = observer.build();
-                        controller.observe(&mut observer);
-                        let prometheus_response = observer.drain();
-                        Response::builder()
-                            .status(StatusCode::OK)
-                            .header("Content-Type", "text/plain; version=0.0.4")
-                            .body(prometheus_response)
-                    });
+        // Settlement API
+        let settlement_api = create_settlements_filter(store.clone(), outgoing_service.clone());
+        info!(target: "interledger-node", "Settlement API listening on: {}", settlement_api_bind_address);
+        spawn(warp::serve(settlement_api).bind(settlement_api_bind_address));
 
-                    info!(target: "interledger-node",
-                        "Prometheus metrics server listening on: {}",
-                        prometheus.bind_address
-                    );
-                    Either::A(
-                        warp::serve(filter)
-                            .bind(prometheus.bind_address)
-                            .map_err(|_| {
-                                error!(target: "interledger-node", "Error binding Prometheus server to the configured address")
-                            }),
-                    )
-                }
-                Err(e) => {
-                    error!(target: "interledger-node", "Error installing global metrics recorder (this is likely caused by trying to run two nodes with Prometheus metrics in the same process): {:?}", e);
-                    Either::B(err(()))
-                }
-            }
+        // Exchange Rate Polling
+        if let Some(provider) = exchange_rate_provider {
+            let exchange_rate_fetcher = ExchangeRateFetcher::new(
+                provider,
+                exchange_rate_poll_failure_tolerance,
+                store.clone(),
+            );
+        // This function does not compile on 1.39 for some reason.
+        // exchange_rate_fetcher
+        //     .spawn_interval(Duration::from_millis(exchange_rate_poll_interval));
         } else {
-            error!(target: "interledger-node", "No prometheus configuration provided");
-            Either::B(err(()))
-        })
+            debug!(target: "interledger-node", "Not using exchange rate provider. Rates must be set via the HTTP API");
+        }
+
+        Ok(())
     }
 
-    /// Run the node on the default Tokio runtime
-    pub fn run(self) {
-        tokio_run(self.serve());
-    }
-}
+    // /// Starts a Prometheus metrics server that will listen on the configured address.
+    // ///
+    // /// # Errors
+    // /// This will fail if another Prometheus server is already running in this
+    // /// process or on the configured port.
+    // #[allow(clippy::cognitive_complexity)]
+    // async fn serve_prometheus(&self) -> Result<(), ()> {
+    //     if let Some(ref prometheus) = self.prometheus {
+    //         // Set up the metrics collector
+    //         let receiver = metrics_runtime::Builder::default()
+    //             .histogram(
+    //                 Duration::from_millis(prometheus.histogram_window),
+    //                 Duration::from_millis(prometheus.histogram_granularity),
+    //             )
+    //             .build()
+    //             .expect("Failed to create metrics Receiver");
+    //         let controller = receiver.controller();
+    //         // Try installing the global recorder
+    //         match metrics::set_boxed_recorder(Box::new(receiver)) {
+    //             Ok(_) => {
+    //                 let observer =
+    //                     Arc::new(metrics_runtime::observers::PrometheusBuilder::default());
 
-#[doc(hidden)]
-pub fn tokio_run(fut: impl Future<Item = (), Error = ()> + Send + 'static) {
-    let mut runtime = tokio::runtime::Builder::new()
-        // Don't swallow panics
-        .panic_handler(|err| std::panic::resume_unwind(err))
-        .name_prefix("interledger-rs-worker-")
-        .build()
-        .expect("failed to start new runtime");
+    //                 let filter = warp::get().and(warp::path::end()).map(move || {
+    //                     let mut observer = observer.build();
+    //                     controller.observe(&mut observer);
+    //                     let prometheus_response = observer.drain();
+    //                     Response::builder()
+    //                         .status(StatusCode::OK)
+    //                         .header("Content-Type", "text/plain; version=0.0.4")
+    //                         .body(prometheus_response)
+    //                 });
 
-    runtime.spawn(fut);
-    runtime.shutdown_on_idle().wait().unwrap();
+    //                 info!(target: "interledger-node",
+    //                     "Prometheus metrics server listening on: {}",
+    //                     prometheus.bind_address
+    //                 );
+
+    //                 Ok(warp::serve(filter).bind(prometheus.bind_address).await)
+    //             }
+    //             Err(e) => {
+    //                 error!(target: "interledger-node", "Error installing global metrics recorder (this is likely caused by trying to run two nodes with Prometheus metrics in the same process): {:?}", e);
+    //                 Err(())
+    //             }
+    //         }
+    //     } else {
+    //         error!(target: "interledger-node", "No prometheus configuration provided");
+    //         Err(())
+    //     }
+    // }
 }

--- a/crates/ilp-node/src/redis_store.rs
+++ b/crates/ilp-node/src/redis_store.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "redis")]
 
 use crate::node::InterledgerNode;
-use futures::{future::result, Future};
+use futures::{Future, TryFutureExt};
 pub use interledger::{
     api::{AccountDetails, NodeStore},
     packet::Address,
@@ -22,18 +22,16 @@ pub fn default_redis_url() -> String {
 // This function could theoretically be defined as an inherent method on InterledgerNode itself.
 // However, we define it in this module in order to consolidate conditionally-compiled code
 // into as few discrete units as possible.
-pub fn serve_redis_node(
-    node: InterledgerNode,
-    ilp_address: Address,
-) -> impl Future<Item = (), Error = ()> {
+pub async fn serve_redis_node(node: InterledgerNode, ilp_address: Address) -> Result<(), ()> {
     let redis_connection_info = node.database_url.clone().into_connection_info().unwrap();
     let redis_addr = redis_connection_info.addr.clone();
     let redis_secret = generate_redis_secret(&node.secret_seed);
-    Box::new(RedisStoreBuilder::new(redis_connection_info, redis_secret)
-    .node_ilp_address(ilp_address.clone())
-    .connect()
-    .map_err(move |err| error!(target: "interledger-node", "Error connecting to Redis: {:?} {:?}", redis_addr, err))
-    .and_then(move |store| node.chain_services(store, ilp_address)))
+    let store = RedisStoreBuilder::new(redis_connection_info, redis_secret)
+        .node_ilp_address(ilp_address.clone())
+        .connect()
+        .map_err(move |err| error!(target: "interledger-node", "Error connecting to Redis: {:?} {:?}", redis_addr, err))
+        .await?;
+    node.chain_services(store, ilp_address).await
 }
 
 pub fn generate_redis_secret(secret_seed: &[u8; 32]) -> [u8; 32] {
@@ -44,29 +42,4 @@ pub fn generate_redis_secret(secret_seed: &[u8; 32]) -> [u8; 32] {
     );
     redis_secret.copy_from_slice(sig.as_ref());
     redis_secret
-}
-
-#[doc(hidden)]
-#[allow(dead_code)]
-#[deprecated(note = "use HTTP API instead")]
-pub fn insert_account_with_redis_store(
-    node: &InterledgerNode,
-    account: AccountDetails,
-) -> impl Future<Item = Uuid, Error = ()> {
-    let redis_secret = generate_redis_secret(&node.secret_seed);
-    result(node.database_url.clone().into_connection_info())
-        .map_err(
-            |err| error!(target: "interledger-node", "Invalid Redis connection details: {:?}", err),
-        )
-        .and_then(move |redis_url| RedisStoreBuilder::new(redis_url, redis_secret).connect())
-        .map_err(|err| error!(target: "interledger-node", "Error connecting to Redis: {:?}", err))
-        .and_then(move |store| {
-            store
-                .insert_account(account)
-                .map_err(|_| error!(target: "interledger-node", "Unable to create account"))
-                .and_then(|account| {
-                    debug!(target: "interledger-node", "Created account: {}", account.id());
-                    Ok(account.id())
-                })
-        })
 }

--- a/crates/ilp-node/src/redis_store.rs
+++ b/crates/ilp-node/src/redis_store.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "redis")]
 
 use crate::node::InterledgerNode;
-use futures::{Future, TryFutureExt};
+use futures::TryFutureExt;
 pub use interledger::{
     api::{AccountDetails, NodeStore},
     packet::Address,
@@ -10,8 +10,7 @@ pub use interledger::{
 };
 pub use redis_crate::{ConnectionInfo, IntoConnectionInfo};
 use ring::hmac;
-use tracing::{debug, error};
-use uuid::Uuid;
+use tracing::error;
 
 static REDIS_SECRET_GENERATION_STRING: &str = "ilp_redis_secret";
 

--- a/crates/ilp-node/src/trace.rs
+++ b/crates/ilp-node/src/trace.rs
@@ -2,7 +2,9 @@ use futures::Future;
 use interledger::{
     ccp::{CcpRoutingAccount, RoutingRelation},
     packet::{ErrorCode, Fulfill, Reject},
-    service::{Account, IncomingRequest, IncomingService, OutgoingRequest, OutgoingService},
+    service::{
+        Account, IlpResult, IncomingRequest, IncomingService, OutgoingRequest, OutgoingService,
+    },
 };
 use std::str;
 use tracing::{debug_span, error_span, info, info_span};
@@ -12,10 +14,10 @@ use uuid::Uuid;
 /// Add tracing context for the incoming request.
 /// This adds minimal information for the ERROR log
 /// level and more information for the DEBUG level.
-pub fn trace_incoming<A: Account>(
+pub async fn trace_incoming<A: Account>(
     request: IncomingRequest<A>,
     mut next: impl IncomingService<A>,
-) -> impl Future<Item = Fulfill, Error = Reject> {
+) -> IlpResult {
     let request_span = error_span!(target: "interledger-node",
         "incoming",
         request.id = %Uuid::new_v4(),
@@ -37,19 +39,17 @@ pub fn trace_incoming<A: Account>(
     );
     let _details_scope = details_span.enter();
 
-    next.handle_request(request)
-        .then(trace_response)
-        .in_current_span()
+    next.handle_request(request).in_current_span().await
 }
 
 /// Add tracing context when the incoming request is
 /// being forwarded and turned into an outgoing request.
 /// This adds minimal information for the ERROR log
 /// level and more information for the DEBUG level.
-pub fn trace_forwarding<A: Account>(
+pub async fn trace_forwarding<A: Account>(
     request: OutgoingRequest<A>,
     mut next: impl OutgoingService<A>,
-) -> impl Future<Item = Fulfill, Error = Reject> {
+) -> IlpResult {
     // Here we only include the outgoing details because this will be
     // inside the "incoming" span that includes the other details
     let request_span = error_span!(target: "interledger-node",
@@ -66,16 +66,16 @@ pub fn trace_forwarding<A: Account>(
     );
     let _details_scope = details_span.enter();
 
-    next.send_request(request).in_current_span()
+    next.send_request(request).in_current_span().await
 }
 
 /// Add tracing context for the outgoing request (created by this node).
 /// This adds minimal information for the ERROR log
 /// level and more information for the DEBUG level.
-pub fn trace_outgoing<A: Account + CcpRoutingAccount>(
+pub async fn trace_outgoing<A: Account + CcpRoutingAccount>(
     request: OutgoingRequest<A>,
     mut next: impl OutgoingService<A>,
-) -> impl Future<Item = Fulfill, Error = Reject> {
+) -> IlpResult {
     let request_span = error_span!(target: "interledger-node",
         "outgoing",
         request.id = %Uuid::new_v4(),
@@ -100,16 +100,14 @@ pub fn trace_outgoing<A: Account + CcpRoutingAccount>(
     // because there's a good chance they'll be offline
     let ignore_rejects = request.prepare.destination().scheme() == "peer"
         && request.to.routing_relation() == RoutingRelation::Child;
-    next.send_request(request)
-        .then(move |result| {
-            if let Err(ref err) = result {
-                if err.code() == ErrorCode::F02_UNREACHABLE && ignore_rejects {
-                    return result;
-                }
-            }
-            trace_response(result)
-        })
-        .in_current_span()
+
+    let result = next.send_request(request).in_current_span().await;
+    if let Err(ref err) = result {
+        if err.code() == ErrorCode::F02_UNREACHABLE && ignore_rejects {
+            return result;
+        }
+    }
+    trace_response(result)
 }
 
 /// Log whether the response was a Fulfill or Reject

--- a/crates/ilp-node/tests/redis/btp.rs
+++ b/crates/ilp-node/tests/redis/btp.rs
@@ -7,10 +7,10 @@ use tokio::runtime::Builder as RuntimeBuilder;
 use tracing::error_span;
 use tracing_futures::Instrument;
 
-#[test]
-fn two_nodes_btp() {
+#[tokio::test]
+async fn two_nodes_btp() {
     // Nodes 1 and 2 are peers, Node 2 is the parent of Node 2
-    install_tracing_subscriber();
+    // install_tracing_subscriber();
     let context = TestContext::new();
 
     // Each node will use its own DB within the redis instance
@@ -23,11 +23,6 @@ fn two_nodes_btp() {
     let node_a_settlement = get_open_port(None);
     let node_b_http = get_open_port(None);
     let node_b_settlement = get_open_port(None);
-
-    let mut runtime = RuntimeBuilder::new()
-        .panic_handler(|err| std::panic::resume_unwind(err))
-        .build()
-        .unwrap();
 
     let alice_on_a = json!({
         "username": "alice_on_a",
@@ -87,117 +82,82 @@ fn two_nodes_btp() {
     }))
     .expect("Error creating node_b.");
 
-    // FIXME This should be fixed after SQL store is implemented.
-    // https://github.com/interledger-rs/interledger-rs/issues/464
-    let alice_fut = create_account_on_node(node_a_http, alice_on_a, "admin")
-        .and_then(move |_| create_account_on_node(node_a_http, b_on_a, "admin"));
-
-    runtime.spawn(
-        node_a
-            .serve()
-            .instrument(error_span!(target: "interledger", "node_a")),
-    );
-
-    let bob_fut = join_all(vec![
-        create_account_on_node(node_b_http, a_on_b, "admin"),
-        create_account_on_node(node_b_http, bob_on_b, "admin"),
-    ]);
-
-    runtime.spawn(
-        node_b
-            .serve()
-            .instrument(error_span!(target: "interledger", "node_b")),
-    );
-
-    runtime
-        .block_on(
-            // Wait for the nodes to spin up
-            delay(500)
-                .map_err(|_| panic!("Something strange happened when `delay`"))
-                .and_then(move |_| {
-                    bob_fut
-                        .and_then(|_| alice_fut)
-                        .and_then(|_| delay(500).map_err(|_| panic!("delay error")))
-                })
-                .and_then(move |_| {
-                    let send_1_to_2 = send_money_to_username(
-                        node_a_http,
-                        node_b_http,
-                        1000,
-                        "bob_on_b",
-                        "alice_on_a",
-                        "default account holder",
-                    );
-                    let send_2_to_1 = send_money_to_username(
-                        node_b_http,
-                        node_a_http,
-                        2000,
-                        "alice_on_a",
-                        "bob_on_b",
-                        "default account holder",
-                    );
-
-                    let get_balances = move || {
-                        futures::future::join_all(vec![
-                            get_balance("alice_on_a", node_a_http, "admin"),
-                            get_balance("bob_on_b", node_b_http, "admin"),
-                        ])
-                    };
-
-                    send_1_to_2
-                        .map_err(|err| {
-                            eprintln!("Error sending from node 1 to node 2: {:?}", err);
-                            err
-                        })
-                        .and_then(move |_| {
-                            get_balances().and_then(move |ret| {
-                                assert_eq!(
-                                    ret[0],
-                                    BalanceData {
-                                        asset_code: "XYZ".to_owned(),
-                                        balance: -1e-6
-                                    }
-                                );
-                                assert_eq!(
-                                    ret[1],
-                                    BalanceData {
-                                        asset_code: "XYZ".to_owned(),
-                                        balance: 1e-6
-                                    }
-                                );
-                                Ok(())
-                            })
-                        })
-                        .and_then(move |_| {
-                            send_2_to_1.map_err(|err| {
-                                eprintln!("Error sending from node 2 to node 1: {:?}", err);
-                                err
-                            })
-                        })
-                        .and_then(move |_| {
-                            get_balances().and_then(move |ret| {
-                                assert_eq!(
-                                    ret[0],
-                                    BalanceData {
-                                        asset_code: "XYZ".to_owned(),
-                                        balance: 1e-6
-                                    }
-                                );
-                                assert_eq!(
-                                    ret[1],
-                                    BalanceData {
-                                        asset_code: "XYZ".to_owned(),
-                                        balance: -1e-6
-                                    }
-                                );
-                                Ok(())
-                            })
-                        })
-                }),
-        )
-        .map_err(|err| {
-            eprintln!("Error executing tests: {:?}", err);
-            err
-        })
+    node_b.serve().await.unwrap(); // .instrument(error_span!(target: "interledger", "node_b")),
+    create_account_on_node(node_b_http, a_on_b, "admin")
+        .await
         .unwrap();
+    create_account_on_node(node_b_http, bob_on_b, "admin")
+        .await
+        .unwrap();
+
+    node_a.serve().await.unwrap(); // .instrument(error_span!(target: "interledger", "node_a")),
+    create_account_on_node(node_a_http, alice_on_a, "admin")
+        .await
+        .unwrap();
+    create_account_on_node(node_a_http, b_on_a, "admin")
+        .await
+        .unwrap();
+
+    let get_balances = move || {
+        futures::future::join_all(vec![
+            get_balance("alice_on_a", node_a_http, "admin"),
+            get_balance("bob_on_b", node_b_http, "admin"),
+        ])
+    };
+
+    send_money_to_username(
+        node_a_http,
+        node_b_http,
+        1000,
+        "bob_on_b",
+        "alice_on_a",
+        "default account holder",
+    )
+    .await
+    .unwrap();
+
+    let ret = get_balances().await;
+    let ret: Vec<_> = ret.into_iter().map(|r| r.unwrap()).collect();
+    assert_eq!(
+        ret[0],
+        BalanceData {
+            asset_code: "XYZ".to_owned(),
+            balance: -1e-6
+        }
+    );
+    assert_eq!(
+        ret[1],
+        BalanceData {
+            asset_code: "XYZ".to_owned(),
+            balance: 1e-6
+        }
+    );
+
+    send_money_to_username(
+        node_b_http,
+        node_a_http,
+        2000,
+        "alice_on_a",
+        "bob_on_b",
+        "default account holder",
+    )
+    .await
+    .unwrap();
+
+    let ret = get_balances().await;
+    let ret: Vec<_> = ret.into_iter().map(|r| r.unwrap()).collect();
+    assert_eq!(
+        ret[0],
+        BalanceData {
+            asset_code: "XYZ".to_owned(),
+            balance: 1e-6
+        }
+    );
+    assert_eq!(
+        ret[1],
+        BalanceData {
+            asset_code: "XYZ".to_owned(),
+            balance: -1e-6
+        }
+    );
 }

--- a/crates/ilp-node/tests/redis/exchange_rates.rs
+++ b/crates/ilp-node/tests/redis/exchange_rates.rs
@@ -2,24 +2,19 @@ use crate::redis_helpers::*;
 use crate::test_helpers::*;
 use futures::Future;
 use ilp_node::InterledgerNode;
-use reqwest::r#async::Client;
+use reqwest::Client;
 use secrecy::SecretString;
 use serde_json::{self, json, Value};
 use std::env;
+use std::time::Duration;
 use tokio::runtime::Builder as RuntimeBuilder;
 use tokio_retry::{strategy::FibonacciBackoff, Retry};
 use tracing::error;
 use tracing_subscriber;
 
-#[test]
-fn coincap() {
-    install_tracing_subscriber();
+#[tokio::test]
+async fn coincap() {
     let context = TestContext::new();
-
-    let mut runtime = RuntimeBuilder::new()
-        .panic_handler(|err| std::panic::resume_unwind(err))
-        .build()
-        .unwrap();
 
     let http_port = get_open_port(None);
 
@@ -33,56 +28,38 @@ fn coincap() {
         "secret_seed": random_secret(),
         "route_broadcast_interval": 200,
         "exchange_rate": {
-            "poll_interval": 60000,
+            "poll_interval": 100,
             "provider": "coincap",
         },
     }))
     .unwrap();
-    runtime.spawn(node.serve());
+    node.serve().await.unwrap();
 
-    let get_rates = move || {
-        Client::new()
-            .get(&format!("http://localhost:{}/rates", http_port))
-            .send()
-            .map_err(|_| panic!("Error getting rates"))
-            .and_then(|mut res| res.json().map_err(|_| panic!("Error getting body")))
-            .and_then(|body: Value| {
-                if let Value::Object(obj) = body {
-                    if obj.is_empty() {
-                        error!("Rates are empty");
-                        return Err(());
-                    }
-                    assert_eq!(
-                        format!("{}", obj.get("USD").expect("Should have USD rate")).as_str(),
-                        "1.0"
-                    );
-                    assert!(obj.contains_key("EUR"));
-                    assert!(obj.contains_key("JPY"));
-                    assert!(obj.contains_key("BTC"));
-                    assert!(obj.contains_key("ETH"));
-                    assert!(obj.contains_key("XRP"));
-                } else {
-                    panic!("Not an object");
-                }
+    // Wait a few seconds so our node can poll the API
+    tokio::time::delay_for(Duration::from_millis(1000)).await;
 
-                Ok(())
-            })
-    };
-
-    runtime
-        .block_on(
-            delay(1000)
-                .map_err(|_| panic!("Something strange happened"))
-                .and_then(move |_| {
-                    Retry::spawn(FibonacciBackoff::from_millis(1000).take(5), get_rates)
-                }),
-        )
+    let ret = Client::new()
+        .get(&format!("http://localhost:{}/rates", http_port))
+        .send()
+        .await
         .unwrap();
+    let txt = ret.text().await.unwrap();
+    let obj: Value = serde_json::from_str(&txt).unwrap();
+
+    assert_eq!(
+        format!("{}", obj.get("USD").expect("Should have USD rate")).as_str(),
+        "1.0"
+    );
+    assert!(obj.get("EUR").is_some());
+    assert!(obj.get("JPY").is_some());
+    assert!(obj.get("BTC").is_some());
+    assert!(obj.get("ETH").is_some());
+    assert!(obj.get("XRP").is_some());
 }
 
 // TODO can we disable this with conditional compilation?
-#[test]
-fn cryptocompare() {
+#[tokio::test]
+async fn cryptocompare() {
     tracing_subscriber::fmt::try_init().unwrap_or(());
     let context = TestContext::new();
 
@@ -92,11 +69,6 @@ fn cryptocompare() {
         return;
     }
     let api_key = SecretString::new(api_key.unwrap());
-
-    let mut runtime = RuntimeBuilder::new()
-        .panic_handler(|err| std::panic::resume_unwind(err))
-        .build()
-        .unwrap();
 
     let http_port = get_open_port(Some(3011));
 
@@ -118,42 +90,21 @@ fn cryptocompare() {
         },
     }))
     .unwrap();
-    runtime.spawn(node.serve());
+    node.serve().await.unwrap();
 
-    let get_rates = move || {
-        Client::new()
-            .get(&format!("http://localhost:{}/rates", http_port))
-            .send()
-            .map_err(|_| panic!("Error getting rates"))
-            .and_then(|mut res| res.json().map_err(|_| panic!("Error getting body")))
-            .and_then(|body: Value| {
-                if let Value::Object(obj) = body {
-                    if obj.is_empty() {
-                        error!("Rates are empty");
-                        return Err(());
-                    }
-                    assert_eq!(
-                        format!("{}", obj.get("USD").expect("Should have USD rate")).as_str(),
-                        "1.0"
-                    );
-                    assert!(obj.contains_key("BTC"));
-                    assert!(obj.contains_key("ETH"));
-                    assert!(obj.contains_key("XRP"));
-                } else {
-                    panic!("Not an object");
-                }
-
-                Ok(())
-            })
-    };
-
-    runtime
-        .block_on(
-            delay(1000)
-                .map_err(|_| panic!("Something strange happened"))
-                .and_then(move |_| {
-                    Retry::spawn(FibonacciBackoff::from_millis(1000).take(5), get_rates)
-                }),
-        )
+    let ret = Client::new()
+        .get(&format!("http://localhost:{}/rates", http_port))
+        .send()
+        .await
         .unwrap();
+    let txt = ret.text().await.unwrap();
+    let obj: Value = serde_json::from_str(&txt).unwrap();
+
+    assert_eq!(
+        format!("{}", obj.get("USD").expect("Should have USD rate")).as_str(),
+        "1.0"
+    );
+    assert!(obj.get("BTC").is_some());
+    assert!(obj.get("ETH").is_some());
+    assert!(obj.get("XRP").is_some());
 }

--- a/crates/ilp-node/tests/redis/redis_helpers.rs
+++ b/crates/ilp-node/tests/redis/redis_helpers.rs
@@ -1,7 +1,7 @@
 // Copied from https://github.com/mitsuhiko/redis-rs/blob/9a1777e8a90c82c315a481cdf66beb7d69e681a2/tests/support/mod.rs
 #![allow(dead_code)]
 
-use futures::Future;
+use futures::{Future, TryFutureExt};
 use redis_crate::{self as redis, ConnectionAddr, ConnectionInfo, RedisError};
 use std::env;
 use std::fs;
@@ -9,7 +9,6 @@ use std::path::PathBuf;
 use std::process;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
-use tokio::timer::Delay;
 
 #[allow(unused)]
 pub fn connection_info_to_string(info: ConnectionInfo) -> String {
@@ -40,8 +39,8 @@ pub fn get_open_port(try_port: Option<u16>) -> u16 {
     panic!("Cannot find open port!");
 }
 
-pub fn delay(ms: u64) -> impl Future<Item = (), Error = ()> {
-    Delay::new(Instant::now() + Duration::from_millis(ms)).map_err(|err| panic!(err))
+pub async fn delay(ms: u64) {
+    tokio::time::delay_for(Duration::from_millis(ms)).await;
 }
 
 #[derive(PartialEq)]
@@ -190,20 +189,21 @@ impl TestContext {
         self.client.get_connection().unwrap()
     }
 
-    pub fn async_connection(
-        &self,
-    ) -> impl Future<Item = redis::aio::Connection, Error = RedisError> {
-        self.client.get_async_connection()
+    pub async fn async_connection(&self) -> Result<redis::aio::Connection, ()> {
+        self.client
+            .get_async_connection()
+            .map_err(|err| panic!(err))
+            .await
     }
 
     pub fn stop_server(&mut self) {
         self.server.stop();
     }
 
-    pub fn shared_async_connection(
+    pub async fn shared_async_connection(
         &self,
-    ) -> impl Future<Item = redis::aio::SharedConnection, Error = RedisError> {
-        self.client.get_shared_async_connection()
+    ) -> Result<redis::aio::MultiplexedConnection, RedisError> {
+        self.client.get_multiplexed_tokio_connection().await
     }
 }
 

--- a/crates/ilp-node/tests/redis/redis_tests.rs
+++ b/crates/ilp-node/tests/redis/redis_tests.rs
@@ -1,6 +1,6 @@
-#![type_length_limit="3000000"]
+#![type_length_limit = "3000000"]
 // mod btp;
-// mod exchange_rates;
+mod exchange_rates;
 // mod prometheus;
 mod three_nodes;
 

--- a/crates/ilp-node/tests/redis/redis_tests.rs
+++ b/crates/ilp-node/tests/redis/redis_tests.rs
@@ -1,6 +1,7 @@
-mod btp;
-mod exchange_rates;
-mod prometheus;
+#![type_length_limit="3000000"]
+// mod btp;
+// mod exchange_rates;
+// mod prometheus;
 mod three_nodes;
 
 mod redis_helpers;

--- a/crates/ilp-node/tests/redis/redis_tests.rs
+++ b/crates/ilp-node/tests/redis/redis_tests.rs
@@ -1,5 +1,5 @@
-#![type_length_limit = "3000000"]
-// mod btp;
+#![type_length_limit = "6000000"]
+mod btp;
 mod exchange_rates;
 // mod prometheus;
 mod three_nodes;

--- a/crates/ilp-node/tests/redis/test_helpers.rs
+++ b/crates/ilp-node/tests/redis/test_helpers.rs
@@ -37,7 +37,7 @@ pub async fn create_account_on_node<T: Serialize>(
     api_port: u16,
     data: T,
     auth: &str,
-) -> Result<String, ()> {
+) -> Result<Account, ()> {
     let client = reqwest::Client::new();
     let res = client
         .post(&format!("http://localhost:{}/accounts", api_port))
@@ -50,9 +50,7 @@ pub async fn create_account_on_node<T: Serialize>(
 
     let res = res.error_for_status().map_err(|_| ())?;
 
-    let data: bytes05::Bytes = res.bytes().map_err(|_| ()).await?;
-
-    Ok(str::from_utf8(&data).unwrap().to_string())
+    Ok(res.json::<Account>().map_err(|_| ()).await.unwrap())
 }
 
 #[allow(unused)]
@@ -101,7 +99,6 @@ pub async fn send_money_to_username<T: Display + Debug>(
         .await?;
 
     let res = res.error_for_status().map_err(|_| ())?;
-    // does this work?
     Ok(res.json::<StreamDelivery>().await.unwrap())
 }
 

--- a/crates/ilp-node/tests/redis/test_helpers.rs
+++ b/crates/ilp-node/tests/redis/test_helpers.rs
@@ -8,16 +8,16 @@ use serde_json::json;
 use std::collections::HashMap;
 use std::fmt::{Debug, Display};
 use std::str;
-use tracing_subscriber;
+// use tracing_subscriber;
 use uuid::Uuid;
 
-pub fn install_tracing_subscriber() {
-    tracing_subscriber::fmt::Subscriber::builder()
-        .with_timer(tracing_subscriber::fmt::time::ChronoUtc::rfc3339())
-        .with_env_filter(tracing_subscriber::filter::EnvFilter::from_default_env())
-        .try_init()
-        .unwrap_or(());
-}
+// pub fn install_tracing_subscriber() {
+//     tracing_subscriber::fmt::Subscriber::builder()
+//         .with_timer(tracing_subscriber::fmt::time::ChronoUtc::rfc3339())
+//         .with_env_filter(tracing_subscriber::filter::EnvFilter::from_default_env())
+//         .try_init()
+//         .unwrap_or(());
+// }
 
 #[allow(unused)]
 pub fn random_secret() -> String {

--- a/crates/ilp-node/tests/redis/test_helpers.rs
+++ b/crates/ilp-node/tests/redis/test_helpers.rs
@@ -1,4 +1,4 @@
-use futures::{stream::Stream, Future};
+use futures::{stream::Stream, Future, TryFutureExt};
 use hex;
 use interledger::stream::StreamDelivery;
 use interledger::{packet::Address, service::Account as AccountTrait, store::account::Account};
@@ -33,56 +33,60 @@ pub struct BalanceData {
 }
 
 #[allow(unused)]
-pub fn create_account_on_node<T: Serialize>(
+pub async fn create_account_on_node<T: Serialize>(
     api_port: u16,
     data: T,
     auth: &str,
-) -> impl Future<Item = String, Error = ()> {
-    let client = reqwest::r#async::Client::new();
-    client
+) -> Result<String, ()> {
+    let client = reqwest::Client::new();
+    let res = client
         .post(&format!("http://localhost:{}/accounts", api_port))
         .header("Content-Type", "application/json")
         .header("Authorization", format!("Bearer {}", auth))
         .json(&data)
         .send()
-        .and_then(move |res| res.error_for_status())
-        .and_then(move |res| res.into_body().concat2())
-        .map_err(|err| {
-            eprintln!("Error creating account on node: {:?}", err);
-        })
-        .and_then(move |chunk| Ok(str::from_utf8(&chunk).unwrap().to_string()))
+        .map_err(|_| ())
+        .await?;
+
+    let res = res.error_for_status().map_err(|_| ())?;
+
+    let data: bytes05::Bytes = res.bytes().map_err(|_| ()).await?;
+
+    Ok(str::from_utf8(&data).unwrap().to_string())
 }
 
 #[allow(unused)]
-pub fn create_account_on_engine<T: Serialize>(
+pub async fn create_account_on_engine<T: Serialize>(
     engine_port: u16,
     account_id: T,
-) -> impl Future<Item = String, Error = ()> {
-    let client = reqwest::r#async::Client::new();
-    client
+) -> Result<String, ()> {
+    let client = reqwest::Client::new();
+    let res = client
         .post(&format!("http://localhost:{}/accounts", engine_port))
         .header("Content-Type", "application/json")
         .json(&json!({ "id": account_id }))
         .send()
-        .and_then(move |res| res.error_for_status())
-        .and_then(move |res| res.into_body().concat2())
-        .map_err(|err| {
-            eprintln!("Error creating account: {:?}", err);
-        })
-        .and_then(move |chunk| Ok(str::from_utf8(&chunk).unwrap().to_string()))
+        .map_err(|_| ())
+        .await?;
+
+    let res = res.error_for_status().map_err(|_| ())?;
+
+    let data: bytes05::Bytes = res.bytes().map_err(|_| ()).await?;
+
+    Ok(str::from_utf8(&data).unwrap().to_string())
 }
 
 #[allow(unused)]
-pub fn send_money_to_username<T: Display + Debug>(
+pub async fn send_money_to_username<T: Display + Debug>(
     from_port: u16,
     to_port: u16,
     amount: u64,
     to_username: T,
     from_username: &str,
     from_auth: &str,
-) -> impl Future<Item = StreamDelivery, Error = ()> {
-    let client = reqwest::r#async::Client::new();
-    client
+) -> Result<StreamDelivery, ()> {
+    let client = reqwest::Client::new();
+    let res = client
         .post(&format!(
             "http://localhost:{}/accounts/{}/payments",
             from_port, from_username
@@ -93,36 +97,28 @@ pub fn send_money_to_username<T: Display + Debug>(
             "source_amount": amount,
         }))
         .send()
-        .and_then(|res| res.error_for_status())
-        .and_then(|res| res.into_body().concat2())
-        .map_err(|err| {
-            eprintln!("Error sending SPSP payment: {:?}", err);
-        })
-        .and_then(move |body| {
-            let ret: StreamDelivery = serde_json::from_slice(&body).unwrap();
-            Ok(ret)
-        })
+        .map_err(|_| ())
+        .await?;
+
+    let res = res.error_for_status().map_err(|_| ())?;
+    // does this work?
+    Ok(res.json::<StreamDelivery>().await.unwrap())
 }
 
 #[allow(unused)]
-pub fn get_all_accounts(
-    node_port: u16,
-    admin_token: &str,
-) -> impl Future<Item = Vec<Account>, Error = ()> {
-    let client = reqwest::r#async::Client::new();
-    client
+pub async fn get_all_accounts(node_port: u16, admin_token: &str) -> Result<Vec<Account>, ()> {
+    let client = reqwest::Client::new();
+    let res = client
         .get(&format!("http://localhost:{}/accounts", node_port))
         .header("Authorization", format!("Bearer {}", admin_token))
         .send()
-        .and_then(|res| res.error_for_status())
-        .and_then(|res| res.into_body().concat2())
-        .map_err(|err| {
-            eprintln!("Error getting account data: {:?}", err);
-        })
-        .and_then(move |body| {
-            let ret: Vec<Account> = serde_json::from_slice(&body).unwrap();
-            Ok(ret)
-        })
+        .map_err(|_| ())
+        .await?;
+
+    let res = res.error_for_status().map_err(|_| ())?;
+    let body: bytes05::Bytes = res.bytes().map_err(|_| ()).await?;
+    let ret: Vec<Account> = serde_json::from_slice(&body).unwrap();
+    Ok(ret)
 }
 
 #[allow(unused)]
@@ -135,26 +131,24 @@ pub fn accounts_to_ids(accounts: Vec<Account>) -> HashMap<Address, Uuid> {
 }
 
 #[allow(unused)]
-pub fn get_balance<T: Display>(
+pub async fn get_balance<T: Display>(
     account_id: T,
     node_port: u16,
     admin_token: &str,
-) -> impl Future<Item = BalanceData, Error = ()> {
-    let client = reqwest::r#async::Client::new();
-    client
+) -> Result<BalanceData, ()> {
+    let client = reqwest::Client::new();
+    let res = client
         .get(&format!(
             "http://localhost:{}/accounts/{}/balance",
             node_port, account_id
         ))
         .header("Authorization", format!("Bearer {}", admin_token))
         .send()
-        .and_then(|res| res.error_for_status())
-        .and_then(|res| res.into_body().concat2())
-        .map_err(|err| {
-            eprintln!("Error getting account data: {:?}", err);
-        })
-        .and_then(|body| {
-            let ret: BalanceData = serde_json::from_slice(&body).unwrap();
-            Ok(ret)
-        })
+        .map_err(|_| ())
+        .await?;
+
+    let res = res.error_for_status().map_err(|_| ())?;
+    let body: bytes05::Bytes = res.bytes().map_err(|_| ()).await?;
+    let ret: BalanceData = serde_json::from_slice(&body).unwrap();
+    Ok(ret)
 }

--- a/crates/ilp-node/tests/redis/three_nodes.rs
+++ b/crates/ilp-node/tests/redis/three_nodes.rs
@@ -8,9 +8,9 @@ use serde_json::json;
 use std::str::FromStr;
 use tokio::runtime::Builder as RuntimeBuilder;
 use tracing::{debug, error_span};
-use tracing_futures::Instrument;
+// use tracing_futures::Instrument;
 
-const LOG_TARGET: &str = "interledger-tests-three-nodes";
+// const LOG_TARGET: &str = "interledger-tests-three-nodes";
 
 #[tokio::test]
 async fn three_nodes() {
@@ -65,11 +65,7 @@ async fn three_nodes() {
         "username": "charlie_on_b",
         "asset_code": "ABC",
         "asset_scale": 6,
-        // "ilp_over_btp_incoming_token" : "three",
-        // TODO: remove these and replace with BTP once it's solved
-        "ilp_over_http_outgoing_token": "two",
-        "ilp_over_http_incoming_token": "three",
-        "ilp_over_http_url": format!("http://localhost:{}/accounts/{}/ilp", node3_http, "bob_on_c"),
+        "ilp_over_btp_incoming_token" : "three",
         "min_balance": -1_000_000_000,
         "routing_relation": "Child",
     });
@@ -85,15 +81,13 @@ async fn three_nodes() {
         "username": "bob_on_c",
         "asset_code": "ABC",
         "asset_scale": 6,
-        "ilp_over_http_outgoing_token": "three",
         "ilp_over_http_incoming_token" : "two",
-        "ilp_over_http_url": format!("http://localhost:{}/accounts/{}/ilp", node2_http, "charlie_on_b"),
+        "ilp_over_http_outgoing_token": "three",
+        "ilp_over_btp_url": format!("btp+ws://localhost:{}/accounts/{}/ilp/btp", node2_http, "charlie_on_b"),
+        "ilp_over_btp_outgoing_token": "three",
         "min_balance": -1_000_000_000,
         "routing_relation": "Parent",
     });
-    // json! does not take comments into account!
-    // "ilp_over_btp_url": format!("btp+ws://localhost:{}/accounts/{}/ilp/btp", node2_http, "charlie_on_b"),
-    // "ilp_over_btp_outgoing_token": "three",
 
     let node1: InterledgerNode = serde_json::from_value(json!({
         "ilp_address": "example.alice",
@@ -164,7 +158,7 @@ async fn three_nodes() {
         .unwrap();
 
     node3.serve().await.unwrap(); // .instrument(error_span!(target: "interledger", "node3")).await.unwrap();
-    let acc = create_account_on_node(node3_http, charlie_on_charlie, "admin")
+    create_account_on_node(node3_http, charlie_on_charlie, "admin")
         .await
         .unwrap();
     create_account_on_node(node3_http, bob_on_charlie, "admin")

--- a/crates/ilp-node/tests/redis/three_nodes.rs
+++ b/crates/ilp-node/tests/redis/three_nodes.rs
@@ -1,6 +1,6 @@
 use crate::redis_helpers::*;
 use crate::test_helpers::*;
-use futures::{future::join_all, stream::*, sync::mpsc, Future};
+use futures::{future::join_all, stream::*, Future};
 use ilp_node::InterledgerNode;
 use interledger::packet::Address;
 use interledger::stream::StreamDelivery;
@@ -12,10 +12,10 @@ use tracing_futures::Instrument;
 
 const LOG_TARGET: &str = "interledger-tests-three-nodes";
 
-#[test]
-fn three_nodes() {
+#[tokio::test]
+async fn three_nodes() {
     // Nodes 1 and 2 are peers, Node 2 is the parent of Node 3
-    install_tracing_subscriber();
+    // install_tracing_subscriber();
     let context = TestContext::new();
 
     // Each node will use its own DB within the redis instance
@@ -32,12 +32,6 @@ fn three_nodes() {
     let node2_settlement = get_open_port(None);
     let node3_http = get_open_port(None);
     let node3_settlement = get_open_port(None);
-
-    let mut runtime = RuntimeBuilder::new()
-        .panic_handler(|err| std::panic::resume_unwind(err))
-        .build()
-        .unwrap();
-
     let alice_on_alice = json!({
         "ilp_address": "example.alice",
         "username": "alice_on_a",
@@ -138,213 +132,137 @@ fn three_nodes() {
     }))
     .expect("Error creating node3.");
 
-    let (finish_sender, finish_receiver) = mpsc::channel(0);
+    node1.serve().await.unwrap(); // .instrument(error_span!(target: "interledger", "node1")).await.unwrap();
+    create_account_on_node(node1_http, alice_on_alice, "admin").await.unwrap();
+    create_account_on_node(node1_http, bob_on_alice, "admin").await.unwrap();
 
-    let alice_fut = join_all(vec![
-        create_account_on_node(node1_http, alice_on_alice, "admin"),
-        create_account_on_node(node1_http, bob_on_alice, "admin"),
-    ]);
+    node2.serve().await.unwrap(); // .instrument(error_span!(target: "interledger", "node2")).await.unwrap();
+    create_account_on_node(node2_http, alice_on_bob, "admin").await.unwrap();
+    create_account_on_node(node2_http, charlie_on_bob, "admin").await.unwrap();
+    // Also set exchange rates
+    let client = reqwest::Client::new();
+    client
+        .put(&format!("http://localhost:{}/rates", node2_http))
+        .header("Authorization", "Bearer admin")
+        .json(&json!({"ABC": 1, "XYZ": 2}))
+        .send()
+        .await.unwrap();
 
-    let mut node1_finish_sender = finish_sender.clone();
-    runtime.spawn(
-        node1
-            .serve()
-            .and_then(move |_| alice_fut)
-            .and_then(move |_| {
-                node1_finish_sender
-                    .try_send(1)
-                    .expect("Could not send message from node_1");
-                Ok(())
-            })
-            .instrument(error_span!(target: "interledger", "node1")),
+    node3.serve().await.unwrap(); // .instrument(error_span!(target: "interledger", "node3")).await.unwrap();
+    create_account_on_node(node3_http, charlie_on_charlie, "admin").await.unwrap();
+    create_account_on_node(node3_http, bob_on_charlie, "admin").await.unwrap();
+
+    delay(1000).await;
+
+    let get_balances = move || {
+        futures::future::join_all(vec![
+            get_balance("alice_on_a", node1_http, "admin"),
+            get_balance("charlie_on_b", node2_http, "admin"),
+            get_balance("charlie_on_c", node3_http, "admin"),
+        ])
+    };
+
+    // Node 1 sends 1000 to Node 3. However, Node1's scale is 9,
+    // while Node 3's scale is 6. This means that Node 3 will
+    // see 1000x less. In addition, the conversion rate is 2:1
+    // for 3's asset, so he will receive 2 total.
+    let receipt = send_money_to_username(
+        node1_http,
+        node3_http,
+        1000,
+        "charlie_on_c",
+        "alice_on_a",
+        "default account holder",
+    ).await.unwrap();
+
+    assert_eq!(
+        receipt.from,
+        Address::from_str("example.alice").unwrap(),
+        "Payment receipt incorrect (1)"
+    );
+    assert!(receipt
+        .to
+        .to_string()
+        .starts_with("example.bob.charlie_on_b.charlie_on_c."));
+    assert_eq!(receipt.sent_asset_code, "XYZ");
+    assert_eq!(receipt.sent_asset_scale, 9);
+    assert_eq!(receipt.sent_amount, 1000);
+    assert_eq!(receipt.delivered_asset_code.unwrap(), "ABC");
+    assert_eq!(receipt.delivered_amount, 2);
+    assert_eq!(receipt.delivered_asset_scale.unwrap(), 6);
+    let ret = get_balances().await;
+    let ret: Vec<_> = ret.into_iter().map(|r| r.unwrap()).collect();
+    // -1000 divided by asset scale 9
+    assert_eq!(
+        ret[0],
+        BalanceData {
+            asset_code: "XYZ".to_owned(),
+            balance: -1e-6
+        }
+    );
+    // 2 divided by asset scale 6
+    assert_eq!(
+        ret[1],
+        BalanceData {
+            asset_code: "ABC".to_owned(),
+            balance: 2e-6
+        }
+    );
+    // 2 divided by asset scale 6
+    assert_eq!(
+        ret[2],
+        BalanceData {
+            asset_code: "ABC".to_owned(),
+            balance: 2e-6
+        }
     );
 
-    let bob_fut = join_all(vec![
-        create_account_on_node(node2_http, alice_on_bob, "admin"),
-        create_account_on_node(node2_http, charlie_on_bob, "admin"),
-    ]);
+    // Charlie sends to Alice
+    let receipt = send_money_to_username(
+        node3_http,
+        node1_http,
+        1000,
+        "alice_on_a",
+        "charlie_on_c",
+        "default account holder",
+    ).await.unwrap();
 
-    let mut node2_finish_sender = finish_sender;
-    runtime.spawn(
-        node2
-            .serve()
-            .and_then(move |_| bob_fut)
-            .and_then(move |_| {
-                let client = reqwest::r#async::Client::new();
-                client
-                    .put(&format!("http://localhost:{}/rates", node2_http))
-                    .header("Authorization", "Bearer admin")
-                    .json(&json!({"ABC": 1, "XYZ": 2}))
-                    .send()
-                    .map_err(|err| panic!(err))
-                    .and_then(move |res| {
-                        res.error_for_status()
-                            .expect("Error setting exchange rates");
-                        node2_finish_sender
-                            .try_send(2)
-                            .expect("Could not send message from node_2");
-                        Ok(())
-                    })
-            })
-            .instrument(error_span!(target: "interledger", "node2")),
+    assert_eq!(
+        receipt.from,
+        Address::from_str("example.bob.charlie_on_b.charlie_on_c").unwrap(),
+        "Payment receipt incorrect (2)"
     );
-
-    // We execute the futures one after the other to avoid race conditions where
-    // Bob gets added before the node's main account
-    let charlie_fut = create_account_on_node(node3_http, charlie_on_charlie, "admin")
-        .and_then(move |_| create_account_on_node(node3_http, bob_on_charlie, "admin"));
-
-    runtime
-        .block_on(
-            node3
-                .serve()
-                .and_then(move |_| finish_receiver.collect())
-                .and_then(move |messages| {
-                    debug!(
-                        target: LOG_TARGET,
-                        "Received finish messages: {:?}", messages
-                    );
-                    charlie_fut
-                })
-                .instrument(error_span!(target: "interledger", "node3"))
-                // we wait some time after the node is up so that we get the
-                // necessary routes from bob
-                .and_then(move |_| {
-                    delay(1000).map_err(|_| panic!("Something strange happened when `delay`"))
-                })
-                .and_then(move |_| {
-                    let send_1_to_3 = send_money_to_username(
-                        node1_http,
-                        node3_http,
-                        1000,
-                        "charlie_on_c",
-                        "alice_on_a",
-                        "default account holder",
-                    );
-                    let send_3_to_1 = send_money_to_username(
-                        node3_http,
-                        node1_http,
-                        1000,
-                        "alice_on_a",
-                        "charlie_on_c",
-                        "default account holder",
-                    );
-
-                    let get_balances = move || {
-                        futures::future::join_all(vec![
-                            get_balance("alice_on_a", node1_http, "admin"),
-                            get_balance("charlie_on_b", node2_http, "admin"),
-                            get_balance("charlie_on_c", node3_http, "admin"),
-                        ])
-                    };
-
-                    // Node 1 sends 1000 to Node 3. However, Node1's scale is 9,
-                    // while Node 3's scale is 6. This means that Node 3 will
-                    // see 1000x less. In addition, the conversion rate is 2:1
-                    // for 3's asset, so he will receive 2 total.
-                    send_1_to_3
-                        .map_err(|err| {
-                            eprintln!("Error sending from node 1 to node 3: {:?}", err);
-                            err
-                        })
-                        .and_then(move |receipt: StreamDelivery| {
-                            debug!(target: LOG_TARGET, "send_1_to_3 receipt: {:?}", receipt);
-                            assert_eq!(
-                                receipt.from,
-                                Address::from_str("example.alice").unwrap(),
-                                "Payment receipt incorrect (1)"
-                            );
-                            assert!(receipt
-                                .to
-                                .to_string()
-                                .starts_with("example.bob.charlie_on_b.charlie_on_c."));
-                            assert_eq!(receipt.sent_asset_code, "XYZ");
-                            assert_eq!(receipt.sent_asset_scale, 9);
-                            assert_eq!(receipt.sent_amount, 1000);
-                            assert_eq!(receipt.delivered_asset_code.unwrap(), "ABC");
-                            assert_eq!(receipt.delivered_amount, 2);
-                            assert_eq!(receipt.delivered_asset_scale.unwrap(), 6);
-                            get_balances().and_then(move |ret| {
-                                // -1000 divided by asset scale 9
-                                assert_eq!(
-                                    ret[0],
-                                    BalanceData {
-                                        asset_code: "XYZ".to_owned(),
-                                        balance: -1e-6
-                                    }
-                                );
-                                // 2 divided by asset scale 6
-                                assert_eq!(
-                                    ret[1],
-                                    BalanceData {
-                                        asset_code: "ABC".to_owned(),
-                                        balance: 2e-6
-                                    }
-                                );
-                                // 2 divided by asset scale 6
-                                assert_eq!(
-                                    ret[2],
-                                    BalanceData {
-                                        asset_code: "ABC".to_owned(),
-                                        balance: 2e-6
-                                    }
-                                );
-                                Ok(())
-                            })
-                        })
-                        .and_then(move |_| {
-                            send_3_to_1.map_err(|err| {
-                                eprintln!("Error sending from node 3 to node 1: {:?}", err);
-                                err
-                            })
-                        })
-                        .and_then(move |receipt| {
-                            debug!(target: LOG_TARGET, "send_3_to_1 receipt: {:?}", receipt);
-                            assert_eq!(
-                                receipt.from,
-                                Address::from_str("example.bob.charlie_on_b.charlie_on_c").unwrap(),
-                                "Payment receipt incorrect (2)"
-                            );
-                            assert!(receipt.to.to_string().starts_with("example.alice"));
-                            assert_eq!(receipt.sent_asset_code, "ABC");
-                            assert_eq!(receipt.sent_asset_scale, 6);
-                            assert_eq!(receipt.sent_amount, 1000);
-                            assert_eq!(receipt.delivered_asset_code.unwrap(), "XYZ");
-                            assert_eq!(receipt.delivered_amount, 500_000);
-                            assert_eq!(receipt.delivered_asset_scale.unwrap(), 9);
-                            get_balances().and_then(move |ret| {
-                                // 499,000 divided by asset scale 9
-                                assert_eq!(
-                                    ret[0],
-                                    BalanceData {
-                                        asset_code: "XYZ".to_owned(),
-                                        balance: 499e-6
-                                    }
-                                );
-                                // -998 divided by asset scale 6
-                                assert_eq!(
-                                    ret[1],
-                                    BalanceData {
-                                        asset_code: "ABC".to_owned(),
-                                        balance: -998e-6
-                                    }
-                                );
-                                // -998 divided by asset scale 6
-                                assert_eq!(
-                                    ret[2],
-                                    BalanceData {
-                                        asset_code: "ABC".to_owned(),
-                                        balance: -998e-6
-                                    }
-                                );
-                                Ok(())
-                            })
-                        })
-                }),
-        )
-        .map_err(|err| {
-            eprintln!("Error executing tests: {:?}", err);
-            err
-        })
-        .unwrap();
+    assert!(receipt.to.to_string().starts_with("example.alice"));
+    assert_eq!(receipt.sent_asset_code, "ABC");
+    assert_eq!(receipt.sent_asset_scale, 6);
+    assert_eq!(receipt.sent_amount, 1000);
+    assert_eq!(receipt.delivered_asset_code.unwrap(), "XYZ");
+    assert_eq!(receipt.delivered_amount, 500_000);
+    assert_eq!(receipt.delivered_asset_scale.unwrap(), 9);
+    let ret = get_balances().await;
+    let ret: Vec<_> = ret.into_iter().map(|r| r.unwrap()).collect();
+    // 499,000 divided by asset scale 9
+    assert_eq!(
+        ret[0],
+        BalanceData {
+            asset_code: "XYZ".to_owned(),
+            balance: 499e-6
+        }
+    );
+    // -998 divided by asset scale 6
+    assert_eq!(
+        ret[1],
+        BalanceData {
+            asset_code: "ABC".to_owned(),
+            balance: -998e-6
+        }
+    );
+    // -998 divided by asset scale 6
+    assert_eq!(
+        ret[2],
+        BalanceData {
+            asset_code: "ABC".to_owned(),
+            balance: -998e-6
+        }
+    );
 }

--- a/crates/ilp-node/tests/redis/three_nodes.rs
+++ b/crates/ilp-node/tests/redis/three_nodes.rs
@@ -65,7 +65,11 @@ async fn three_nodes() {
         "username": "charlie_on_b",
         "asset_code": "ABC",
         "asset_scale": 6,
-        "ilp_over_btp_incoming_token" : "three",
+        // "ilp_over_btp_incoming_token" : "three",
+        // TODO: remove these and replace with BTP once it's solved
+        "ilp_over_http_outgoing_token": "two",
+        "ilp_over_http_incoming_token": "three",
+        "ilp_over_http_url": format!("http://localhost:{}/accounts/{}/ilp", node3_http, "bob_on_c"),
         "min_balance": -1_000_000_000,
         "routing_relation": "Child",
     });
@@ -81,13 +85,15 @@ async fn three_nodes() {
         "username": "bob_on_c",
         "asset_code": "ABC",
         "asset_scale": 6,
-        "ilp_over_http_incoming_token" : "two",
         "ilp_over_http_outgoing_token": "three",
-        "ilp_over_btp_url": format!("btp+ws://localhost:{}/accounts/{}/ilp/btp", node2_http, "charlie_on_b"),
-        "ilp_over_btp_outgoing_token": "three",
+        "ilp_over_http_incoming_token" : "two",
+        "ilp_over_http_url": format!("http://localhost:{}/accounts/{}/ilp", node2_http, "charlie_on_b"),
         "min_balance": -1_000_000_000,
         "routing_relation": "Parent",
     });
+    // json! does not take comments into account!
+    // "ilp_over_btp_url": format!("btp+ws://localhost:{}/accounts/{}/ilp/btp", node2_http, "charlie_on_b"),
+    // "ilp_over_btp_outgoing_token": "three",
 
     let node1: InterledgerNode = serde_json::from_value(json!({
         "ilp_address": "example.alice",
@@ -133,12 +139,20 @@ async fn three_nodes() {
     .expect("Error creating node3.");
 
     node1.serve().await.unwrap(); // .instrument(error_span!(target: "interledger", "node1")).await.unwrap();
-    create_account_on_node(node1_http, alice_on_alice, "admin").await.unwrap();
-    create_account_on_node(node1_http, bob_on_alice, "admin").await.unwrap();
+    create_account_on_node(node1_http, alice_on_alice, "admin")
+        .await
+        .unwrap();
+    create_account_on_node(node1_http, bob_on_alice, "admin")
+        .await
+        .unwrap();
 
     node2.serve().await.unwrap(); // .instrument(error_span!(target: "interledger", "node2")).await.unwrap();
-    create_account_on_node(node2_http, alice_on_bob, "admin").await.unwrap();
-    create_account_on_node(node2_http, charlie_on_bob, "admin").await.unwrap();
+    create_account_on_node(node2_http, alice_on_bob, "admin")
+        .await
+        .unwrap();
+    create_account_on_node(node2_http, charlie_on_bob, "admin")
+        .await
+        .unwrap();
     // Also set exchange rates
     let client = reqwest::Client::new();
     client
@@ -146,11 +160,16 @@ async fn three_nodes() {
         .header("Authorization", "Bearer admin")
         .json(&json!({"ABC": 1, "XYZ": 2}))
         .send()
-        .await.unwrap();
+        .await
+        .unwrap();
 
     node3.serve().await.unwrap(); // .instrument(error_span!(target: "interledger", "node3")).await.unwrap();
-    create_account_on_node(node3_http, charlie_on_charlie, "admin").await.unwrap();
-    create_account_on_node(node3_http, bob_on_charlie, "admin").await.unwrap();
+    let acc = create_account_on_node(node3_http, charlie_on_charlie, "admin")
+        .await
+        .unwrap();
+    create_account_on_node(node3_http, bob_on_charlie, "admin")
+        .await
+        .unwrap();
 
     delay(1000).await;
 
@@ -173,7 +192,9 @@ async fn three_nodes() {
         "charlie_on_c",
         "alice_on_a",
         "default account holder",
-    ).await.unwrap();
+    )
+    .await
+    .unwrap();
 
     assert_eq!(
         receipt.from,
@@ -225,7 +246,9 @@ async fn three_nodes() {
         "alice_on_a",
         "charlie_on_c",
         "default account holder",
-    ).await.unwrap();
+    )
+    .await
+    .unwrap();
 
     assert_eq!(
         receipt.from,

--- a/crates/interledger-api/Cargo.toml
+++ b/crates/interledger-api/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 
 [dependencies]
 bytes = { version = "0.4.12", default-features = false }
+bytes05 = { package = "bytes", version = "0.5", default-features = false }
 futures = { version = "0.3.1", default-features = false }
 futures-retry = { version = "0.4", default-features = false }
 http = { version = "0.2", default-features = false }
@@ -35,6 +36,9 @@ warp = { git = "https://github.com/seanmonstar/warp.git" }
 secrecy = { version = "0.5.2", default-features = false, features = ["serde"] }
 lazy_static = "1.4.0"
 async-trait = "0.1.22"
+
+[dev-dependencies]
+tokio = { version = "0.2.9", features = ["rt-core", "macros"] }
 
 [badges]
 circle-ci = { repository = "interledger-rs/interledger-rs" }

--- a/crates/interledger-api/Cargo.toml
+++ b/crates/interledger-api/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 
 [dependencies]
 bytes = { version = "0.4.12", default-features = false }
-futures = { version = "0.1.29", default-features = false }
-futures-retry = { version = "0.3.3", default-features = false }
-http = { version = "0.1.18", default-features = false }
+futures = { version = "0.3.1", default-features = false }
+futures-retry = { version = "0.4", default-features = false }
+http = { version = "0.2", default-features = false }
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
 interledger-http = { path = "../interledger-http", version = "^0.4.0", default-features = false }
 interledger-ildcp = { path = "../interledger-ildcp", version = "^0.4.0", default-features = false }
@@ -27,12 +27,14 @@ log = { version = "0.4.8", default-features = false }
 serde = { version = "1.0.101", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.41", default-features = false }
 serde_path_to_error = { version = "0.1", default-features = false }
-reqwest = { version = "0.9.22", default-features = false, features = ["default-tls"] }
+reqwest = { version = "0.10", default-features = false, features = ["default-tls", "json"] }
 url = { version = "2.1.0", default-features = false, features = ["serde"] }
 uuid = { version = "0.8.1", default-features = false}
-warp = { version = "0.1.20", default-features = false }
+# warp = { version = "0.1.20", default-features = false }
+warp = { git = "https://github.com/seanmonstar/warp.git" }
 secrecy = { version = "0.5.2", default-features = false, features = ["serde"] }
 lazy_static = "1.4.0"
+async-trait = "0.1.22"
 
 [badges]
 circle-ci = { repository = "interledger-rs/interledger-rs" }

--- a/crates/interledger-api/Cargo.toml
+++ b/crates/interledger-api/Cargo.toml
@@ -27,7 +27,7 @@ interledger-btp = { path = "../interledger-btp", version = "^0.4.0", default-fea
 log = { version = "0.4.8", default-features = false }
 serde = { version = "1.0.101", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.41", default-features = false }
-serde_path_to_error = { version = "0.1", default-features = false }
+serde_path_to_error = { version = "0.1.2", default-features = false }
 reqwest = { version = "0.10", default-features = false, features = ["default-tls", "json"] }
 url = { version = "2.1.0", default-features = false, features = ["serde"] }
 uuid = { version = "0.8.1", default-features = false}
@@ -36,6 +36,7 @@ warp = { git = "https://github.com/seanmonstar/warp.git" }
 secrecy = { version = "0.5.2", default-features = false, features = ["serde"] }
 lazy_static = "1.4.0"
 async-trait = "0.1.22"
+mime = "0.3.16"
 
 [dev-dependencies]
 tokio = { version = "0.2.9", features = ["rt-core", "macros"] }

--- a/crates/interledger-api/src/http_retry.rs
+++ b/crates/interledger-api/src/http_retry.rs
@@ -1,9 +1,9 @@
 // Adapted from the futures-retry example: https://gitlab.com/mexus/futures-retry/blob/master/examples/tcp-client-complex.rs
-use futures::future::Future;
+use futures::TryFutureExt;
 use futures_retry::{ErrorHandler, FutureRetry, RetryPolicy};
 use http::StatusCode;
 use log::trace;
-use reqwest::r#async::Client as HttpClient;
+use reqwest::Client as HttpClient;
 use serde_json::json;
 use std::{default::Default, fmt::Display, time::Duration};
 use url::Url;
@@ -28,11 +28,11 @@ impl Client {
         }
     }
 
-    pub fn create_engine_account<T: Display + Copy>(
+    pub async fn create_engine_account<T: Display + Copy + Unpin>(
         &self,
         engine_url: Url,
         id: T,
-    ) -> impl Future<Item = StatusCode, Error = reqwest::Error> {
+    ) -> Result<StatusCode, reqwest::Error> {
         let mut se_url = engine_url.clone();
         se_url
             .path_segments_mut()
@@ -46,26 +46,25 @@ impl Client {
 
         // The actual HTTP request which gets made to the engine
         let client = self.client.clone();
-        let create_settlement_engine_account = move || {
-            client
-                .post(se_url.as_ref())
-                .json(&json!({"id" : id.to_string()}))
-                .send()
-                .and_then(move |response| {
-                    // If the account is not found on the peer's connector, the
-                    // retry logic will not get triggered. When the counterparty
-                    // tries to add the account, they will complete the handshake.
-                    Ok(response.status())
-                })
-        };
 
-        FutureRetry::new(
-            create_settlement_engine_account,
+        // If the account is not found on the peer's connector, the
+        // retry logic will not get triggered. When the counterparty
+        // tries to add the account, they will complete the handshake.
+        let res = FutureRetry::new(
+            move || {
+                client
+                    .post(se_url.as_ref())
+                    .json(&json!({"id" : id.to_string()}))
+                    .send()
+                    .map_ok(move |response| response.status())
+            },
             IoHandler::new(
                 self.max_retries,
                 format!("[Engine: {}, Account: {}]", engine_url, id),
             ),
         )
+        .await?;
+        Ok(res)
     }
 }
 
@@ -111,12 +110,22 @@ where
             self.max_attempts
         );
 
-        if e.is_client_error() {
-            // do not retry 4xx
-            RetryPolicy::ForwardError(e)
-        } else if e.is_timeout() || e.is_server_error() {
-            // Retry timeouts and 5xx every 5 seconds
+        // TODO: Should we make this policy more sophisticated?
+
+        // Retry timeouts every 5s
+        if e.is_timeout() {
             RetryPolicy::WaitRetry(Duration::from_secs(5))
+        } else if let Some(status) = e.status() {
+            if status.is_client_error() {
+                // do not retry 4xx
+                RetryPolicy::ForwardError(e)
+            } else if status.is_server_error() {
+                // Retry 5xx every 5 seconds
+                RetryPolicy::WaitRetry(Duration::from_secs(5))
+            } else {
+                // Otherwise just retry every second
+                RetryPolicy::WaitRetry(Duration::from_secs(1))
+            }
         } else {
             // Retry other errors slightly more frequently since they may be
             // related to the engine not having started yet

--- a/crates/interledger-api/src/http_retry.rs
+++ b/crates/interledger-api/src/http_retry.rs
@@ -50,6 +50,8 @@ impl Client {
         // If the account is not found on the peer's connector, the
         // retry logic will not get triggered. When the counterparty
         // tries to add the account, they will complete the handshake.
+
+        let msg = format!("[Engine: {}, Account: {}]", engine_url, id);
         let res = FutureRetry::new(
             move || {
                 client
@@ -60,7 +62,7 @@ impl Client {
             },
             IoHandler::new(
                 self.max_retries,
-                format!("[Engine: {}, Account: {}]", engine_url, id),
+                msg,
             ),
         )
         .await?;

--- a/crates/interledger-api/src/lib.rs
+++ b/crates/interledger-api/src/lib.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 use warp::{self, Filter};
 
 pub(crate) mod http_retry;
-// mod routes;
+mod routes;
 
 // This enum and the following functions are used to allow clients to send either
 // numbers or strings and have them be properly deserialized into the appropriate

--- a/crates/interledger-api/src/lib.rs
+++ b/crates/interledger-api/src/lib.rs
@@ -251,23 +251,25 @@ where
         self
     }
 
-    // pub fn into_warp_filter(self) -> warp::filters::BoxedFilter<(impl warp::Reply,)> {
-    //     routes::accounts_api(
-    //         self.server_secret,
-    //         self.admin_api_token.clone(),
-    //         self.default_spsp_account,
-    //         self.incoming_handler,
-    //         self.outgoing_handler,
-    //         self.btp,
-    //         self.store.clone(),
-    //     )
-    //     .or(routes::node_settings_api(
-    //         self.admin_api_token,
-    //         self.node_version,
-    //         self.store,
-    //     ))
-    //     .boxed()
-    // }
+    pub fn into_warp_filter(self) -> warp::filters::BoxedFilter<(impl warp::Reply,)> {
+        let routes = warp::any().map(|| "Hello, World!");
+        routes.boxed()
+        // routes::accounts_api(
+        //     self.server_secret,
+        //     self.admin_api_token.clone(),
+        //     self.default_spsp_account,
+        //     self.incoming_handler,
+        //     self.outgoing_handler,
+        //     self.btp,
+        //     self.store.clone(),
+        // )
+        // .or(routes::node_settings_api(
+        //     self.admin_api_token,
+        //     self.node_version,
+        //     self.store,
+        // ))
+        // .boxed()
+    }
 
     // pub fn bind(self, addr: SocketAddr) -> impl Future<Item = (), Error = ()> {
     //     warp::serve(self.into_warp_filter()).bind(addr)

--- a/crates/interledger-api/src/lib.rs
+++ b/crates/interledger-api/src/lib.rs
@@ -93,7 +93,7 @@ pub trait NodeStore: AddressStore + Clone + Send + Sync + 'static {
 
     async fn set_static_routes<R>(&self, routes: R) -> Result<(), ()>
     where
-        R: IntoIterator<Item = (String, Uuid)>;
+        R: IntoIterator<Item = (String, Uuid)> + Send + 'async_trait;
 
     async fn set_static_route(&self, prefix: String, account_id: Uuid) -> Result<(), ()>;
 
@@ -101,7 +101,7 @@ pub trait NodeStore: AddressStore + Clone + Send + Sync + 'static {
 
     async fn set_settlement_engines(
         &self,
-        asset_to_url_map: impl IntoIterator<Item = (String, Url)>,
+        asset_to_url_map: impl IntoIterator<Item = (String, Url)> + Send + 'async_trait,
     ) -> Result<(), ()>;
 
     async fn get_asset_settlement_engine(&self, asset_code: &str) -> Result<Option<Url>, ()>;

--- a/crates/interledger-api/src/lib.rs
+++ b/crates/interledger-api/src/lib.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::Future;
 use interledger_btp::{BtpAccount, BtpOutgoingService};
 use interledger_ccp::CcpRoutingAccount;
 use interledger_http::{HttpAccount, HttpStore};
@@ -252,28 +251,26 @@ where
     }
 
     pub fn into_warp_filter(self) -> warp::filters::BoxedFilter<(impl warp::Reply,)> {
-        let routes = warp::any().map(|| "Hello, World!");
-        routes.boxed()
-        // routes::accounts_api(
-        //     self.server_secret,
-        //     self.admin_api_token.clone(),
-        //     self.default_spsp_account,
-        //     self.incoming_handler,
-        //     self.outgoing_handler,
-        //     self.btp,
-        //     self.store.clone(),
-        // )
-        // .or(routes::node_settings_api(
-        //     self.admin_api_token,
-        //     self.node_version,
-        //     self.store,
-        // ))
-        // .boxed()
+        routes::accounts_api(
+            self.server_secret,
+            self.admin_api_token.clone(),
+            self.default_spsp_account,
+            self.incoming_handler,
+            self.outgoing_handler,
+            self.btp,
+            self.store.clone(),
+        )
+        .or(routes::node_settings_api(
+            self.admin_api_token,
+            self.node_version,
+            self.store,
+        ))
+        .boxed()
     }
 
-    // pub fn bind(self, addr: SocketAddr) -> impl Future<Item = (), Error = ()> {
-    //     warp::serve(self.into_warp_filter()).bind(addr)
-    // }
+    pub async fn bind(self, addr: SocketAddr) {
+        warp::serve(self.into_warp_filter()).bind(addr).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/interledger-api/src/routes/accounts.rs
+++ b/crates/interledger-api/src/routes/accounts.rs
@@ -73,10 +73,8 @@ where
             let admin_auth_header = admin_auth_header_clone.clone();
             async move {
                 if authorization.expose_secret() == &admin_auth_header {
-                    println!("autorized!");
                     Ok::<(), Rejection>(())
                 } else {
-                    println!("unautorized!");
                     Err(Rejection::from(ApiError::unauthorized()))
                 }
             }
@@ -398,6 +396,7 @@ where
     // GET /accounts/:username/spsp
     let server_secret_clone = server_secret.clone();
     let get_spsp = warp::get()
+        .and(warp::path("accounts"))
         .and(account_username_to_id)
         .and(warp::path("spsp"))
         .and(warp::path::end())
@@ -676,6 +675,7 @@ pub fn deserialize_json<T: DeserializeOwned + Send>(
 #[cfg(test)]
 mod tests {
     use crate::routes::test_helpers::*;
+    // TODO: Add test for GET /accounts/:username/spsp and /.well_known
 
     #[tokio::test]
     async fn only_admin_can_create_account() {

--- a/crates/interledger-api/src/routes/accounts.rs
+++ b/crates/interledger-api/src/routes/accounts.rs
@@ -2,11 +2,11 @@ use crate::{http_retry::Client, number_or_string, AccountDetails, AccountSetting
 use bytes::Bytes;
 use futures::{
     future::{err, join_all, ok, Either},
-    Future, Stream,
+    Future, Stream, TryFutureExt,
 };
 use interledger_btp::{connect_to_service_account, BtpAccount, BtpOutgoingService};
 use interledger_ccp::{CcpRoutingAccount, Mode, RouteControlRequest, RoutingRelation};
-use interledger_http::{deserialize_json, error::*, HttpAccount, HttpStore};
+use interledger_http::{error::*, HttpAccount, HttpStore};
 use interledger_ildcp::IldcpRequest;
 use interledger_ildcp::IldcpResponse;
 use interledger_router::RouterStore;
@@ -64,66 +64,53 @@ where
         + 'static,
 {
     // TODO can we make any of the Filters const or put them in lazy_static?
-
-    // Helper filters
-    let admin_auth_header = format!("Bearer {}", admin_api_token);
-    let admin_only = warp::header::<SecretString>("authorization")
-        .and_then(
-            move |authorization: SecretString| -> Result<(), Rejection> {
-                if authorization.expose_secret() == &admin_auth_header {
-                    Ok(())
-                } else {
-                    Err(ApiError::unauthorized().into())
-                }
-            },
-        )
-        // This call makes it so we do not pass on a () value on
-        // success to the next filter, it just gets rid of it
-        .untuple_one()
-        .boxed();
     let with_store = warp::any().map(move || store.clone()).boxed();
     let admin_auth_header = format!("Bearer {}", admin_api_token);
     let with_admin_auth_header = warp::any().map(move || admin_auth_header.clone()).boxed();
     let with_incoming_handler = warp::any().map(move || incoming_handler.clone()).boxed();
+
+    // Helper filters
+    let admin_auth_header = format!("Bearer {}", admin_api_token);
+    let admin_only = warp::header::<SecretString>("authorization")
+        .and_then(move |authorization: SecretString| {
+            // ugly clone to make function Fn
+            let header = admin_auth_header.clone();
+            async move {
+                if authorization.expose_secret() == &header {
+                    Ok(())
+                } else {
+                    Err(Rejection::from(ApiError::unauthorized()))
+                }
+            }
+        })
+        .untuple_one()
+        .boxed();
+
     // Note that the following path filters should be applied before others
     // (such as method and authentication) to avoid triggering unexpected errors for requests
     // that do not match this path.
     let accounts = warp::path("accounts");
     let accounts_index = accounts.and(warp::path::end());
-    // This is required when using `admin_or_authorized_user_only` or `authorized_user_only` filter.
-    // Sets Username from path into ext for context.
-    let account_username = accounts
-        .and(warp::path::param2::<Username>())
-        .and_then(|username: Username| -> Result<_, Rejection> {
-            warp::filters::ext::set(username);
-            Ok(())
-        })
-        .untuple_one()
-        .boxed();
-    let account_username_to_id = accounts
-        .and(warp::path::param2::<Username>())
+
+    // Converts an account username to an account id or errors out
+    let account_username_to_id = warp::path::param::<Username>()
         .and(with_store.clone())
-        .and_then(|username: Username, store: S| {
-            store
-                .get_account_id_from_username(&username)
-                .map_err::<_, Rejection>(move |_| {
-                    // TODO differentiate between server error and not found
-                    error!("Error getting account id from username: {}", username);
-                    ApiError::account_not_found().into()
-                })
+        .and_then(move |username: Username, store: S| {
+            async move {
+                store
+                    .get_account_id_from_username(&username)
+                    .map_err(|_| {
+                        // TODO differentiate between server error and not found
+                        error!("Error getting account id from username: {}", username);
+                        Rejection::from(ApiError::account_not_found())
+                    })
+                    .await
+            }
         })
         .boxed();
 
-    // Receives parameters which were prepared by `account_username` and
-    // considers the request is eligible to be processed or not, checking the auth.
-    // Why we separate `account_username` and this filter is that
-    // we want to check whether the sender is eligible to access this path but at the same time,
-    // we don't want to spawn any `Rejection`s at `account_username`.
-    // At the point of `account_username`, there might be some other
-    // remaining path filters. So we have to process those first, not to spawn errors of
-    // unauthorized that the the request actually should not cause.
-    // This function needs parameters which can be prepared by `account_username`.
-    let admin_or_authorized_user_only = warp::filters::ext::get::<Username>()
+    // Checks if the account is an admin or if they have provided a valid password
+    let admin_or_authorized_user_only = warp::path::param::<Username>()
         .and(warp::header::<SecretString>("authorization"))
         .and(with_store.clone())
         .and(with_admin_auth_header.clone())
@@ -132,72 +119,78 @@ where
              auth_string: SecretString,
              store: S,
              admin_auth_header: String| {
-                if auth_string.expose_secret().len() < BEARER_TOKEN_START {
-                    return Either::A(err(ApiError::bad_request().into()));
-                }
-                Either::B(store.get_account_id_from_username(&path_username).then(
-                    move |account_id: Result<Uuid, _>| {
-                        if account_id.is_err() {
-                            return Either::A(err::<Uuid, Rejection>(
-                                ApiError::account_not_found().into(),
-                            ));
-                        }
-                        let account_id = account_id.unwrap();
-                        if auth_string.expose_secret() == &admin_auth_header {
-                            return Either::A(ok(account_id));
-                        }
-                        Either::B(
-                            store
-                                .get_account_from_http_auth(
-                                    &path_username,
-                                    &auth_string.expose_secret()[BEARER_TOKEN_START..],
-                                )
-                                .then(move |authorized_account: Result<A, _>| {
-                                    if authorized_account.is_err() {
-                                        return err(ApiError::unauthorized().into());
-                                    }
-                                    let authorized_account = authorized_account.unwrap();
-                                    if &path_username == authorized_account.username() {
-                                        ok(authorized_account.id())
-                                    } else {
-                                        err(ApiError::unauthorized().into())
-                                    }
-                                }),
-                        )
-                    },
-                ))
-            },
-        )
-        .boxed();
+                async move {
+                    if auth_string.expose_secret().len() < BEARER_TOKEN_START {
+                        return Err(Rejection::from(ApiError::bad_request()));
+                    }
 
-    // The same structure as `admin_or_authorized_user_only`.
-    // This function needs parameters which can be prepared by `account_username`.
-    let authorized_user_only = warp::filters::ext::get::<Username>()
-        .and(warp::header::<SecretString>("authorization"))
-        .and(with_store.clone())
-        .and_then(
-            |path_username: Username, auth_string: SecretString, store: S| {
-                if auth_string.expose_secret().len() < BEARER_TOKEN_START {
-                    return Either::A(err(ApiError::bad_request().into()));
-                }
-                Either::B(
-                    store
+                    let account_id = store
+                        .get_account_id_from_username(&path_username)
+                        .map_err(|_| {
+                            // TODO differentiate between server error and not found
+                            error!("Error getting account id from username: {}", path_username);
+                            Rejection::from(ApiError::account_not_found())
+                        })
+                        .await?;
+
+                    // If it's an admin, there's no need for more checks
+                    if auth_string.expose_secret() == &admin_auth_header {
+                        return Ok(account_id);
+                    }
+
+                    // Try getting the account from the store
+                    let authorized_account = store
                         .get_account_from_http_auth(
                             &path_username,
                             &auth_string.expose_secret()[BEARER_TOKEN_START..],
                         )
-                        .then(move |authorized_account: Result<A, _>| {
-                            if authorized_account.is_err() {
-                                return err::<A, Rejection>(ApiError::unauthorized().into());
-                            }
-                            let authorized_account = authorized_account.unwrap();
-                            if &path_username == authorized_account.username() {
-                                ok(authorized_account)
-                            } else {
-                                err(ApiError::unauthorized().into())
-                            }
-                        }),
-                )
+                        .map_err(|_| Rejection::from(ApiError::unauthorized()))
+                        .await?;
+
+                    // Only return the account if the provided username matched the fetched one
+                    // This maybe is redundant?
+                    if &path_username == authorized_account.username() {
+                        Ok(authorized_account.id())
+                    } else {
+                        Err(ApiError::unauthorized().into())
+                    }
+                }
+            },
+        )
+        .boxed();
+
+    // Checks if the account has provided a valid password (same as admin-or-auth call, minus one call, can we refactor them together?)
+    let authorized_user_only = warp::path::param::<Username>()
+        .and(warp::header::<SecretString>("authorization"))
+        .and(with_store.clone())
+        .and(with_admin_auth_header.clone())
+        .and_then(
+            |path_username: Username,
+             auth_string: SecretString,
+             store: S,
+             admin_auth_header: String| {
+                async move {
+                    if auth_string.expose_secret().len() < BEARER_TOKEN_START {
+                        return Err(Rejection::from(ApiError::bad_request()));
+                    }
+
+                    // Try getting the account from the store
+                    let authorized_account = store
+                        .get_account_from_http_auth(
+                            &path_username,
+                            &auth_string.expose_secret()[BEARER_TOKEN_START..],
+                        )
+                        .map_err(|_| Rejection::from(ApiError::unauthorized()))
+                        .await?;
+
+                    // Only return the account if the provided username matched the fetched one
+                    // This maybe is redundant?
+                    if &path_username == authorized_account.username() {
+                        Ok(authorized_account.id())
+                    } else {
+                        Err(ApiError::unauthorized().into())
+                    }
+                }
             },
         )
         .boxed();
@@ -205,284 +198,285 @@ where
     // POST /accounts
     let btp_clone = btp.clone();
     let outgoing_handler_clone = outgoing_handler.clone();
-    let post_accounts = warp::post2()
-        .and(accounts_index)
-        .and(admin_only.clone())
-        .and(deserialize_json())
-        .and(with_store.clone())
-        .and_then(move |account_details: AccountDetails, store: S| {
-            let store_clone = store.clone();
-            let handler = outgoing_handler_clone.clone();
-            let btp = btp_clone.clone();
-            store
-                .insert_account(account_details.clone())
-                .map_err(move |_| {
-                    error!("Error inserting account into store: {:?}", account_details);
-                    // TODO need more information
-                    ApiError::internal_server_error().into()
-                })
-                .and_then(move |account| {
-                    connect_to_external_services(handler, account, store_clone, btp)
-                })
-                .and_then(|account: A| Ok(warp::reply::json(&account)))
-        })
-        .boxed();
-
-    // GET /accounts
-    let get_accounts = warp::get2()
+    let post_accounts = warp::post()
         .and(accounts_index)
         .and(admin_only.clone())
         .and(with_store.clone())
-        .and_then(|store: S| {
-            store
-                .get_all_accounts()
-                .map_err::<_, Rejection>(|_| ApiError::internal_server_error().into())
-                .and_then(|accounts| Ok(warp::reply::json(&accounts)))
-        })
-        .boxed();
-
-    // PUT /accounts/:username
-    let put_account = warp::put2()
-        .and(account_username_to_id.clone())
-        .and(warp::path::end())
-        .and(admin_only.clone())
-        .and(deserialize_json())
-        .and(with_store.clone())
-        .and_then(move |id: Uuid, account_details: AccountDetails, store: S| {
-            let store_clone = store.clone();
-            let handler = outgoing_handler.clone();
-            let btp = btp.clone();
-            store
-                .update_account(id, account_details)
-                .map_err::<_, Rejection>(move |_| ApiError::internal_server_error().into())
-                .and_then(move |account| {
-                    connect_to_external_services(handler, account, store_clone, btp)
-                })
-                .and_then(|account: A| Ok(warp::reply::json(&account)))
-        })
-        .boxed();
-
-    // GET /accounts/:username
-    let get_account = warp::get2()
-        .and(account_username.clone())
-        .and(warp::path::end())
-        .and(admin_or_authorized_user_only.clone())
-        .and(with_store.clone())
-        .and_then(|id: Uuid, store: S| {
-            store
-                .get_accounts(vec![id])
-                .map_err::<_, Rejection>(|_| ApiError::account_not_found().into())
-                .and_then(|accounts| Ok(warp::reply::json(&accounts[0])))
-        })
-        .boxed();
-
-    // GET /accounts/:username/balance
-    let get_account_balance = warp::get2()
-        .and(account_username.clone())
-        .and(warp::path("balance"))
-        .and(warp::path::end())
-        .and(admin_or_authorized_user_only.clone())
-        .and(with_store.clone())
-        .and_then(|id: Uuid, store: S| {
-            // TODO reduce the number of store calls it takes to get the balance
-            store
-                .get_accounts(vec![id])
-                .map_err(|_| warp::reject::not_found())
-                .and_then(move |mut accounts| {
-                    let account = accounts.pop().unwrap();
-                    let acc_clone = account.clone();
-                    let asset_scale = acc_clone.asset_scale();
-                    let asset_code = acc_clone.asset_code().to_owned();
-                    store
-                        .get_balance(account)
-                        .map_err(move |_| {
-                            error!("Error getting balance for account: {}", id);
-                            ApiError::internal_server_error().into()
-                        })
-                        .and_then(move |balance: i64| {
-                            Ok(warp::reply::json(&json!({
-                                // normalize to the base unit
-                                "balance": balance as f64 / 10_u64.pow(asset_scale.into()) as f64,
-                                "asset_code": asset_code,
-                            })))
-                        })
-                })
-        })
-        .boxed();
-
-    // DELETE /accounts/:username
-    let delete_account = warp::delete2()
-        .and(account_username_to_id.clone())
-        .and(warp::path::end())
-        .and(admin_only.clone())
-        .and(with_store.clone())
-        .and_then(|id: Uuid, store: S| {
-            store
-                .delete_account(id)
-                .map_err::<_, Rejection>(move |_| {
-                    error!("Error deleting account {}", id);
-                    ApiError::internal_server_error().into()
-                })
-                .and_then(|account| Ok(warp::reply::json(&account)))
-        })
-        .boxed();
-
-    // PUT /accounts/:username/settings
-    let put_account_settings = warp::put2()
-        .and(account_username.clone())
-        .and(warp::path("settings"))
-        .and(warp::path::end())
-        .and(admin_or_authorized_user_only.clone())
-        .and(deserialize_json())
-        .and(with_store.clone())
-        .and_then(|id: Uuid, settings: AccountSettings, store: S| {
-            store
-                .modify_account_settings(id, settings)
-                .map_err::<_, Rejection>(move |_| {
-                    error!("Error updating account settings {}", id);
-                    ApiError::internal_server_error().into()
-                })
-                .and_then(|settings| Ok(warp::reply::json(&settings)))
-        })
-        .boxed();
-
-    // (Websocket) /accounts/:username/payments/incoming
-    let incoming_payment_notifications = account_username
-        .clone()
-        .and(warp::path("payments"))
-        .and(warp::path("incoming"))
-        .and(warp::path::end())
-        .and(admin_or_authorized_user_only.clone())
-        .and(warp::ws2())
-        .and(with_store.clone())
-        .map(|id: Uuid, ws: warp::ws::Ws2, store: S| {
-            ws.on_upgrade(move |ws: warp::ws::WebSocket| {
-                let (tx, rx) = futures::sync::mpsc::unbounded::<PaymentNotification>();
-                store.add_payment_notification_subscription(id, tx);
-                rx.map_err(|_| -> warp::Error { unreachable!("unbounded rx never errors") })
-                    .map(|notification| {
-                        warp::ws::Message::text(serde_json::to_string(&notification).unwrap())
+        .and_then(move |account_details: AccountDetails, store: S| async move {
+                let store_clone = store.clone();
+                let handler = outgoing_handler_clone.clone();
+                let btp = btp_clone.clone();
+                let account = store
+                    .insert_account(account_details.clone())
+                    .map_err(move |_| {
+                        error!("Error inserting account into store: {:?}", account_details);
+                        // TODO need more information
+                        Rejection::from(ApiError::internal_server_error())
                     })
-                    .forward(ws)
-                    .map(|_| ())
-                    .map_err(|err| error!("Error forwarding notifications to websocket: {:?}", err))
-            })
-        })
-        .boxed();
+                    .await?;
 
-    // POST /accounts/:username/payments
-    let post_payments = warp::post2()
-        .and(account_username.clone())
-        .and(warp::path("payments"))
-        .and(warp::path::end())
-        .and(authorized_user_only.clone())
-        .and(deserialize_json())
-        .and(with_incoming_handler.clone())
-        .and_then(
-            move |account: A, pay_request: SpspPayRequest, incoming_handler: I| {
-                pay(
-                    incoming_handler,
-                    account.clone(),
-                    &pay_request.receiver,
-                    pay_request.source_amount,
-                )
-                .and_then(move |receipt| {
-                    debug!("Sent SPSP payment, receipt: {:?}", receipt);
-                    Ok(warp::reply::json(&json!(receipt)))
-                })
-                .map_err::<_, Rejection>(|err| {
-                    error!("Error sending SPSP payment: {:?}", err);
-                    // TODO give a different error message depending on what type of error it is
-                    ApiError::internal_server_error().into()
-                })
-            },
-        )
-        .boxed();
+                // connect_to_external_services(handler, account, store_clone, btp).await?;
+                warp::reply::json(&account.unwrap())
+        });
+        // .boxed();
 
-    // GET /accounts/:username/spsp
-    let server_secret_clone = server_secret.clone();
-    let get_spsp = warp::get2()
-        .and(account_username_to_id.clone())
-        .and(warp::path("spsp"))
-        .and(warp::path::end())
-        .and(with_store.clone())
-        .and_then(move |id: Uuid, store: S| {
-            let server_secret_clone = server_secret_clone.clone();
-            store
-                .get_accounts(vec![id])
-                .map_err::<_, Rejection>(|_| ApiError::internal_server_error().into())
-                .and_then(move |accounts| {
-                    // TODO return the response without instantiating an SpspResponder (use a simple fn)
-                    Ok(SpspResponder::new(
-                        accounts[0].ilp_address().clone(),
-                        server_secret_clone.clone(),
-                    )
-                    .generate_http_response())
-                })
-        })
-        .boxed();
+    //     // GET /accounts
+    //     let get_accounts = warp::get2()
+    //         .and(accounts_index)
+    //         .and(admin_only.clone())
+    //         .and(with_store.clone())
+    //         .and_then(|store: S| {
+    //             store
+    //                 .get_all_accounts()
+    //                 .map_err::<_, Rejection>(|_| ApiError::internal_server_error().into())
+    //                 .and_then(|accounts| Ok(warp::reply::json(&accounts)))
+    //         })
+    //         .boxed();
 
-    // GET /.well-known/pay
-    // This is the endpoint a [Payment Pointer](https://github.com/interledger/rfcs/blob/master/0026-payment-pointers/0026-payment-pointers.md)
-    // with no path resolves to
-    let server_secret_clone = server_secret.clone();
-    let get_spsp_well_known = warp::get2()
-        .and(warp::path(".well-known"))
-        .and(warp::path("pay"))
-        .and(warp::path::end())
-        .and(with_store.clone())
-        .and_then(move |store: S| {
-            // TODO don't clone this
-            if let Some(username) = default_spsp_account.clone() {
-                let server_secret_clone = server_secret_clone.clone();
-                Either::A(
-                    store
-                        .get_account_id_from_username(&username)
-                        .map_err(move |_| {
-                            error!("Account not found: {}", username);
-                            warp::reject::not_found()
-                        })
-                        .and_then(move |id| {
-                            // TODO this shouldn't take multiple store calls
-                            store
-                                .get_accounts(vec![id])
-                                .map_err(|_| ApiError::internal_server_error().into())
-                                .map(|mut accounts| accounts.pop().unwrap())
-                        })
-                        .and_then(move |account| {
-                            // TODO return the response without instantiating an SpspResponder (use a simple fn)
-                            Ok(SpspResponder::new(
-                                account.ilp_address().clone(),
-                                server_secret_clone.clone(),
-                            )
-                            .generate_http_response())
-                        }),
-                )
-            } else {
-                Either::B(err(ApiError::not_found().into()))
-            }
-        })
-        .boxed();
+    //     // PUT /accounts/:username
+    //     let put_account = warp::put2()
+    //         .and(account_username_to_id.clone())
+    //         .and(warp::path::end())
+    //         .and(admin_only.clone())
+    //         .and(deserialize_json())
+    //         .and(with_store.clone())
+    //         .and_then(move |id: Uuid, account_details: AccountDetails, store: S| {
+    //             let store_clone = store.clone();
+    //             let handler = outgoing_handler.clone();
+    //             let btp = btp.clone();
+    //             store
+    //                 .update_account(id, account_details)
+    //                 .map_err::<_, Rejection>(move |_| ApiError::internal_server_error().into())
+    //                 .and_then(move |account| {
+    //                     connect_to_external_services(handler, account, store_clone, btp)
+    //                 })
+    //                 .and_then(|account: A| Ok(warp::reply::json(&account)))
+    //         })
+    //         .boxed();
 
-    get_spsp
-        .or(get_spsp_well_known)
-        .or(post_accounts)
-        .or(get_accounts)
-        .or(put_account)
-        .or(get_account)
-        .or(get_account_balance)
-        .or(delete_account)
-        .or(put_account_settings)
-        .or(incoming_payment_notifications)
-        .or(post_payments)
-        .boxed()
+    //     // GET /accounts/:username
+    //     let get_account = warp::get2()
+    //         .and(account_username.clone())
+    //         .and(warp::path::end())
+    //         .and(admin_or_authorized_user_only.clone())
+    //         .and(with_store.clone())
+    //         .and_then(|id: Uuid, store: S| {
+    //             store
+    //                 .get_accounts(vec![id])
+    //                 .map_err::<_, Rejection>(|_| ApiError::account_not_found().into())
+    //                 .and_then(|accounts| Ok(warp::reply::json(&accounts[0])))
+    //         })
+    //         .boxed();
+
+    //     // GET /accounts/:username/balance
+    //     let get_account_balance = warp::get2()
+    //         .and(account_username.clone())
+    //         .and(warp::path("balance"))
+    //         .and(warp::path::end())
+    //         .and(admin_or_authorized_user_only.clone())
+    //         .and(with_store.clone())
+    //         .and_then(|id: Uuid, store: S| {
+    //             // TODO reduce the number of store calls it takes to get the balance
+    //             store
+    //                 .get_accounts(vec![id])
+    //                 .map_err(|_| warp::reject::not_found())
+    //                 .and_then(move |mut accounts| {
+    //                     let account = accounts.pop().unwrap();
+    //                     let acc_clone = account.clone();
+    //                     let asset_scale = acc_clone.asset_scale();
+    //                     let asset_code = acc_clone.asset_code().to_owned();
+    //                     store
+    //                         .get_balance(account)
+    //                         .map_err(move |_| {
+    //                             error!("Error getting balance for account: {}", id);
+    //                             ApiError::internal_server_error().into()
+    //                         })
+    //                         .and_then(move |balance: i64| {
+    //                             Ok(warp::reply::json(&json!({
+    //                                 // normalize to the base unit
+    //                                 "balance": balance as f64 / 10_u64.pow(asset_scale.into()) as f64,
+    //                                 "asset_code": asset_code,
+    //                             })))
+    //                         })
+    //                 })
+    //         })
+    //         .boxed();
+
+    //     // DELETE /accounts/:username
+    //     let delete_account = warp::delete2()
+    //         .and(account_username_to_id.clone())
+    //         .and(warp::path::end())
+    //         .and(admin_only.clone())
+    //         .and(with_store.clone())
+    //         .and_then(|id: Uuid, store: S| {
+    //             store
+    //                 .delete_account(id)
+    //                 .map_err::<_, Rejection>(move |_| {
+    //                     error!("Error deleting account {}", id);
+    //                     ApiError::internal_server_error().into()
+    //                 })
+    //                 .and_then(|account| Ok(warp::reply::json(&account)))
+    //         })
+    //         .boxed();
+
+    //     // PUT /accounts/:username/settings
+    //     let put_account_settings = warp::put2()
+    //         .and(account_username.clone())
+    //         .and(warp::path("settings"))
+    //         .and(warp::path::end())
+    //         .and(admin_or_authorized_user_only.clone())
+    //         .and(deserialize_json())
+    //         .and(with_store.clone())
+    //         .and_then(|id: Uuid, settings: AccountSettings, store: S| {
+    //             store
+    //                 .modify_account_settings(id, settings)
+    //                 .map_err::<_, Rejection>(move |_| {
+    //                     error!("Error updating account settings {}", id);
+    //                     ApiError::internal_server_error().into()
+    //                 })
+    //                 .and_then(|settings| Ok(warp::reply::json(&settings)))
+    //         })
+    //         .boxed();
+
+    //     // (Websocket) /accounts/:username/payments/incoming
+    //     let incoming_payment_notifications = account_username
+    //         .clone()
+    //         .and(warp::path("payments"))
+    //         .and(warp::path("incoming"))
+    //         .and(warp::path::end())
+    //         .and(admin_or_authorized_user_only.clone())
+    //         .and(warp::ws2())
+    //         .and(with_store.clone())
+    //         .map(|id: Uuid, ws: warp::ws::Ws2, store: S| {
+    //             ws.on_upgrade(move |ws: warp::ws::WebSocket| {
+    //                 let (tx, rx) = futures::sync::mpsc::unbounded::<PaymentNotification>();
+    //                 store.add_payment_notification_subscription(id, tx);
+    //                 rx.map_err(|_| -> warp::Error { unreachable!("unbounded rx never errors") })
+    //                     .map(|notification| {
+    //                         warp::ws::Message::text(serde_json::to_string(&notification).unwrap())
+    //                     })
+    //                     .forward(ws)
+    //                     .map(|_| ())
+    //                     .map_err(|err| error!("Error forwarding notifications to websocket: {:?}", err))
+    //             })
+    //         })
+    //         .boxed();
+
+    //     // POST /accounts/:username/payments
+    //     let post_payments = warp::post2()
+    //         .and(account_username.clone())
+    //         .and(warp::path("payments"))
+    //         .and(warp::path::end())
+    //         .and(authorized_user_only.clone())
+    //         .and(deserialize_json())
+    //         .and(with_incoming_handler.clone())
+    //         .and_then(
+    //             move |account: A, pay_request: SpspPayRequest, incoming_handler: I| {
+    //                 pay(
+    //                     incoming_handler,
+    //                     account.clone(),
+    //                     &pay_request.receiver,
+    //                     pay_request.source_amount,
+    //                 )
+    //                 .and_then(move |receipt| {
+    //                     debug!("Sent SPSP payment, receipt: {:?}", receipt);
+    //                     Ok(warp::reply::json(&json!(receipt)))
+    //                 })
+    //                 .map_err::<_, Rejection>(|err| {
+    //                     error!("Error sending SPSP payment: {:?}", err);
+    //                     // TODO give a different error message depending on what type of error it is
+    //                     ApiError::internal_server_error().into()
+    //                 })
+    //             },
+    //         )
+    //         .boxed();
+
+    // // GET /accounts/:username/spsp
+    // let server_secret_clone = server_secret.clone();
+    // let get_spsp = warp::get()
+    //     .and(account_username_to_id.clone())
+    //     .and(warp::path("spsp"))
+    //     .and(warp::path::end())
+    //     .and(with_store.clone())
+    //     .and_then(move |id: Uuid, store: S| {
+    //         async {
+    //         let server_secret_clone = server_secret_clone.clone();
+    //         let accounts = store
+    //             .get_accounts(vec![id])
+    //             .map_err(|_| Rejection::from(ApiError::internal_server_error()))
+    //             .await?;
+    //         // TODO return the response without instantiating an SpspResponder (use a simple fn)
+    //         Ok(SpspResponder::new(
+    //             accounts[0].ilp_address().clone(),
+    //             server_secret_clone.clone(),
+    //         )
+    //         .generate_http_response())
+    //     }
+    //     })
+    //     .boxed();
+
+    //     // GET /.well-known/pay
+    //     // This is the endpoint a [Payment Pointer](https://github.com/interledger/rfcs/blob/master/0026-payment-pointers/0026-payment-pointers.md)
+    //     // with no path resolves to
+    //     let server_secret_clone = server_secret.clone();
+    //     let get_spsp_well_known = warp::get2()
+    //         .and(warp::path(".well-known"))
+    //         .and(warp::path("pay"))
+    //         .and(warp::path::end())
+    //         .and(with_store.clone())
+    //         .and_then(move |store: S| {
+    //             // TODO don't clone this
+    //             if let Some(username) = default_spsp_account.clone() {
+    //                 let server_secret_clone = server_secret_clone.clone();
+    //                 Either::A(
+    //                     store
+    //                         .get_account_id_from_username(&username)
+    //                         .map_err(move |_| {
+    //                             error!("Account not found: {}", username);
+    //                             warp::reject::not_found()
+    //                         })
+    //                         .and_then(move |id| {
+    //                             // TODO this shouldn't take multiple store calls
+    //                             store
+    //                                 .get_accounts(vec![id])
+    //                                 .map_err(|_| ApiError::internal_server_error().into())
+    //                                 .map(|mut accounts| accounts.pop().unwrap())
+    //                         })
+    //                         .and_then(move |account| {
+    //                             // TODO return the response without instantiating an SpspResponder (use a simple fn)
+    //                             Ok(SpspResponder::new(
+    //                                 account.ilp_address().clone(),
+    //                                 server_secret_clone.clone(),
+    //                             )
+    //                             .generate_http_response())
+    //                         }),
+    //                 )
+    //             } else {
+    //                 Either::B(err(ApiError::not_found().into()))
+    //             }
+    //         })
+    //         .boxed();
+
+    // get_spsp
+    //         .or(get_spsp_well_known)
+    //         .or(post_accounts)
+    //         .or(get_accounts)
+    //         .or(put_account)
+    //         .or(get_account)
+    //         .or(get_account_balance)
+    //         .or(delete_account)
+    //         .or(put_account_settings)
+    //         .or(incoming_payment_notifications)
+    //         .or(post_payments)
+    // .boxed()
+    warp::path("/").map(|| warp::reply()).boxed()
 }
 
-fn get_address_from_parent_and_update_routes<O, A, S>(
+async fn get_address_from_parent_and_update_routes<O, A, S>(
     mut service: O,
     parent: A,
     store: S,
-) -> impl Future<Item = (), Error = ()>
+) -> Result<(), ()>
 where
     O: OutgoingService<A> + Clone + Send + Sync + 'static,
     A: CcpRoutingAccount + Clone + Send + Sync + 'static,
@@ -494,7 +488,7 @@ where
         parent.id()
     );
     let prepare = IldcpRequest {}.to_prepare();
-    service
+    let fulfill = service
         .send_request(OutgoingRequest {
             from: parent.clone(), // Does not matter what we put here, they will get the account from the HTTP/BTP credentials
             to: parent.clone(),
@@ -502,54 +496,53 @@ where
             original_amount: 0,
         })
         .map_err(|err| error!("Error getting ILDCP info: {:?}", err))
-        .and_then(|fulfill| {
-            let response = IldcpResponse::try_from(fulfill.into_data().freeze()).map_err(|err| {
-                error!(
-                    "Unable to parse ILDCP response from fulfill packet: {:?}",
-                    err
-                );
-            });
-            debug!("Got ILDCP response from parent: {:?}", response);
-            let ilp_address = match response {
-                Ok(info) => info.ilp_address(),
-                Err(_) => return err(()),
-            };
-            ok(ilp_address)
-        })
-        .and_then(move |ilp_address| {
-            debug!("ILP address is now: {}", ilp_address);
-            // TODO we may want to make this trigger the CcpRouteManager to request
-            let prepare = RouteControlRequest {
-                mode: Mode::Sync,
-                last_known_epoch: 0,
-                last_known_routing_table_id: [0; 16],
-                features: Vec::new(),
-            }
-            .to_prepare();
-            debug!("Asking for routes from {:?}", parent.clone());
-            join_all(vec![
-                // Set the parent to be the default route for everything
-                // that starts with their global prefix
-                store.set_default_route(parent.id()),
-                // Update our store's address
-                store.set_ilp_address(ilp_address),
-                // Get the parent's routes for us
-                Box::new(
-                    service
-                        .send_request(OutgoingRequest {
-                            from: parent.clone(),
-                            to: parent.clone(),
-                            original_amount: prepare.amount(),
-                            prepare: prepare.clone(),
-                        })
-                        .and_then(move |_| Ok(()))
-                        .map_err(move |err| {
-                            error!("Got error when trying to update routes {:?}", err)
-                        }),
-                ),
-            ])
-        })
-        .and_then(move |_| Ok(()))
+        .await?;
+
+    let info = IldcpResponse::try_from(fulfill.into_data().freeze()).map_err(|err| {
+        error!(
+            "Unable to parse ILDCP response from fulfill packet: {:?}",
+            err
+        );
+    })?;
+    debug!("Got ILDCP response from parent: {:?}", info);
+    let ilp_address = info.ilp_address();
+
+    debug!("ILP address is now: {}", ilp_address);
+    // TODO we may want to make this trigger the CcpRouteManager to request
+    let prepare = RouteControlRequest {
+        mode: Mode::Sync,
+        last_known_epoch: 0,
+        last_known_routing_table_id: [0; 16],
+        features: Vec::new(),
+    }
+    .to_prepare();
+
+    debug!("Asking for routes from {:?}", parent.clone());
+    let ret = join_all(vec![
+        // Set the parent to be the default route for everything
+        // that starts with their global prefix
+        store.set_default_route(parent.id()),
+        // Update our store's address
+        store.set_ilp_address(ilp_address),
+        // Get the parent's routes for us
+        Box::pin(
+            service
+                .send_request(OutgoingRequest {
+                    from: parent.clone(),
+                    to: parent.clone(),
+                    original_amount: prepare.amount(),
+                    prepare: prepare.clone(),
+                })
+                .map_err(|_| ())
+                .map_ok(|_| ()),
+        ),
+    ])
+    .await;
+    // If any of the 3 futures errored, propagate the error outside
+    if ret.into_iter().any(|r| r.is_err()) {
+        return Err(());
+    }
+    Ok(())
 }
 
 // Helper function which gets called whenever a new account is added or
@@ -562,12 +555,12 @@ where
 // 2b. Perform a RouteControl Request to make them send us any new routes
 // 3. If they have a settlement engine endpoitn configured: Make a POST to the
 //    engine's account creation endpoint with the account's id
-fn connect_to_external_services<O, A, S, B>(
+async fn connect_to_external_services<O, A, S, B>(
     service: O,
     account: A,
     store: S,
     btp: BtpOutgoingService<B, A>,
-) -> impl Future<Item = A, Error = warp::reject::Rejection>
+) -> Result<A, warp::reject::Rejection>
 where
     O: OutgoingService<A> + Clone + Send + Sync + 'static,
     A: CcpRoutingAccount + BtpAccount + SettlementAccount + Clone + Send + Sync + 'static,
@@ -576,64 +569,59 @@ where
 {
     // Try to connect to the account's BTP socket if they have
     // one configured
-    let btp_connect_fut = if account.get_ilp_over_btp_url().is_some() {
+    if account.get_ilp_over_btp_url().is_some() {
         trace!("Newly inserted account has a BTP URL configured, will try to connect");
-        Either::A(
-            connect_to_service_account(account.clone(), true, btp)
-                .map_err(|_| ApiError::internal_server_error().into()),
-        )
-    } else {
-        Either::B(ok(()))
-    };
+        connect_to_service_account(account.clone(), true, btp)
+            .map_err(|_| Rejection::from(ApiError::internal_server_error()))
+            .await?
+    }
 
-    btp_connect_fut.and_then(move |_| {
-        // If we added a parent, get the address assigned to us by
-        // them and update all of our routes
-        let get_ilp_address_fut = if account.routing_relation() == RoutingRelation::Parent {
-            Either::A(
-                get_address_from_parent_and_update_routes(service, account.clone(), store.clone())
-                .map_err(|_| ApiError::internal_server_error().into())
-            )
+    // If we added a parent, get the address assigned to us by
+    // them and update all of our routes
+    if account.routing_relation() == RoutingRelation::Parent {
+        get_address_from_parent_and_update_routes(service, account.clone(), store.clone())
+            .map_err(|_| Rejection::from(ApiError::internal_server_error()))
+            .await?;
+    }
+
+    // Register the account with the settlement engine
+    // if a settlement_engine_url was configured on the account
+    // or if there is a settlement engine configured for that
+    // account's asset_code
+    let default_settlement_engine = store
+        .get_asset_settlement_engine(account.asset_code())
+        .map_err(|_| Rejection::from(ApiError::internal_server_error()))
+        .await?;
+
+    let settlement_engine_url = account
+        .settlement_engine_details()
+        .map(|details| details.url)
+        .or(default_settlement_engine);
+    if let Some(se_url) = settlement_engine_url {
+        let id = account.id();
+        let http_client = Client::default();
+        trace!(
+            "Sending account {} creation request to settlement engine: {:?}",
+            id,
+            se_url.clone()
+        );
+
+        let status_code = http_client
+            .create_engine_account(se_url, id)
+            .map_err(|_| Rejection::from(ApiError::internal_server_error()))
+            .await?;
+
+        if status_code.is_success() {
+            trace!("Account {} created on the SE", id);
         } else {
-            Either::B(ok(()))
-        };
+            error!(
+                "Error creating account. Settlement engine responded with HTTP code: {}",
+                status_code
+            );
+        }
+    }
 
-        let default_settlement_engine_fut = store.get_asset_settlement_engine(account.asset_code())
-            .map_err(|_| ApiError::internal_server_error().into());
-
-        // Register the account with the settlement engine
-        // if a settlement_engine_url was configured on the account
-        // or if there is a settlement engine configured for that
-        // account's asset_code
-        default_settlement_engine_fut.join(get_ilp_address_fut).and_then(move |(default_settlement_engine, _)| {
-            let settlement_engine_url = account.settlement_engine_details().map(|details| details.url).or(default_settlement_engine);
-            if let Some(se_url) = settlement_engine_url {
-                let id = account.id();
-                let http_client = Client::default();
-                trace!(
-                    "Sending account {} creation request to settlement engine: {:?}",
-                    id,
-                    se_url.clone()
-                );
-                Either::A(
-                    http_client.create_engine_account(se_url, id)
-                    .map_err(|_| ApiError::internal_server_error().into())
-                    .and_then(move |status_code| {
-                        if status_code.is_success() {
-                            trace!("Account {} created on the SE", id);
-                        } else {
-                            error!("Error creating account. Settlement engine responded with HTTP code: {}", status_code);
-                        }
-                        Ok(())
-                    })
-                    .and_then(move |_| {
-                        Ok(account)
-                    }))
-            } else {
-                Either::B(ok(account))
-            }
-        })
-    })
+    Ok(account)
 }
 
 #[cfg(test)]

--- a/crates/interledger-api/src/routes/mod.rs
+++ b/crates/interledger-api/src/routes/mod.rs
@@ -1,8 +1,8 @@
-mod accounts;
-// mod node_settings;
+// mod accounts;
+mod node_settings;
 
 // pub use accounts::accounts_api;
-// pub use node_settings::node_settings_api;
+pub use node_settings::node_settings_api;
 
-// #[cfg(test)]
-// pub mod test_helpers;
+#[cfg(test)]
+pub mod test_helpers;

--- a/crates/interledger-api/src/routes/mod.rs
+++ b/crates/interledger-api/src/routes/mod.rs
@@ -1,7 +1,7 @@
-// mod accounts;
+mod accounts;
 mod node_settings;
 
-// pub use accounts::accounts_api;
+pub use accounts::accounts_api;
 pub use node_settings::node_settings_api;
 
 #[cfg(test)]

--- a/crates/interledger-api/src/routes/mod.rs
+++ b/crates/interledger-api/src/routes/mod.rs
@@ -1,8 +1,8 @@
 mod accounts;
-mod node_settings;
+// mod node_settings;
 
-pub use accounts::accounts_api;
-pub use node_settings::node_settings_api;
+// pub use accounts::accounts_api;
+// pub use node_settings::node_settings_api;
 
-#[cfg(test)]
-pub mod test_helpers;
+// #[cfg(test)]
+// pub mod test_helpers;

--- a/crates/interledger-api/src/routes/node_settings.rs
+++ b/crates/interledger-api/src/routes/node_settings.rs
@@ -197,7 +197,6 @@ where
         .and(with_store.clone())
         .and_then(|prefix: String, body: bytes05::Bytes, store: S| {
             async move {
-                println!("TRYING TO PARSE USERNAEME");
                 let username_str =
                     str::from_utf8(&body).map_err(|_| Rejection::from(ApiError::bad_request()))?;
                 let username = Username::from_str(username_str)

--- a/crates/interledger-api/src/routes/node_settings.rs
+++ b/crates/interledger-api/src/routes/node_settings.rs
@@ -2,9 +2,9 @@ use crate::{http_retry::Client, ExchangeRates, NodeStore};
 use bytes::Buf;
 use futures::{
     future::{err, join_all, Either},
-    Future,
+    Future, TryFutureExt,
 };
-use interledger_http::{deserialize_json, error::*, HttpAccount, HttpStore};
+use interledger_http::{error::*, HttpAccount, HttpStore};
 use interledger_packet::Address;
 use interledger_router::RouterStore;
 use interledger_service::{Account, Username};
@@ -19,7 +19,8 @@ use std::{
     str::{self, FromStr},
 };
 use url::Url;
-use warp::{self, Filter, Rejection};
+use uuid::Uuid;
+use warp::{self, reply::Json, Filter, Rejection};
 
 // TODO add more to this response
 #[derive(Clone, Serialize)]
@@ -41,20 +42,22 @@ where
         + BalanceStore<Account = A>
         + ExchangeRateStore
         + RouterStore,
-    A: Account + HttpAccount + SettlementAccount + Serialize + 'static,
+    A: Account + HttpAccount + Send + Sync + SettlementAccount + Serialize + 'static,
 {
     // Helper filters
     let admin_auth_header = format!("Bearer {}", admin_api_token);
     let admin_only = warp::header::<SecretString>("authorization")
-        .and_then(
-            move |authorization: SecretString| -> Result<(), Rejection> {
-                if authorization.expose_secret() == &admin_auth_header {
-                    Ok(())
+        .and_then(move |authorization: SecretString| {
+            let authorization_clone = authorization.clone();
+            let admin_auth_header = admin_auth_header.clone();
+            async move {
+                if authorization_clone.expose_secret() == &admin_auth_header {
+                    Ok::<(), Rejection>(())
                 } else {
-                    Err(ApiError::unauthorized().into())
+                    Err(Rejection::from(ApiError::unauthorized()))
                 }
-            },
-        )
+            }
+        })
         // This call makes it so we do not pass on a () value on
         // success to the next filter, it just gets rid of it
         .untuple_one()
@@ -62,7 +65,7 @@ where
     let with_store = warp::any().map(move || store.clone()).boxed();
 
     // GET /
-    let get_root = warp::get2()
+    let get_root = warp::get()
         .and(warp::path::end())
         .and(with_store.clone())
         .map(move |store: S| {
@@ -75,197 +78,201 @@ where
         .boxed();
 
     // PUT /rates
-    let put_rates = warp::put2()
+    let put_rates = warp::put()
         .and(warp::path("rates"))
         .and(warp::path::end())
         .and(admin_only.clone())
-        .and(deserialize_json())
+        .and(warp::body::json())
         .and(with_store.clone())
-        .and_then(|rates: ExchangeRates, store: S| -> Result<_, Rejection> {
-            if store.set_exchange_rates(rates.0.clone()).is_ok() {
-                Ok(warp::reply::json(&rates))
-            } else {
-                error!("Error setting exchange rates");
-                Err(ApiError::internal_server_error().into())
+        .and_then(|rates: ExchangeRates, store: S| {
+            async move {
+                if store.set_exchange_rates(rates.0.clone()).is_ok() {
+                    Ok(warp::reply::json(&rates))
+                } else {
+                    error!("Error setting exchange rates");
+                    Err(Rejection::from(ApiError::internal_server_error()))
+                }
             }
         })
         .boxed();
 
     // GET /rates
-    let get_rates = warp::get2()
+    let get_rates = warp::get()
         .and(warp::path("rates"))
         .and(warp::path::end())
         .and(with_store.clone())
-        .and_then(|store: S| -> Result<_, Rejection> {
-            if let Ok(rates) = store.get_all_exchange_rates() {
-                Ok(warp::reply::json(&rates))
-            } else {
-                error!("Error getting exchange rates");
-                Err(ApiError::internal_server_error().into())
+        .and_then(|store: S| {
+            async move {
+                if let Ok(rates) = store.get_all_exchange_rates() {
+                    Ok::<Json, Rejection>(warp::reply::json(&rates))
+                } else {
+                    error!("Error getting exchange rates");
+                    Err(Rejection::from(ApiError::internal_server_error()))
+                }
             }
         })
         .boxed();
 
-    // GET /routes
+    // // GET /routes
     // Response: Map of ILP Address prefix -> Username
-    let get_routes = warp::get2()
+    let get_routes = warp::get()
         .and(warp::path("routes"))
         .and(warp::path::end())
         .and(with_store.clone())
         .and_then(|store: S| {
-            // Convert the account IDs listed in the routing table
-            // to the usernames for the API response
-            let routes = store.routing_table().clone();
-            store
-                .get_accounts(routes.values().cloned().collect())
-                .map_err::<_, Rejection>(|_| {
-                    error!("Error getting accounts from store");
-                    ApiError::internal_server_error().into()
-                })
-                .and_then(move |accounts| {
-                    let routes: HashMap<String, String> = HashMap::from_iter(
-                        routes
-                            .iter()
-                            .map(|(prefix, _)| prefix.to_string())
-                            .zip(accounts.into_iter().map(|a| a.username().to_string())),
-                    );
+            async move {
+                // Convert the account IDs listed in the routing table
+                // to the usernames for the API response
+                let routes = store.routing_table().clone();
+                let accounts = store
+                    .get_accounts(routes.values().cloned().collect())
+                    .map_err(|_| {
+                        error!("Error getting accounts from store");
+                        Rejection::from(ApiError::internal_server_error())
+                    })
+                    .await?;
+                let routes: HashMap<String, String> = HashMap::from_iter(
+                    routes
+                        .iter()
+                        .map(|(prefix, _)| prefix.to_string())
+                        .zip(accounts.into_iter().map(|a| a.username().to_string())),
+                );
 
-                    Ok(warp::reply::json(&routes))
-                })
+                Ok::<Json, Rejection>(warp::reply::json(&routes))
+            }
         })
         .boxed();
 
     // PUT /routes/static
     // Body: Map of ILP Address prefix -> Username
-    let put_static_routes = warp::put2()
+    let put_static_routes = warp::put()
         .and(warp::path("routes"))
         .and(warp::path("static"))
         .and(warp::path::end())
         .and(admin_only.clone())
-        .and(deserialize_json())
+        .and(warp::body::json())
         .and(with_store.clone())
-        .and_then(|routes: HashMap<String, Username>, store: S| {
-            // Convert the usernames to account IDs to set the routes in the store
-            let store_clone = store.clone();
-            let usernames: Vec<Username> = routes.values().cloned().collect();
-            // TODO use one store call to look up all of the usernames
-            join_all(usernames.into_iter().map(move |username| {
-                store_clone
-                    .get_account_id_from_username(&username)
-                    .map_err(move |_| {
-                        error!("No account exists with username: {}", username);
-                        ApiError::account_not_found().into()
-                    })
-            }))
-            .and_then(move |account_ids| {
+        .and_then(move |routes: HashMap<String, String>, store: S| {
+            async move {
+                // Convert the usernames to account IDs to set the routes in the store
+                let mut usernames: Vec<Username> = Vec::new();
+                for username in routes.values() {
+                    let user = match Username::from_str(&username) {
+                        Ok(u) => u,
+                        Err(_) => return Err(Rejection::from(ApiError::bad_request())),
+                    };
+                    usernames.push(user);
+                }
+
+                let mut account_ids: Vec<Uuid> = Vec::new();
+                for username in usernames {
+                    account_ids.push(
+                        store
+                            .get_account_id_from_username(&username)
+                            .map_err(|_| {
+                                error!("Error setting static routes");
+                                Rejection::from(ApiError::internal_server_error())
+                            })
+                            .await?,
+                    );
+                }
+
                 let prefixes = routes.keys().map(|s| s.to_string());
                 store
                     .set_static_routes(prefixes.zip(account_ids.into_iter()))
-                    .map_err::<_, Rejection>(|_| {
+                    .map_err(|_| {
                         error!("Error setting static routes");
-                        ApiError::internal_server_error().into()
+                        Rejection::from(ApiError::internal_server_error())
                     })
-                    .map(move |_| warp::reply::json(&routes))
-            })
+                    .await?;
+                Ok::<Json, Rejection>(warp::reply::json(&routes))
+            }
         })
         .boxed();
 
     // PUT /routes/static/:prefix
     // Body: Username
-    let put_static_route = warp::put2()
+    let put_static_route = warp::put()
         .and(warp::path("routes"))
         .and(warp::path("static"))
-        .and(warp::path::param2::<String>())
+        .and(warp::path::param::<String>())
         .and(warp::path::end())
         .and(admin_only.clone())
-        .and(warp::body::concat())
+        .and(warp::body::bytes())
         .and(with_store.clone())
-        .and_then(|prefix: String, body: warp::body::FullBody, store: S| {
-            if let Ok(username) = str::from_utf8(body.bytes())
-                .map_err(|_| ())
-                .and_then(|string| Username::from_str(string).map_err(|_| ()))
-            {
+        .and_then(|prefix: String, body: bytes05::Bytes, store: S| {
+            async move {
+                println!("TRYING TO PARSE USERNAEME");
+                let username_str =
+                    str::from_utf8(&body).map_err(|_| Rejection::from(ApiError::bad_request()))?;
+                let username = Username::from_str(username_str)
+                    .map_err(|_| Rejection::from(ApiError::bad_request()))?;
                 // Convert the username to an account ID to set it in the store
-                let username_clone = username.clone();
-                Either::A(
-                    store
-                        .clone()
-                        .get_account_id_from_username(&username)
-                        .map_err(move |_| {
-                            error!("No account exists with username: {}", username_clone);
-                            ApiError::account_not_found().into()
-                        })
-                        .and_then(move |account_id| {
-                            store
-                                .set_static_route(prefix, account_id)
-                                .map_err::<_, Rejection>(|_| {
-                                    error!("Error setting static route");
-                                    ApiError::internal_server_error().into()
-                                })
-                        })
-                        .map(move |_| username.to_string()),
-                )
-            } else {
-                Either::B(err(ApiError::bad_request().into()))
+                let account_id = store
+                    .get_account_id_from_username(&username)
+                    .map_err(|_| {
+                        error!("No account exists with username: {}", username);
+                        Rejection::from(ApiError::account_not_found())
+                    })
+                    .await?;
+                store
+                    .set_static_route(prefix, account_id)
+                    .map_err(|_| {
+                        error!("Error setting static route");
+                        Rejection::from(ApiError::internal_server_error())
+                    })
+                    .await?;
+                Ok::<String, Rejection>(username.to_string())
             }
         })
         .boxed();
 
     // PUT /settlement/engines
-    let put_settlement_engines = warp::put2()
+    let put_settlement_engines = warp::put()
         .and(warp::path("settlement"))
         .and(warp::path("engines"))
         .and(warp::path::end())
         .and(admin_only.clone())
-        .and(deserialize_json())
+        .and(warp::body::json())
         .and(with_store.clone())
-        .and_then(|asset_to_url_map: HashMap<String, Url>, store: S| {
+        .and_then(move |asset_to_url_map: HashMap<String, Url>, store: S| async move {
             let asset_to_url_map_clone = asset_to_url_map.clone();
             store
                 .set_settlement_engines(asset_to_url_map.clone())
-                .map_err::<_, Rejection>(|_| {
+                .map_err(|_| {
                     error!("Error setting settlement engines");
-                    ApiError::internal_server_error().into()
-                })
-                .and_then(move |_| {
-                    // Create the accounts on the settlement engines for any
-                    // accounts that are using the default settlement engine URLs
-                    // (This is done in case we modify the globally configured settlement
-                    // engine URLs after accounts have already been added)
+                    Rejection::from(ApiError::internal_server_error())
+                }).await?;
+            // Create the accounts on the settlement engines for any
+            // accounts that are using the default settlement engine URLs
+            // (This is done in case we modify the globally configured settlement
+            // engine URLs after accounts have already been added)
 
-                    // TODO we should come up with a better way of ensuring
-                    // the accounts are created that doesn't involve loading
-                    // all of the accounts from the database into memory
-                    // (even if this isn't called often, it could crash the node at some point)
-                    store.get_all_accounts()
-                        .map_err(|_| ApiError::internal_server_error().into())
-                    .and_then(move |accounts| {
-                        let client = Client::default();
-                        let create_settlement_accounts =
-                            accounts.into_iter().filter_map(move |account| {
-                                let id = account.id();
-                                // Try creating the account on the settlement engine if the settlement_engine_url of the
-                                // account is the one we just configured as the default for the account's asset code
-                                if let Some(details) = account.settlement_engine_details() {
-                                    if Some(&details.url) == asset_to_url_map.get(account.asset_code()) {
-                                        return Some(client.create_engine_account(details.url, account.id())
-                                            .map_err(|_| ApiError::internal_server_error().into())
-                                            .and_then(move |status_code| {
-                                                if status_code.is_success() {
-                                                    trace!("Account {} created on the SE", id);
-                                                } else {
-                                                    error!("Error creating account. Settlement engine responded with HTTP code: {}", status_code);
-                                                }
-                                                Ok(())
-                                            }));
-                                        }
-                                }
-                                None
-                            });
-                        join_all(create_settlement_accounts)
-                    })
-                })
-                .and_then(move |_| Ok(warp::reply::json(&asset_to_url_map_clone)))
+            // TODO we should come up with a better way of ensuring
+            // the accounts are created that doesn't involve loading
+            // all of the accounts from the database into memory
+            // (even if this isn't called often, it could crash the node at some point)
+            let accounts = store.get_all_accounts()
+                .map_err(|_| Rejection::from(ApiError::internal_server_error())).await?;
+
+            let client = Client::default();
+            // Try creating the account on the settlement engine if the settlement_engine_url of the
+            // account is the one we just configured as the default for the account's asset code
+            for account in accounts {
+                if let Some(details) = account.settlement_engine_details() {
+                    if Some(&details.url) == asset_to_url_map.get(account.asset_code()) {
+                        let status_code = client.create_engine_account(details.url, account.id())
+                            .map_err(|_| Rejection::from(ApiError::internal_server_error()))
+                            .await?;
+                        if status_code.is_success() {
+                            trace!("Account {} created on the SE", account.id());
+                        } else {
+                            error!("Error creating account. Settlement engine responded with HTTP code: {}", status_code);
+                        }
+                    }
+                }
+            }
+            Ok::<Json, Rejection>(warp::reply::json(&asset_to_url_map_clone))
         })
         .boxed();
 
@@ -284,10 +291,10 @@ mod tests {
     use crate::routes::test_helpers::{api_call, test_node_settings_api};
     use serde_json::{json, Value};
 
-    #[test]
-    fn gets_status() {
+    #[tokio::test]
+    async fn gets_status() {
         let api = test_node_settings_api();
-        let resp = api_call(&api, "GET", "/", "", None);
+        let resp = api_call(&api, "GET", "/", "", None).await;
         assert_eq!(resp.status().as_u16(), 200);
         assert_eq!(
             resp.body(),
@@ -295,10 +302,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn gets_rates() {
+    #[tokio::test]
+    async fn gets_rates() {
         let api = test_node_settings_api();
-        let resp = api_call(&api, "GET", "/rates", "", None);
+        let resp = api_call(&api, "GET", "/rates", "", None).await;
         assert_eq!(resp.status().as_u16(), 200);
         assert_eq!(
             serde_json::from_slice::<Value>(resp.body()).unwrap(),
@@ -306,56 +313,60 @@ mod tests {
         );
     }
 
-    #[test]
-    fn gets_routes() {
+    #[tokio::test]
+    async fn gets_routes() {
         let api = test_node_settings_api();
-        let resp = api_call(&api, "GET", "/routes", "", None);
+        let resp = api_call(&api, "GET", "/routes", "", None).await;
         assert_eq!(resp.status().as_u16(), 200);
     }
 
-    #[test]
-    fn only_admin_can_put_rates() {
+    #[tokio::test]
+    async fn only_admin_can_put_rates() {
         let api = test_node_settings_api();
         let rates = json!({"ABC": 1.0});
-        let resp = api_call(&api, "PUT", "/rates", "admin", Some(rates.clone()));
+        let resp = api_call(&api, "PUT", "/rates", "admin", Some(rates.clone())).await;
         assert_eq!(resp.status().as_u16(), 200);
 
-        let resp = api_call(&api, "PUT", "/rates", "wrong", Some(rates));
+        let resp = api_call(&api, "PUT", "/rates", "wrong", Some(rates)).await;
         assert_eq!(resp.status().as_u16(), 401);
     }
 
-    #[test]
-    fn only_admin_can_put_static_routes() {
+    #[tokio::test]
+    async fn only_admin_can_put_static_routes() {
         let api = test_node_settings_api();
         let routes = json!({"g.node1": "alice", "example.eu": "bob"});
-        let resp = api_call(&api, "PUT", "/routes/static", "admin", Some(routes.clone()));
+        let resp = api_call(&api, "PUT", "/routes/static", "admin", Some(routes.clone())).await;
         assert_eq!(resp.status().as_u16(), 200);
 
-        let resp = api_call(&api, "PUT", "/routes/static", "wrong", Some(routes));
+        let resp = api_call(&api, "PUT", "/routes/static", "wrong", Some(routes)).await;
         assert_eq!(resp.status().as_u16(), 401);
     }
 
-    #[test]
-    fn only_admin_can_put_single_static_route() {
+    #[tokio::test]
+    async fn only_admin_can_put_single_static_route() {
         let api = test_node_settings_api();
-        let api_put = move |auth: &str| {
-            warp::test::request()
-                .method("PUT")
-                .path("/routes/static/g.node1")
-                .body("alice")
-                .header("Authorization", format!("Bearer {}", auth.to_string()))
-                .reply(&api)
+        let api_put = |auth: String| {
+            let auth = format!("Bearer {}", auth);
+            async {
+                warp::test::request()
+                    .method("PUT")
+                    .path("/routes/static/g.node1")
+                    .body("alice")
+                    .header("Authorization", auth)
+                    .reply(&api)
+                    .await
+            }
         };
 
-        let resp = api_put("admin");
+        let resp = api_put("admin".to_owned()).await;
         assert_eq!(resp.status().as_u16(), 200);
 
-        let resp = api_put("wrong");
+        let resp = api_put("wrong".to_owned()).await;
         assert_eq!(resp.status().as_u16(), 401);
     }
 
-    #[test]
-    fn only_admin_can_put_engines() {
+    #[tokio::test]
+    async fn only_admin_can_put_engines() {
         let api = test_node_settings_api();
         let engines = json!({"ABC": "http://localhost:3000", "XYZ": "http://localhost:3001"});
         let resp = api_call(
@@ -364,10 +375,11 @@ mod tests {
             "/settlement/engines",
             "admin",
             Some(engines.clone()),
-        );
+        )
+        .await;
         assert_eq!(resp.status().as_u16(), 200);
 
-        let resp = api_call(&api, "PUT", "/settlement/engines", "wrong", Some(engines));
+        let resp = api_call(&api, "PUT", "/settlement/engines", "wrong", Some(engines)).await;
         assert_eq!(resp.status().as_u16(), 401);
     }
 }

--- a/crates/interledger-api/src/routes/test_helpers.rs
+++ b/crates/interledger-api/src/routes/test_helpers.rs
@@ -1,11 +1,10 @@
-use crate::{routes::{node_settings_api, accounts_api}, AccountDetails, AccountSettings, NodeStore};
+use crate::{
+    routes::{accounts_api, node_settings_api},
+    AccountDetails, AccountSettings, NodeStore,
+};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::channel::mpsc::UnboundedSender;
-use futures::{
-    future::{err, ok},
-    Future,
-};
 use http::Response;
 use interledger_btp::{BtpAccount, BtpOutgoingService};
 use interledger_ccp::{CcpRoutingAccount, RoutingRelation};
@@ -41,6 +40,7 @@ where
     F: warp::Filter + 'static,
     F::Extract: warp::Reply,
 {
+    println!("calling {:?}, {:?} {:?}", method, endpoint, data);
     let mut ret = warp::test::request()
         .method(method)
         .path(endpoint)

--- a/crates/interledger-api/src/routes/test_helpers.rs
+++ b/crates/interledger-api/src/routes/test_helpers.rs
@@ -40,7 +40,6 @@ where
     F: warp::Filter + 'static,
     F::Extract: warp::Reply,
 {
-    println!("calling {:?}, {:?} {:?}", method, endpoint, data);
     let mut ret = warp::test::request()
         .method(method)
         .path(endpoint)

--- a/crates/interledger-api/src/routes/test_helpers.rs
+++ b/crates/interledger-api/src/routes/test_helpers.rs
@@ -1,4 +1,4 @@
-use crate::{routes::node_settings_api, AccountDetails, AccountSettings, NodeStore};
+use crate::{routes::{node_settings_api, accounts_api}, AccountDetails, AccountSettings, NodeStore};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::channel::mpsc::UnboundedSender;
@@ -58,40 +58,40 @@ pub fn test_node_settings_api(
     node_settings_api("admin".to_owned(), None, TestStore).recover(default_rejection_handler)
 }
 
-// pub fn test_accounts_api(
-// ) -> impl warp::Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-//     let incoming = incoming_service_fn(|_request| {
-//         Err(RejectBuilder {
-//             code: ErrorCode::F02_UNREACHABLE,
-//             message: b"No other incoming handler!",
-//             data: &[],
-//             triggered_by: None,
-//         }
-//         .build())
-//     });
-//     let outgoing = outgoing_service_fn(move |_request| {
-//         Ok(FulfillBuilder {
-//             fulfillment: &[0; 32],
-//             data: b"hello!",
-//         }
-//         .build())
-//     });
-//     let btp = BtpOutgoingService::new(
-//         Address::from_str("example.alice").unwrap(),
-//         outgoing.clone(),
-//     );
-//     let store = TestStore;
-//     accounts_api(
-//         Bytes::from("admin"),
-//         "admin".to_owned(),
-//         None,
-//         incoming,
-//         outgoing,
-//         btp,
-//         store,
-//     )
-//     .recover(default_rejection_handler)
-// }
+pub fn test_accounts_api(
+) -> impl warp::Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    let incoming = incoming_service_fn(|_request| {
+        Err(RejectBuilder {
+            code: ErrorCode::F02_UNREACHABLE,
+            message: b"No other incoming handler!",
+            data: &[],
+            triggered_by: None,
+        }
+        .build())
+    });
+    let outgoing = outgoing_service_fn(move |_request| {
+        Ok(FulfillBuilder {
+            fulfillment: &[0; 32],
+            data: b"hello!",
+        }
+        .build())
+    });
+    let btp = BtpOutgoingService::new(
+        Address::from_str("example.alice").unwrap(),
+        outgoing.clone(),
+    );
+    let store = TestStore;
+    accounts_api(
+        Bytes::from("admin"),
+        "admin".to_owned(),
+        None,
+        incoming,
+        outgoing,
+        btp,
+        store,
+    )
+    .recover(default_rejection_handler)
+}
 
 /*
  * Lots of boilerplate implementations of all necessary traits to launch

--- a/crates/interledger-btp/Cargo.toml
+++ b/crates/interledger-btp/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 bytes = { version = "0.4.12", default-features = false }
 byteorder = { version = "1.3.2", default-features = false }
 chrono = { version = "0.4.9", default-features = false }
-futures = { version = "0.1.29", default-features = false }
+futures = { version = "0.3.1", default-features = false }
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 log = { version = "0.4.8", default-features = false }
@@ -20,14 +20,16 @@ parking_lot = { version = "0.9.0", default-features = false }
 quick-error = { version = "1.2.2", default-features = false }
 rand = { version = "0.7.2", default-features = false, features = ["std"] }
 stream-cancel = { version = "0.4.4", default-features = false }
-tokio-executor = { version = "0.1.8", default-features = false }
-tokio-timer = { version = "0.2.11", default-features = false }
-tokio-tungstenite = { version = "0.9.0", default-features = false, features = ["tls", "connect"] }
-tungstenite = { version = "0.9.1", default-features = false }
+# tokio-tungstenite = { version = "0.9.0", default-features = false, features = ["tls", "connect"] }
+tokio-tungstenite = { package = "tokio-tungstenite", git = "https://github.com/snapview/tokio-tungstenite", default-features = false, features = ["tls", "connect"] }
+
+tungstenite = { version = "0.9.2", default-features = false }
 url = { version = "2.1.0", default-features = false }
 uuid = { version = "0.8.1", default-features = false, features = ["v4"]}
 warp = { version = "0.1.20", default-features = false, features = ["websocket"] }
 secrecy = "0.5.1"
+async-trait = "0.1.22"
+tokio = { version = "0.2.8", features = ["rt-core"] }
 
 [dev-dependencies]
 hex = { version = "0.4.0", default-features = false }

--- a/crates/interledger-btp/Cargo.toml
+++ b/crates/interledger-btp/Cargo.toml
@@ -19,21 +19,20 @@ num-bigint = { version = "0.2.3", default-features = false, features = ["std"] }
 parking_lot = { version = "0.9.0", default-features = false }
 quick-error = { version = "1.2.2", default-features = false }
 rand = { version = "0.7.2", default-features = false, features = ["std"] }
-stream-cancel = { version = "0.4.4", default-features = false }
-# tokio-tungstenite = { version = "0.9.0", default-features = false, features = ["tls", "connect"] }
-tokio-tungstenite = { package = "tokio-tungstenite", git = "https://github.com/snapview/tokio-tungstenite", default-features = false, features = ["tls", "connect"] }
+stream-cancel = { version = "0.5", default-features = false }
+tokio-tungstenite = { version = "0.10.0", package = "tokio-tungstenite", git = "https://github.com/snapview/tokio-tungstenite", default-features = false, features = ["tls", "connect"] }
 
-tungstenite = { version = "0.9.2", default-features = false }
+tungstenite = { version = "0.9.1", default-features = false }
 url = { version = "2.1.0", default-features = false }
 uuid = { version = "0.8.1", default-features = false, features = ["v4"]}
 # warp = { version = "0.1.20", default-features = false, features = ["websocket"] }
 warp = { git = "https://github.com/seanmonstar/warp.git" }
 secrecy = "0.5.1"
 async-trait = "0.1.22"
-tokio = { version = "0.2.8", features = ["rt-core"] }
+tokio = { version = "0.2.8", features = ["rt-core", "time", "stream"] }
+lazy_static = { version = "1.4.0", default-features = false }
+pin-project = "0.4.6"
 
 [dev-dependencies]
 hex = { version = "0.4.0", default-features = false }
-lazy_static = { version = "1.4.0", default-features = false }
 net2 = { version = "0.2.33", default-features = false }
-tokio = { version = "0.1.22", default-features = false }

--- a/crates/interledger-btp/Cargo.toml
+++ b/crates/interledger-btp/Cargo.toml
@@ -26,7 +26,8 @@ tokio-tungstenite = { package = "tokio-tungstenite", git = "https://github.com/s
 tungstenite = { version = "0.9.2", default-features = false }
 url = { version = "2.1.0", default-features = false }
 uuid = { version = "0.8.1", default-features = false, features = ["v4"]}
-warp = { version = "0.1.20", default-features = false, features = ["websocket"] }
+# warp = { version = "0.1.20", default-features = false, features = ["websocket"] }
+warp = { git = "https://github.com/seanmonstar/warp.git" }
 secrecy = "0.5.1"
 async-trait = "0.1.22"
 tokio = { version = "0.2.8", features = ["rt-core"] }

--- a/crates/interledger-btp/src/client.rs
+++ b/crates/interledger-btp/src/client.rs
@@ -1,7 +1,9 @@
 use super::packet::*;
 use super::service::BtpOutgoingService;
 use super::BtpAccount;
-use futures::{future::join_all, Future, Sink, Stream};
+use futures::{
+    future::join_all, Future, Sink, SinkExt, Stream, StreamExt, TryFutureExt, TryStreamExt,
+};
 use interledger_packet::Address;
 use interledger_service::*;
 use log::{debug, error, trace};
@@ -22,12 +24,12 @@ pub fn parse_btp_url(uri: &str) -> Result<Url, ParseError> {
 /// Create a BtpOutgoingService wrapping BTP connections to the accounts specified.
 /// Calling `handle_incoming` with an `IncomingService` will turn the returned
 /// BtpOutgoingService into a bidirectional handler.
-pub fn connect_client<A, S>(
+pub async fn connect_client<A, S>(
     ilp_address: Address,
     accounts: Vec<A>,
     error_on_unavailable: bool,
     next_outgoing: S,
-) -> impl Future<Item = BtpOutgoingService<S, A>, Error = ()>
+) -> Result<BtpOutgoingService<S, A>, ()>
 where
     S: OutgoingService<A> + Clone + 'static,
     A: BtpAccount + 'static,
@@ -42,14 +44,15 @@ where
             service.clone(),
         ));
     }
-    join_all(connect_btp).and_then(move |_| Ok(service))
+    join_all(connect_btp).await;
+    Ok(service)
 }
 
-pub fn connect_to_service_account<O, A>(
+pub async fn connect_to_service_account<O, A>(
     account: A,
     error_on_unavailable: bool,
     service: BtpOutgoingService<O, A>,
-) -> impl Future<Item = (), Error = ()>
+) -> Result<(), ()>
 where
     O: OutgoingService<A> + Clone + 'static,
     A: BtpAccount + 'static,
@@ -67,58 +70,61 @@ where
         .map(|s| s.to_vec())
         .unwrap_or_default();
     debug!("Connecting to {}", url);
-    connect_async(url.clone())
+
+    let (mut connection, _) = connect_async(url.clone())
         .map_err(move |err| {
             error!(
                 "Error connecting to WebSocket server for account: {} {:?}",
                 account_id, err
             )
         })
-        .and_then(move |(connection, _)| {
-            trace!(
-                "Connected to account {} (URI: {}), sending auth packet",
-                account_id,
-                url
-            );
-            // Send BTP authentication
-            let auth_packet = Message::Binary(
-                BtpPacket::Message(BtpMessage {
-                    request_id: random(),
-                    protocol_data: vec![
-                        ProtocolData {
-                            protocol_name: String::from("auth"),
-                            content_type: ContentType::ApplicationOctetStream,
-                            data: vec![],
-                        },
-                        ProtocolData {
-                            protocol_name: String::from("auth_token"),
-                            content_type: ContentType::TextPlainUtf8,
-                            data: token,
-                        },
-                    ],
-                })
-                .to_bytes(),
-            );
+        .await?;
 
-            // TODO check that the response is a success before proceeding
-            // (right now we just assume they'll close the connection if the auth didn't work)
-            connection
-                .send(auth_packet)
-                .map_err(move |_| error!("Error sending auth packet on connection: {}", url))
-                .then(move |result| match result {
-                    Ok(connection) => {
-                        debug!("Connected to account {}'s server", account.id());
-                        let connection = connection.from_err().sink_from_err();
-                        service.add_connection(account, connection);
-                        Ok(())
-                    }
-                    Err(_) => {
-                        if error_on_unavailable {
-                            Err(())
-                        } else {
-                            Ok(())
-                        }
-                    }
-                })
+    trace!(
+        "Connected to account {} (URI: {}), sending auth packet",
+        account_id,
+        url
+    );
+
+    // Send BTP authentication
+    let auth_packet = Message::Binary(
+        BtpPacket::Message(BtpMessage {
+            request_id: random(),
+            protocol_data: vec![
+                ProtocolData {
+                    protocol_name: String::from("auth"),
+                    content_type: ContentType::ApplicationOctetStream,
+                    data: vec![],
+                },
+                ProtocolData {
+                    protocol_name: String::from("auth_token"),
+                    content_type: ContentType::TextPlainUtf8,
+                    data: token,
+                },
+            ],
         })
+        .to_bytes(),
+    );
+
+    // TODO check that the response is a success before proceeding
+    // (right now we just assume they'll close the connection if the auth didn't work)
+    let result = connection
+        .send(auth_packet)
+        .map_err(move |_| error!("Error sending auth packet on connection: {}", url))
+        .await;
+
+    match result {
+        Ok(_) => {
+            debug!("Connected to account {}'s server", account.id());
+            service.add_connection(account, connection);
+            Ok(())
+        }
+        Err(_) => {
+            if error_on_unavailable {
+                Err(())
+            } else {
+                Ok(())
+            }
+        }
+    }
 }

--- a/crates/interledger-btp/src/lib.rs
+++ b/crates/interledger-btp/src/lib.rs
@@ -213,13 +213,15 @@ mod client_server {
                 .build())
             }),
         );
-        btp_service.clone().handle_incoming(incoming_service_fn(|_| {
-            Ok(FulfillBuilder {
-                fulfillment: &[0; 32],
-                data: b"test data",
-            }
-            .build())
-        }));
+        btp_service
+            .clone()
+            .handle_incoming(incoming_service_fn(|_| {
+                Ok(FulfillBuilder {
+                    fulfillment: &[0; 32],
+                    data: b"test data",
+                }
+                .build())
+            }));
         let filter = btp_service_as_filter(btp_service.clone(), server_store);
         let server = warp::serve(filter);
         // Spawn the server and listen for incoming connections
@@ -229,8 +231,7 @@ mod client_server {
         let account = TestAccount {
             id: Uuid::new_v4(),
             ilp_over_btp_url: Some(
-                Url::parse(&format!("btp+ws://{}/accounts/alice/ilp/btp", bind_addr))
-                    .unwrap(),
+                Url::parse(&format!("btp+ws://{}/accounts/alice/ilp/btp", bind_addr)).unwrap(),
             ),
             ilp_over_btp_outgoing_token: Some("test_auth_token".to_string()),
             ilp_over_btp_incoming_token: None,
@@ -252,17 +253,21 @@ mod client_server {
                 }
                 .build())
             }),
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
-        let mut btp_service = btp_service.handle_incoming(incoming_service_fn(move |_| {
-            Err(RejectBuilder {
-                code: ErrorCode::F02_UNREACHABLE,
-                message: &[],
-                data: &[],
-                triggered_by: Some(&addr),
-            }
-            .build())
-        })).await;
+        let mut btp_service = btp_service
+            .handle_incoming(incoming_service_fn(move |_| {
+                Err(RejectBuilder {
+                    code: ErrorCode::F02_UNREACHABLE,
+                    message: &[],
+                    data: &[],
+                    triggered_by: Some(&addr),
+                }
+                .build())
+            }))
+            .await;
 
         let res = btp_service
             .send_request(OutgoingRequest {
@@ -277,8 +282,8 @@ mod client_server {
                     data: b"test data",
                 }
                 .build(),
-            }).await;
-            dbg!(&res);
+            })
+            .await;
         assert!(res.is_ok());
         btp_service.close();
     }

--- a/crates/interledger-btp/src/lib.rs
+++ b/crates/interledger-btp/src/lib.rs
@@ -15,11 +15,11 @@ mod client;
 mod errors;
 mod oer;
 mod packet;
-// mod server;
+mod server;
 mod service;
 
 pub use self::client::{connect_client, connect_to_service_account, parse_btp_url};
-// pub use self::server::btp_service_as_filter; // This is consumed only by the node.
+pub use self::server::btp_service_as_filter; // This is consumed only by the node.
 pub use self::service::{BtpOutgoingService, BtpService};
 
 pub trait BtpAccount: Account {

--- a/crates/interledger-btp/src/lib.rs
+++ b/crates/interledger-btp/src/lib.rs
@@ -188,105 +188,98 @@ mod client_server {
     }
 
     // TODO should this be an integration test, since it binds to a port?
-    #[test]
-    fn client_server_test() {
-        let mut runtime = Runtime::new().unwrap();
-        runtime
-            .block_on(lazy(|| {
-                let bind_addr = get_open_port();
+    #[tokio::test]
+    async fn client_server_test() {
+        let bind_addr = get_open_port();
 
-                let server_store = TestStore {
-                    accounts: Arc::new(vec![TestAccount {
-                        id: Uuid::new_v4(),
-                        ilp_over_btp_incoming_token: Some("test_auth_token".to_string()),
-                        ilp_over_btp_outgoing_token: None,
-                        ilp_over_btp_url: None,
-                    }]),
-                };
-                let server_address = Address::from_str("example.server").unwrap();
-                let btp_service = BtpOutgoingService::new(
-                    server_address.clone(),
-                    outgoing_service_fn(move |_| {
-                        Err(RejectBuilder {
-                            code: ErrorCode::F02_UNREACHABLE,
-                            message: b"No other outgoing handler",
-                            triggered_by: Some(&server_address),
-                            data: &[],
-                        }
-                        .build())
-                    }),
-                );
-                let filter = btp_service_as_filter(btp_service.clone(), server_store);
-                btp_service.handle_incoming(incoming_service_fn(|_| {
-                    Ok(FulfillBuilder {
-                        fulfillment: &[0; 32],
-                        data: b"test data",
-                    }
-                    .build())
-                }));
+        let server_store = TestStore {
+            accounts: Arc::new(vec![TestAccount {
+                id: Uuid::new_v4(),
+                ilp_over_btp_incoming_token: Some("test_auth_token".to_string()),
+                ilp_over_btp_outgoing_token: None,
+                ilp_over_btp_url: None,
+            }]),
+        };
+        let server_address = Address::from_str("example.server").unwrap();
+        let btp_service = BtpOutgoingService::new(
+            server_address.clone(),
+            outgoing_service_fn(move |_| {
+                Err(RejectBuilder {
+                    code: ErrorCode::F02_UNREACHABLE,
+                    message: b"No other outgoing handler",
+                    triggered_by: Some(&server_address),
+                    data: &[],
+                }
+                .build())
+            }),
+        );
+        btp_service.clone().handle_incoming(incoming_service_fn(|_| {
+            Ok(FulfillBuilder {
+                fulfillment: &[0; 32],
+                data: b"test data",
+            }
+            .build())
+        }));
+        let filter = btp_service_as_filter(btp_service.clone(), server_store);
+        let server = warp::serve(filter);
+        // Spawn the server and listen for incoming connections
+        tokio::spawn(server.bind(bind_addr));
 
-                let account = TestAccount {
-                    id: Uuid::new_v4(),
-                    ilp_over_btp_url: Some(
-                        Url::parse(&format!("btp+ws://{}/accounts/alice/ilp/btp", bind_addr))
-                            .unwrap(),
-                    ),
-                    ilp_over_btp_outgoing_token: Some("test_auth_token".to_string()),
-                    ilp_over_btp_incoming_token: None,
-                };
-                let accounts = vec![account.clone()];
-                let addr = Address::from_str("example.address").unwrap();
-                let addr_clone = addr.clone();
-                let client = connect_client(
-                    addr.clone(),
-                    accounts,
-                    true,
-                    outgoing_service_fn(move |_| {
-                        Err(RejectBuilder {
-                            code: ErrorCode::F02_UNREACHABLE,
-                            message: &[],
-                            data: &[],
-                            triggered_by: Some(&addr_clone),
-                        }
-                        .build())
-                    }),
-                )
-                .and_then(move |btp_service| {
-                    let mut btp_service =
-                        btp_service.handle_incoming(incoming_service_fn(move |_| {
-                            Err(RejectBuilder {
-                                code: ErrorCode::F02_UNREACHABLE,
-                                message: &[],
-                                data: &[],
-                                triggered_by: Some(&addr),
-                            }
-                            .build())
-                        }));
-                    let btp_service_clone = btp_service.clone();
-                    btp_service
-                        .send_request(OutgoingRequest {
-                            from: account.clone(),
-                            to: account.clone(),
-                            original_amount: 100,
-                            prepare: PrepareBuilder {
-                                destination: Address::from_str("example.destination").unwrap(),
-                                amount: 100,
-                                execution_condition: &[0; 32],
-                                expires_at: SystemTime::now() + Duration::from_secs(30),
-                                data: b"test data",
-                            }
-                            .build(),
-                        })
-                        .map_err(|reject| println!("Packet was rejected: {:?}", reject))
-                        .and_then(move |_| {
-                            btp_service_clone.close();
-                            Ok(())
-                        })
-                });
-                let server = warp::serve(filter);
-                tokio::spawn(server.bind(bind_addr));
-                client
-            }))
-            .unwrap();
+        // Try to connect
+        let account = TestAccount {
+            id: Uuid::new_v4(),
+            ilp_over_btp_url: Some(
+                Url::parse(&format!("btp+ws://{}/accounts/alice/ilp/btp", bind_addr))
+                    .unwrap(),
+            ),
+            ilp_over_btp_outgoing_token: Some("test_auth_token".to_string()),
+            ilp_over_btp_incoming_token: None,
+        };
+        let accounts = vec![account.clone()];
+        let addr = Address::from_str("example.address").unwrap();
+        let addr_clone = addr.clone();
+
+        let btp_service = connect_client(
+            addr.clone(),
+            accounts,
+            true,
+            outgoing_service_fn(move |_| {
+                Err(RejectBuilder {
+                    code: ErrorCode::F02_UNREACHABLE,
+                    message: &[],
+                    data: &[],
+                    triggered_by: Some(&addr_clone),
+                }
+                .build())
+            }),
+        ).await.unwrap();
+
+        let mut btp_service = btp_service.handle_incoming(incoming_service_fn(move |_| {
+            Err(RejectBuilder {
+                code: ErrorCode::F02_UNREACHABLE,
+                message: &[],
+                data: &[],
+                triggered_by: Some(&addr),
+            }
+            .build())
+        })).await;
+
+        let res = btp_service
+            .send_request(OutgoingRequest {
+                from: account.clone(),
+                to: account.clone(),
+                original_amount: 100,
+                prepare: PrepareBuilder {
+                    destination: Address::from_str("example.destination").unwrap(),
+                    amount: 100,
+                    execution_condition: &[0; 32],
+                    expires_at: SystemTime::now() + Duration::from_secs(30),
+                    data: b"test data",
+                }
+                .build(),
+            }).await;
+            dbg!(&res);
+        assert!(res.is_ok());
+        btp_service.close();
     }
 }

--- a/crates/interledger-btp/src/server.rs
+++ b/crates/interledger-btp/src/server.rs
@@ -1,22 +1,21 @@
-use super::service::{BtpOutgoingService, WsError};
 use super::{packet::*, BtpAccount, BtpStore};
-use futures::{Future, Sink, Stream};
+use super::{service::BtpOutgoingService, wrapped_ws::WsWrap};
+use futures::{FutureExt, Sink, Stream};
+use futures::{SinkExt, StreamExt, TryFutureExt};
 use interledger_service::*;
-use log::{debug, error, warn};
+use log::{debug, warn};
 use secrecy::{ExposeSecret, SecretString};
-use std::time::Duration;
-use tungstenite;
+// use std::time::Duration;
 use warp::{
     self,
-    ws::{Message, WebSocket},
+    ws::{Message, WebSocket, Ws},
     Filter,
 };
 
 // Close the incoming websocket connection if the auth details
 // have not been received within this timeout
-const WEBSOCKET_TIMEOUT: Duration = Duration::from_secs(10);
-
-// const MAX_MESSAGE_SIZE: usize = 40000;
+// const WEBSOCKET_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_MESSAGE_SIZE: usize = 40000;
 
 /// Returns a BtpOutgoingService and a warp Filter.
 ///
@@ -36,242 +35,163 @@ pub fn btp_service_as_filter<O, S, A>(
 where
     O: OutgoingService<A> + Clone + Send + Sync + 'static,
     S: BtpStore<Account = A> + Clone + Send + Sync + 'static,
-    A: BtpAccount + 'static,
+    A: BtpAccount + Send + Sync + 'static,
 {
-    let routes = warp::any().map(|| "Hello, World!");
-    routes.boxed()
-    // warp::path("accounts")
-    //     .and(warp::path::param2::<Username>())
-    //     .and(warp::path("ilp"))
-    //     .and(warp::path("btp"))
-    //     .and(warp::path::end())
-    //     .and(warp::ws2())
-    //     .map(move |username: Username, ws: Ws2| {
-    //         let store = store.clone();
-    //         let service_clone = service.clone();
-    //         ws.on_upgrade(move |ws: WebSocket| {
-    //             // TODO set max_message_size once https://github.com/seanmonstar/warp/pull/272 is merged
-    //             let service_clone = service_clone.clone();
-    //             Timeout::new(validate_auth(store, username, ws), WEBSOCKET_TIMEOUT)
-    //                 .and_then(move |(account, connection)| {
-    //                     debug!(
-    //                         "Added connection for account {}: (id: {})",
-    //                         account.username(),
-    //                         account.id()
-    //                     );
-    //                     service_clone.add_connection(account, WsWrap { connection });
-    //                     Ok(())
-    //                 })
-    //                 .or_else(|_| {
-    //                     warn!("Closing Websocket connection because of an error");
-    //                     Ok(())
-    //                 })
-    //         })
-    //     })
-    //     .boxed()
+    warp::path("accounts")
+        .and(warp::path::param::<Username>())
+        .and(warp::path("ilp"))
+        .and(warp::path("btp"))
+        .and(warp::path::end())
+        .and(warp::ws())
+        .map(move |username: Username, ws: Ws| {
+            // warp Websocket
+            let service_clone = service.clone();
+            let store_clone = store.clone();
+            ws.max_message_size(MAX_MESSAGE_SIZE)
+                .on_upgrade(|socket: WebSocket| {
+                    // wrapper over tungstenite Websocket
+                    add_connections(socket, username, service_clone, store_clone)
+                        .map(|result| result.unwrap())
+                })
+        })
+        .boxed()
 }
 
 /// This wraps a warp Websocket connection to make it act like a
 /// tungstenite Websocket connection. It is needed for
 /// compatibility with the BTP service that interacts with the
 /// websocket implementation from warp and tokio-tungstenite
-struct WsWrap<W> {
-    connection: W,
+async fn add_connections<O, S, A>(
+    socket: WebSocket,
+    username: Username,
+    service: BtpOutgoingService<O, A>,
+    store: S,
+) -> Result<(), ()>
+where
+    O: OutgoingService<A> + Clone + Send + Sync + 'static,
+    S: BtpStore<Account = A> + Clone + Send + Sync + 'static,
+    A: BtpAccount + Send + Sync + 'static,
+{
+    // We ignore all the errors
+    let socket = socket.filter_map(|v| async move { v.ok() });
+    match validate_auth(store, username, socket)
+        // .timeout(WEBSOCKET_TIMEOUT) // No method found?
+        .await
+    {
+        Ok((account, connection)) => {
+            // We need to wrap our Warp connection in order to cast the Sink type
+            // to tungstenite::Message. This probably can be implemented with SinkExt::with
+            // but couldn't figure out how.
+            service.add_connection(account.clone(), WsWrap { connection });
+            debug!(
+                "Added connection for account {}: (id: {})",
+                account.username(),
+                account.id()
+            );
+        }
+        Err(_) => {
+            warn!("Closing Websocket connection because of an error");
+        }
+    };
+
+    Ok(())
 }
 
-// impl<W> Stream for WsWrap<W>
-// where
-//     W: Stream<Item = Message, Error = warp::Error>
-//         + Sink<SinkItem = Message, SinkError = warp::Error>,
-// {
-//     type Item = tungstenite::Message;
-//     type Error = WsError;
+struct Auth {
+    request_id: u32,
+    token: SecretString,
+}
 
-//     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-//         match self.connection.poll() {
-//             Ok(Async::NotReady) => Ok(Async::NotReady),
-//             Ok(Async::Ready(None)) => Ok(Async::Ready(None)),
-//             Ok(Async::Ready(Some(message))) => {
-//                 let message = if message.is_ping() {
-//                     tungstenite::Message::Ping(message.into_bytes())
-//                 } else if message.is_binary() {
-//                     tungstenite::Message::Binary(message.into_bytes())
-//                 } else if message.is_text() {
-//                     tungstenite::Message::Text(message.to_str().unwrap_or_default().to_string())
-//                 } else if message.is_close() {
-//                     tungstenite::Message::Close(None)
-//                 } else {
-//                     warn!(
-//                         "Got unexpected websocket message, closing connection: {:?}",
-//                         message
-//                     );
-//                     tungstenite::Message::Close(None)
-//                 };
-//                 Ok(Async::Ready(Some(message)))
-//             }
-//             Err(err) => Err(WsError::from(err)),
-//         }
-//     }
-// }
+async fn validate_auth<S, A>(
+    store: S,
+    username: Username,
+    connection: impl Stream<Item = Message> + Sink<Message>,
+) -> Result<(A, impl Stream<Item = Message> + Sink<Message>), ()>
+where
+    S: BtpStore<Account = A> + 'static,
+    A: BtpAccount + 'static,
+{
+    let (auth, mut connection) = get_auth(Box::pin(connection)).await?;
+    debug!("Got BTP connection for username: {}", username);
+    let account = store
+        .get_account_from_btp_auth(&username, &auth.token.expose_secret())
+        .map_err(move |_| warn!("BTP connection does not correspond to an account"))
+        .await?;
 
-// impl<W> Sink for WsWrap<W>
-// where
-//     W: Stream<Item = Message, Error = warp::Error>
-//         + Sink<SinkItem = Message, SinkError = warp::Error>,
-// {
-//     type SinkItem = tungstenite::Message;
-//     type SinkError = WsError;
+    let auth_response = Message::binary(
+        BtpResponse {
+            request_id: auth.request_id,
+            protocol_data: Vec::new(),
+        }
+        .to_bytes(),
+    );
 
-//     fn start_send(
-//         &mut self,
-//         item: Self::SinkItem,
-//     ) -> Result<AsyncSink<Self::SinkItem>, Self::SinkError> {
-//         match item {
-//             tungstenite::Message::Binary(data) => self
-//                 .connection
-//                 .start_send(Message::binary(data))
-//                 .map(|result| {
-//                     if let AsyncSink::NotReady(message) = result {
-//                         AsyncSink::NotReady(tungstenite::Message::Binary(message.into_bytes()))
-//                     } else {
-//                         AsyncSink::Ready
-//                     }
-//                 })
-//                 .map_err(WsError::from),
-//             tungstenite::Message::Text(data) => {
-//                 match self.connection.start_send(Message::text(data)) {
-//                     Ok(AsyncSink::NotReady(message)) => {
-//                         if let Ok(string) = String::from_utf8(message.into_bytes()) {
-//                             Ok(AsyncSink::NotReady(tungstenite::Message::text(string)))
-//                         } else {
-//                             Err(WsError::Tungstenite(tungstenite::Error::Utf8))
-//                         }
-//                     }
-//                     Ok(AsyncSink::Ready) => Ok(AsyncSink::Ready),
-//                     Err(err) => Err(WsError::from(err)),
-//                 }
-//             }
-//             // Ignore other message types because warp's WebSocket type doesn't
-//             // allow us to send any other types of messages
-//             // TODO make sure warp's websocket responds to pings and/or sends them to keep the
-//             // connection alive
-//             _ => Ok(AsyncSink::Ready),
-//         }
-//     }
+    let _ = connection.send(auth_response).await;
 
-//     fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
-//         self.connection.poll_complete().map_err(WsError::from)
-//     }
-// }
+    Ok((account, connection))
+}
 
-// struct Auth {
-//     request_id: u32,
-//     token: SecretString,
-// }
+/// Reads the first non-empty non-error binary message from the WebSocket and attempts to parse it as an AuthToken
+async fn get_auth(
+    connection: impl Stream<Item = Message> + Sink<Message> + Unpin,
+) -> Result<(Auth, impl Stream<Item = Message> + Sink<Message>), ()> {
+    // Skip non-binary messages like Pings and Pongs
+    // Note that the BTP protocol spec technically specifies that
+    // the auth message MUST be the first packet sent over the
+    // WebSocket connection. However, the JavaScript implementation
+    // of BTP sends a Ping packet first, so we should ignore it.
+    // (Be liberal in what you accept but strict in what you send)
+    // TODO: should we error if the client sends something other than a binary or ping packet first?
+    let mut connection =
+        connection.skip_while(move |message| futures::future::ready(!message.is_binary()));
 
-// fn validate_auth<S, A>(
-//     store: S,
-//     username: Username,
-//     connection: impl Stream<Item = Message, Error = warp::Error>
-//         + Sink<SinkItem = Message, SinkError = warp::Error>,
-// ) -> impl Future<
-//     Item = (
-//         A,
-//         impl Stream<Item = Message, Error = warp::Error>
-//             + Sink<SinkItem = Message, SinkError = warp::Error>,
-//     ),
-//     Error = (),
-// >
-// where
-//     S: BtpStore<Account = A> + 'static,
-//     A: BtpAccount + 'static,
-// {
-//     get_auth(connection).and_then(move |(auth, connection)| {
-//         debug!("Got BTP connection for username: {}", username);
-//         store
-//             .get_account_from_btp_auth(&username, &auth.token.expose_secret())
-//             .map_err(move |_| warn!("BTP connection does not correspond to an account"))
-//             .and_then(move |account| {
-//                 let auth_response = Message::binary(
-//                     BtpResponse {
-//                         request_id: auth.request_id,
-//                         protocol_data: Vec::new(),
-//                     }
-//                     .to_bytes(),
-//                 );
-//                 connection
-//                     .send(auth_response)
-//                     .map_err(|_err| error!("warp::Error sending auth response"))
-//                     .and_then(|connection| Ok((account, connection)))
-//             })
-//     })
-// }
+    // The first packet sent on the connection MUST be the auth packet
+    let message = connection.next().await;
+    match parse_auth(message) {
+        Some(auth) => Ok((auth, Box::pin(connection))),
+        None => {
+            warn!("Got a BTP connection where the first packet sent was not a valid BTP Auth message. Closing the connection");
+            Err(())
+        }
+    }
+}
 
-// fn get_auth(
-//     connection: impl Stream<Item = Message, Error = warp::Error>
-//         + Sink<SinkItem = Message, SinkError = warp::Error>,
-// ) -> impl Future<
-//     Item = (
-//         Auth,
-//         impl Stream<Item = Message, Error = warp::Error>
-//             + Sink<SinkItem = Message, SinkError = warp::Error>,
-//     ),
-//     Error = (),
-// > {
-//     connection
-//         .skip_while(|message| {
-//             // Skip non-binary messages like Pings and Pongs
-//             // Note that the BTP protocol spec technically specifies that
-//             // the auth message MUST be the first packet sent over the
-//             // WebSocket connection. However, the JavaScript implementation
-//             // of BTP sends a Ping packet first, so we should ignore it.
-//             // (Be liberal in what you accept but strict in what you send)
-//             Ok(!message.is_binary())
-//             // TODO: should we error if the client sends something other than a binary or ping packet first?
-//         })
-//         .into_future()
-//         .map_err(|_err| ())
-//         .and_then(move |(message, connection)| {
-//             // The first packet sent on the connection MUST be the auth packet
-//             result(parse_auth(message).map(|auth| (auth, connection)).ok_or_else(|| {
-//                 warn!("Got a BTP connection where the first packet sent was not a valid BTP Auth message. Closing the connection")
-//             }))
-//         })
-// }
+fn parse_auth(ws_packet: Option<Message>) -> Option<Auth> {
+    if let Some(message) = ws_packet {
+        if message.is_binary() {
+            match BtpMessage::from_bytes(message.as_bytes()) {
+                Ok(message) => {
+                    let request_id = message.request_id;
+                    let mut token: Option<String> = None;
+                    // The primary data should be the "auth" with empty data
+                    // The secondary data MUST have the "auth_token" with the authorization
+                    // token set as the data field
+                    for protocol_data in message.protocol_data.iter() {
+                        let protocol_name: &str = protocol_data.protocol_name.as_ref();
+                        if protocol_name == "auth_token" {
+                            token = String::from_utf8(protocol_data.data.clone()).ok();
+                        }
+                    }
 
-// fn parse_auth(ws_packet: Option<Message>) -> Option<Auth> {
-//     if let Some(message) = ws_packet {
-//         if message.is_binary() {
-//             match BtpMessage::from_bytes(message.as_bytes()) {
-//                 Ok(message) => {
-//                     let request_id = message.request_id;
-//                     let mut token: Option<String> = None;
-//                     for protocol_data in message.protocol_data.iter() {
-//                         let protocol_name: &str = protocol_data.protocol_name.as_ref();
-//                         if protocol_name == "auth_token" {
-//                             token = String::from_utf8(protocol_data.data.clone()).ok();
-//                         }
-//                     }
-
-//                     if let Some(token) = token {
-//                         return Some(Auth {
-//                             request_id,
-//                             token: SecretString::new(token.to_string()),
-//                         });
-//                     } else {
-//                         warn!("BTP packet is missing auth token");
-//                     }
-//                 }
-//                 Err(err) => {
-//                     warn!(
-//                         "warp::Error parsing BTP packet from Websocket message: {:?}",
-//                         err
-//                     );
-//                 }
-//             }
-//         } else {
-//             warn!("Websocket packet is not binary");
-//         }
-//     }
-//     None
-// }
+                    if let Some(token) = token {
+                        return Some(Auth {
+                            request_id,
+                            token: SecretString::new(token),
+                        });
+                    } else {
+                        warn!("BTP packet is missing auth token");
+                    }
+                }
+                Err(err) => {
+                    warn!(
+                        "warp::Error parsing BTP packet from Websocket message: {:?}",
+                        err
+                    );
+                }
+            }
+        } else {
+            warn!("Websocket packet is not binary");
+        }
+    }
+    None
+}

--- a/crates/interledger-btp/src/server.rs
+++ b/crates/interledger-btp/src/server.rs
@@ -222,7 +222,7 @@ struct WsWrap<W> {
 //         .skip_while(|message| {
 //             // Skip non-binary messages like Pings and Pongs
 //             // Note that the BTP protocol spec technically specifies that
-//             // the auth message MUST be the first packet sent over the 
+//             // the auth message MUST be the first packet sent over the
 //             // WebSocket connection. However, the JavaScript implementation
 //             // of BTP sends a Ping packet first, so we should ignore it.
 //             // (Be liberal in what you accept but strict in what you send)

--- a/crates/interledger-btp/src/wrapped_ws.rs
+++ b/crates/interledger-btp/src/wrapped_ws.rs
@@ -1,0 +1,133 @@
+use futures::stream::Stream;
+use futures::Sink;
+use log::warn;
+use pin_project::pin_project;
+use std::error::Error;
+use std::fmt;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use warp::ws::Message;
+
+/// Wrapper struct to unify the Tungstenite WebSocket connection from connect_async
+/// with the Warp websocket connection from ws.upgrade. Stream and Sink are re-implemented
+/// for this struct, normalizing it to use Tungstenite's messages and a wrapped error type
+#[pin_project]
+#[derive(Clone)]
+pub struct WsWrap<W> {
+    #[pin]
+    connection: W,
+}
+
+impl<W> Stream for WsWrap<W>
+where
+    W: Stream<Item = Result<Message, warp::Error>>,
+{
+    type Item = Result<tungstenite::Message, WsError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        match this.connection.poll_next(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(val) => {
+                match val {
+                    Some(v) => {
+                        let v = match v {
+                            // We could do a map_ok / map_err here but we wouldn't
+                            // be able to convert the Sink to the desired data type
+                            Ok(msg) => Ok(convert_msg(msg)),
+                            Err(err) => Err(WsError::from(err)),
+                        };
+                        Poll::Ready(Some(v))
+                    }
+                    None => Poll::Ready(None),
+                }
+            }
+        }
+    }
+}
+
+impl<W, E> Sink<tungstenite::Message> for WsWrap<W>
+where
+    W: Sink<Message, Error = E>,
+    E: Into<WsError>,
+{
+    type Error = WsError;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        let this = self.project();
+        this.connection.poll_ready(cx).map_err(|e| e.into())
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: tungstenite::Message) -> Result<(), Self::Error> {
+        let this = self.project();
+        let item = match item {
+            tungstenite::Message::Binary(data) => Message::binary(data),
+            tungstenite::Message::Text(data) => Message::text(data),
+            // Ignore other message types because warp's WebSocket type doesn't
+            // allow us to send any other types of messages
+            // TODO make sure warp's websocket responds to pings and/or sends them to keep the
+            // connection alive
+            _ => return Ok(()),
+        };
+        this.connection.start_send(item).map_err(|e| e.into())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        let this = self.project();
+        this.connection.poll_flush(cx).map_err(|e| e.into())
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        let this = self.project();
+        this.connection.poll_close(cx).map_err(|e| e.into())
+    }
+}
+
+// Implement From<tungstenite::WebSocket> and From<warp::ws::WebSocket> ?
+
+fn convert_msg(message: Message) -> tungstenite::Message {
+    if message.is_ping() {
+        tungstenite::Message::Ping(message.into_bytes())
+    } else if message.is_binary() {
+        tungstenite::Message::Binary(message.into_bytes())
+    } else if message.is_text() {
+        tungstenite::Message::Text(message.to_str().unwrap_or_default().to_string())
+    } else if message.is_close() {
+        tungstenite::Message::Close(None)
+    } else {
+        warn!(
+            "Got unexpected websocket message, closing connection: {:?}",
+            message
+        );
+        tungstenite::Message::Close(None)
+    }
+}
+
+#[derive(Debug)]
+pub enum WsError {
+    Tungstenite(tungstenite::Error),
+    Warp(warp::Error),
+}
+
+impl fmt::Display for WsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            WsError::Tungstenite(err) => err.fmt(f),
+            WsError::Warp(err) => err.fmt(f),
+        }
+    }
+}
+
+impl Error for WsError {}
+
+impl From<tungstenite::Error> for WsError {
+    fn from(err: tungstenite::Error) -> Self {
+        WsError::Tungstenite(err)
+    }
+}
+
+impl From<warp::Error> for WsError {
+    fn from(err: warp::Error) -> Self {
+        WsError::Warp(err)
+    }
+}

--- a/crates/interledger-ccp/Cargo.toml
+++ b/crates/interledger-ccp/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 [dependencies]
 bytes = { version = "0.4.12", default-features = false }
 byteorder = { version = "1.3.2", default-features = false }
-futures = { version = "0.1.29", default-features = false }
+futures = { version = "0.3", default-features = false }
 hex = { version = "0.4.0", default-features = false }
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
@@ -19,6 +19,7 @@ log = { version = "0.4.8", default-features = false }
 parking_lot = { version = "0.9.0", default-features = false }
 ring = { version = "0.16.9", default-features = false }
 tokio-executor = { version = "0.1.8", default-features = false }
-tokio-timer = { version = "0.2.11", default-features = false }
 uuid = { version = "0.8.1", default-features = false, features = ["v4"]}
 serde = { version = "1.0.101", default-features = false, features = ["derive"] }
+async-trait = "0.1.22"
+tokio = { version = "0.2.6", features = ["time", "rt-core", "macros"] }

--- a/crates/interledger-ccp/src/lib.rs
+++ b/crates/interledger-ccp/src/lib.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 
 /// Data structure used to describe the routing relation of an account with its peers.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Serialize, Deserialize, Ord, Eq)]
 pub enum RoutingRelation {
     /// An account from which we do not receive routes from, neither broadcast
     /// routes to

--- a/crates/interledger-ccp/src/lib.rs
+++ b/crates/interledger-ccp/src/lib.rs
@@ -10,7 +10,6 @@
 //! we know about.
 
 use async_trait::async_trait;
-use futures::Future;
 use interledger_service::Account;
 use std::collections::HashMap;
 use std::{fmt, str::FromStr};

--- a/crates/interledger-ccp/src/routing_table.rs
+++ b/crates/interledger-ccp/src/routing_table.rs
@@ -110,12 +110,12 @@ where
         self.prefix_map.resolve(prefix)
     }
 
-    pub fn get_simplified_table(&self) -> HashMap<&str, A> {
+    pub fn get_simplified_table(&self) -> HashMap<String, A> {
         HashMap::from_iter(
             self.prefix_map
                 .map
                 .iter()
-                .map(|(address, (account, _route))| (address.as_str(), account.clone())),
+                .map(|(address, (account, _route))| (address.clone(), account.clone())),
         )
     }
 

--- a/crates/interledger-ccp/src/routing_table.rs
+++ b/crates/interledger-ccp/src/routing_table.rs
@@ -10,7 +10,7 @@ lazy_static! {
     static ref RANDOM: SystemRandom = SystemRandom::new();
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct PrefixMap<T> {
     map: HashMap<String, T>,
 }
@@ -44,7 +44,7 @@ impl<T> PrefixMap<T> {
 /// When an Interledger node reloads, it will generate a new UUID for its routing table.
 /// Each update applied increments the epoch number, so it acts as a version tracker.
 /// This helps peers make sure they are in sync with one another and request updates if not.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RoutingTable<A> {
     id: [u8; 16],
     epoch: u32,

--- a/crates/interledger-ccp/src/server.rs
+++ b/crates/interledger-ccp/src/server.rs
@@ -672,10 +672,6 @@ where
                 ));
                 debug_assert_eq!(epoch as usize + 1, forwarding_table_updates.len());
 
-                dbg!(
-                    "updating store routing table",
-                    local_table.get_simplified_table()
-                );
                 store.set_routes(local_table.get_simplified_table())
             };
 
@@ -1515,7 +1511,6 @@ mod handle_route_update_request {
             })
             .await
             .unwrap();
-        dbg!("store routes", &service.store.routes);
         assert_eq!(
             service
                 .store

--- a/crates/interledger-ccp/src/server.rs
+++ b/crates/interledger-ccp/src/server.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-use crate::packet::PEER_PROTOCOL_CONDITION;
 use crate::{
     packet::{
         Mode, Route, RouteControlRequest, RouteUpdateRequest, CCP_CONTROL_DESTINATION,
@@ -8,19 +6,14 @@ use crate::{
     routing_table::RoutingTable,
     CcpRoutingAccount, RouteManagerStore, RoutingRelation,
 };
-use futures::{
-    future::{err, join_all, ok, Either},
-    Future, Stream,
-};
-#[cfg(test)]
+use async_trait::async_trait;
+use futures::{future::join_all, TryFutureExt};
 use interledger_packet::PrepareBuilder;
-use interledger_packet::{Address, ErrorCode, Fulfill, Reject, RejectBuilder};
+use interledger_packet::{Address, ErrorCode, RejectBuilder};
 use interledger_service::{
-    Account, AddressStore, BoxedIlpFuture, IncomingRequest, IncomingService, OutgoingRequest,
+    Account, AddressStore, IlpResult, IncomingRequest, IncomingService, OutgoingRequest,
     OutgoingService,
 };
-#[cfg(test)]
-use lazy_static::lazy_static;
 use log::{debug, error, trace, warn};
 use parking_lot::{Mutex, RwLock};
 use ring::digest::{digest, SHA256};
@@ -33,13 +26,14 @@ use std::{
         atomic::{AtomicU32, Ordering},
         Arc,
     },
-    time::{Duration, Instant},
+    time::Duration,
 };
-use tokio_timer::Interval;
 use uuid::Uuid;
 
-#[cfg(not(test))]
-use tokio_executor::spawn;
+#[cfg(test)]
+use crate::packet::PEER_PROTOCOL_CONDITION;
+#[cfg(test)]
+use lazy_static::lazy_static;
 
 // TODO should the route expiry be longer? we use 30 seconds now
 // because the expiry shortener will lower the expiry to 30 seconds
@@ -116,7 +110,13 @@ where
 
         #[cfg(not(test))]
         {
-            spawn(service.start_broadcast_interval(self.broadcast_interval));
+            let broadcast_interval = self.broadcast_interval;
+            let service_clone = service.clone();
+            tokio::spawn(async move {
+                service_clone
+                    .start_broadcast_interval(broadcast_interval)
+                    .await
+            });
         }
 
         service
@@ -180,20 +180,17 @@ where
     A: CcpRoutingAccount + Send + Sync + 'static,
 {
     /// Returns a future that will trigger this service to update its routes and broadcast
-    /// updates to peers on the given interval.
-    pub fn start_broadcast_interval(&self, interval: u64) -> impl Future<Item = (), Error = ()> {
-        let clone = self.clone();
-        self.request_all_routes().and_then(move |_| {
-            Interval::new(Instant::now(), Duration::from_millis(interval))
-                .map_err(|err| error!("Interval error, no longer sending route updates: {:?}", err))
-                .for_each(move |_| {
-                    // ensure we have the latest ILP Address from the store
-                    clone.update_ilp_address();
-                    // Returning an error would end the broadcast loop
-                    // so we want to return Ok even if there was an error
-                    clone.broadcast_routes().then(|_| Ok(()))
-                })
-        })
+    /// updates to peers on the given interval. `interval` is in milliseconds
+    pub async fn start_broadcast_interval(&self, interval: u64) -> Result<(), ()> {
+        self.request_all_routes().await?;
+        let mut interval = tokio::time::interval(Duration::from_millis(interval));
+        while let _ = interval.tick().await {
+            // ensure we have the latest ILP Address from the store
+            self.update_ilp_address();
+            // Do not consume the result if an error since we want to keep the loop going
+            let _ = self.broadcast_routes().await;
+        }
+        Ok(())
     }
 
     fn update_ilp_address(&self) {
@@ -210,52 +207,47 @@ where
         }
     }
 
-    pub fn broadcast_routes(&self) -> impl Future<Item = (), Error = ()> {
-        let clone = self.clone();
-        self.update_best_routes(None)
-            .and_then(move |_| clone.send_route_updates())
+    pub async fn broadcast_routes(&self) -> Result<(), ()> {
+        self.update_best_routes(None).await?;
+        self.send_route_updates().await
     }
 
     /// Request routes from all the peers we are willing to receive routes from.
     /// This is mostly intended for when the CCP server starts up and doesn't have any routes from peers.
-    fn request_all_routes(&self) -> impl Future<Item = (), Error = ()> {
-        let clone = self.clone();
-        self.store
-            .get_accounts_to_receive_routes_from()
-            .then(|result| {
-                let accounts = result.unwrap_or_else(|_| Vec::new());
-                join_all(accounts.into_iter().map(move |account| {
-                    clone.send_route_control_request(account, DUMMY_ROUTING_TABLE_ID, 0)
-                }))
-            })
-            .then(|_| Ok(()))
+    async fn request_all_routes(&self) -> Result<(), ()> {
+        let result = self.store.get_accounts_to_receive_routes_from().await;
+        let accounts = result.unwrap_or_else(|_| Vec::new());
+        join_all(
+            accounts
+                .into_iter()
+                .map(|account| self.send_route_control_request(account, DUMMY_ROUTING_TABLE_ID, 0)),
+        )
+        .await;
+        Ok(())
     }
 
     /// Handle a CCP Route Control Request. If this is from an account that we broadcast routes to,
     /// we'll send an outgoing Route Update Request to them.
-    fn handle_route_control_request(
-        &self,
-        request: IncomingRequest<A>,
-    ) -> impl Future<Item = Fulfill, Error = Reject> {
+    async fn handle_route_control_request(&self, request: IncomingRequest<A>) -> IlpResult {
         if !request.from.should_send_routes() {
-            return Either::A(err(RejectBuilder {
+            return Err(RejectBuilder {
                 code: ErrorCode::F00_BAD_REQUEST,
                 message: b"We are not configured to send routes to you, sorry",
                 triggered_by: Some(&self.ilp_address.read()),
                 data: &[],
             }
-            .build()));
+            .build());
         }
 
         let control = RouteControlRequest::try_from(&request.prepare);
         if control.is_err() {
-            return Either::A(err(RejectBuilder {
+            return Err(RejectBuilder {
                 code: ErrorCode::F00_BAD_REQUEST,
                 message: b"Invalid route control request",
                 triggered_by: Some(&self.ilp_address.read()),
                 data: &[],
             }
-            .build()));
+            .build());
         }
         let control = control.unwrap();
         debug!(
@@ -295,40 +287,38 @@ where
             #[cfg(test)]
             {
                 let ilp_address = self.ilp_address.read().clone();
-                return Either::B(Either::A(
-                    self.send_route_update(request.from.clone(), from_epoch_index, to_epoch_index)
-                        .map_err(move |_| {
-                            RejectBuilder {
-                                code: ErrorCode::T01_PEER_UNREACHABLE,
-                                message: b"Error sending route update request",
-                                data: &[],
-                                triggered_by: Some(&ilp_address),
-                            }
-                            .build()
-                        })
-                        .and_then(|_| Ok(CCP_RESPONSE.clone())),
-                ));
+                return self
+                    .send_route_update(request.from.clone(), from_epoch_index, to_epoch_index)
+                    .map_err(move |_| {
+                        RejectBuilder {
+                            code: ErrorCode::T01_PEER_UNREACHABLE,
+                            message: b"Error sending route update request",
+                            data: &[],
+                            triggered_by: Some(&ilp_address),
+                        }
+                        .build()
+                    })
+                    .map_ok(|_| Ok(CCP_RESPONSE.clone()))
+                    .await?;
             }
 
             #[cfg(not(test))]
             {
-                spawn(self.send_route_update(
-                    request.from.clone(),
-                    from_epoch_index,
-                    to_epoch_index,
-                ));
+                tokio::spawn({
+                    let self_clone = self.clone();
+                    async move {
+                        self_clone
+                            .send_route_update(
+                                request.from.clone(),
+                                from_epoch_index,
+                                to_epoch_index,
+                            )
+                            .await
+                    }
+                });
             }
         }
-
-        #[cfg(not(test))]
-        {
-            Either::B(ok(CCP_RESPONSE.clone()))
-        }
-
-        #[cfg(test)]
-        {
-            Either::B(Either::B(ok(CCP_RESPONSE.clone())))
-        }
+        Ok(CCP_RESPONSE.clone())
     }
 
     /// Remove invalid routes before processing the Route Update Request
@@ -367,27 +357,27 @@ where
     /// If updates are applied to the Incoming Routing Table for this peer, we will
     /// then check whether those routes are better than the current best ones we have in the
     /// Local Routing Table.
-    fn handle_route_update_request(&self, request: IncomingRequest<A>) -> BoxedIlpFuture {
+    async fn handle_route_update_request(&self, request: IncomingRequest<A>) -> IlpResult {
         // Ignore the request if we don't accept routes from them
         if !request.from.should_receive_routes() {
-            return Box::new(err(RejectBuilder {
+            return Err(RejectBuilder {
                 code: ErrorCode::F00_BAD_REQUEST,
                 message: b"Your route broadcasts are not accepted here",
                 triggered_by: Some(&self.ilp_address.read()),
                 data: &[],
             }
-            .build()));
+            .build());
         }
 
         let update = RouteUpdateRequest::try_from(&request.prepare);
         if update.is_err() {
-            return Box::new(err(RejectBuilder {
+            return Err(RejectBuilder {
                 code: ErrorCode::F00_BAD_REQUEST,
                 message: b"Invalid route update request",
                 triggered_by: Some(&self.ilp_address.read()),
                 data: &[],
             }
-            .build()));
+            .build());
         }
         let update = update.unwrap();
         debug!(
@@ -399,7 +389,7 @@ where
         // Filter out routes that don't make sense or that we won't accept
         let update = self.filter_routes(update);
 
-        let mut incoming_tables = self.incoming_tables.write();
+        let mut incoming_tables = self.incoming_tables.write().clone();
         if !&incoming_tables.contains_key(&request.from.id()) {
             incoming_tables.insert(
                 request.from.id(),
@@ -410,7 +400,7 @@ where
         // Update the routing table we maintain for the account we got this from.
         // Figure out whether we need to update our routes for any of the prefixes
         // that were included in this route update.
-        match (*incoming_tables)
+        match incoming_tables
             .get_mut(&request.from.id())
             .expect("Should have inserted a routing table for this account")
             .handle_update_request(request.from.clone(), update)
@@ -418,43 +408,52 @@ where
             Ok(prefixes_updated) => {
                 if prefixes_updated.is_empty() {
                     trace!("Route update request did not contain any prefixes we need to update our routes for");
-                    return Box::new(ok(CCP_RESPONSE.clone()));
+                    return Ok(CCP_RESPONSE.clone());
                 }
 
                 debug!(
                     "Recalculating best routes for prefixes: {}",
                     prefixes_updated.join(", ")
                 );
-                let future = self.update_best_routes(Some(
-                    prefixes_updated
-                        .into_iter()
-                        .map(|s| s.to_string())
-                        .collect(),
-                ));
 
                 #[cfg(not(test))]
                 {
-                    spawn(future);
-                    Box::new(ok(CCP_RESPONSE.clone()))
+                    tokio::spawn({
+                        let self_clone = self.clone();
+                        async move {
+                            self_clone
+                                .update_best_routes(Some(
+                                    prefixes_updated
+                                        .into_iter()
+                                        .map(|s| s.to_string())
+                                        .collect(),
+                                ))
+                                .await
+                        }
+                    });
                 }
 
                 #[cfg(test)]
                 {
                     let ilp_address = self.ilp_address.clone();
-                    Box::new(
-                        future
-                            .map_err(move |_| {
-                                RejectBuilder {
-                                    code: ErrorCode::T00_INTERNAL_ERROR,
-                                    message: b"Error processing route update",
-                                    data: &[],
-                                    triggered_by: Some(&ilp_address.read()),
-                                }
-                                .build()
-                            })
-                            .and_then(|_| Ok(CCP_RESPONSE.clone())),
-                    )
+                    self.update_best_routes(Some(
+                        prefixes_updated
+                            .into_iter()
+                            .map(|s| s.to_string())
+                            .collect(),
+                    ))
+                    .map_err(move |_| {
+                        RejectBuilder {
+                            code: ErrorCode::T00_INTERNAL_ERROR,
+                            message: b"Error processing route update",
+                            data: &[],
+                            triggered_by: Some(&ilp_address.read()),
+                        }
+                        .build()
+                    })
+                    .await?;
                 }
+                return Ok(CCP_RESPONSE.clone());
             }
             Err(message) => {
                 warn!("Error handling incoming Route Update request, sending a Route Control request to get updated routing table info from peer. Error was: {}", &message);
@@ -465,31 +464,37 @@ where
                     triggered_by: Some(&self.ilp_address.read()),
                 }
                 .build();
+
                 let table = &incoming_tables[&request.from.id()];
-                let future = self.send_route_control_request(
-                    request.from.clone(),
-                    table.id(),
-                    table.epoch(),
-                );
-                #[cfg(not(test))]
-                {
-                    spawn(future);
-                    Box::new(err(reject))
-                }
+
+                // TODO: Fix lifetime error
+                // #[cfg(not(test))]
+                // tokio::spawn({
+                //     let self_clone = self.clone();
+                //     async move { self_clone.send_route_control_request(
+                //         request.from.clone(),
+                //         table.id(),
+                //         table.epoch(),
+                //         ).await;
+                //     }
+                // });
+
                 #[cfg(test)]
-                Box::new(future.then(move |_| Err(reject)))
+                self.send_route_control_request(request.from.clone(), table.id(), table.epoch())
+                    .await;
+                return Err(reject);
             }
         }
     }
 
     /// Request a Route Update from the specified peer. This is sent when we get
     /// a Route Update Request from them with a gap in the epochs since the last one we saw.
-    fn send_route_control_request(
+    async fn send_route_control_request(
         &self,
         account: A,
         last_known_routing_table_id: [u8; 16],
         last_known_epoch: u32,
-    ) -> impl Future<Item = (), Error = ()> {
+    ) -> Result<(), ()> {
         let account_id = account.id();
         let control = RouteControlRequest {
             mode: Mode::Sync,
@@ -503,7 +508,8 @@ where
             hex::encode(&last_known_routing_table_id[..]),
             last_known_epoch);
         let prepare = control.to_prepare();
-        self.clone()
+        let result = self
+            .clone()
             .outgoing
             .send_request(OutgoingRequest {
                 // TODO If we start charging or paying for CCP broadcasts we'll need to
@@ -514,15 +520,15 @@ where
                 original_amount: prepare.amount(),
                 prepare,
             })
-            .then(move |result| {
-                if let Err(err) = result {
-                    warn!(
-                        "Error sending Route Control Request to account {}: {:?}",
-                        account_id, err
-                    )
-                }
-                Ok(())
-            })
+            .await;
+
+        if let Err(err) = result {
+            warn!(
+                "Error sending Route Control Request to account {}: {:?}",
+                account_id, err
+            )
+        }
+        Ok(())
     }
 
     /// Check whether the Local Routing Table currently has the best routes for the
@@ -530,10 +536,7 @@ where
     /// with some new or modified routes that might be better than our existing ones.
     ///
     /// If prefixes is None, this will check the best routes for all local and configured prefixes.
-    fn update_best_routes(
-        &self,
-        prefixes: Option<Vec<String>>,
-    ) -> impl Future<Item = (), Error = ()> + 'static {
+    async fn update_best_routes(&self, prefixes: Option<Vec<String>>) -> Result<(), ()> {
         let local_table = self.local_table.clone();
         let forwarding_table = self.forwarding_table.clone();
         let forwarding_table_updates = self.forwarding_table_updates.clone();
@@ -541,140 +544,138 @@ where
         let ilp_address = self.ilp_address.read().clone();
         let mut store = self.store.clone();
 
-        self.store.get_local_and_configured_routes().and_then(
-            move |(ref local_routes, ref configured_routes)| {
-                let (better_routes, withdrawn_routes) = {
-                    // Note we only use a read lock here and later get a write lock if we need to update the table
-                    let local_table = local_table.read();
-                    let incoming_tables = incoming_tables.read();
+        let (local_routes, configured_routes) =
+            self.store.get_local_and_configured_routes().await?;
 
-                    // Either check the given prefixes or check all of our local and configured routes
-                    let prefixes_to_check: Box<dyn Iterator<Item = &str>> =
-                        if let Some(ref prefixes) = prefixes {
-                            Box::new(prefixes.iter().map(|prefix| prefix.as_str()))
-                        } else {
-                            let routes = configured_routes.iter().chain(local_routes.iter());
-                            Box::new(routes.map(|(prefix, _account)| prefix.as_str()))
-                        };
+        // TODO: Should we extract this to a function and #[inline] it?
+        let (better_routes, withdrawn_routes) = {
+            // Note we only use a read lock here and later get a write lock if we need to update the table
+            let local_table = local_table.read();
+            let incoming_tables = incoming_tables.read();
 
-                    // Check all the prefixes to see which ones we have different routes for
-                    // and which ones we don't have routes for anymore
-                    let mut better_routes: Vec<(&str, A, Route)> =
-                        Vec::with_capacity(prefixes_to_check.size_hint().0);
-                    let mut withdrawn_routes: Vec<&str> = Vec::new();
-                    for prefix in prefixes_to_check {
-                        // See which prefixes there is now a better route for
-                        if let Some((best_next_account, best_route)) = get_best_route_for_prefix(
-                            local_routes,
-                            configured_routes,
-                            &incoming_tables,
-                            prefix,
-                        ) {
-                            if let Some((ref next_account, ref _route)) =
-                                local_table.get_route(prefix)
-                            {
-                                if next_account.id() == best_next_account.id() {
-                                    continue;
-                                } else {
-                                    better_routes.push((
-                                        prefix,
-                                        best_next_account.clone(),
-                                        best_route.clone(),
-                                    ));
-                                }
-                            } else {
-                                better_routes.push((prefix, best_next_account, best_route));
-                            }
-                        } else {
-                            // No longer have a route to this prefix
-                            withdrawn_routes.push(prefix);
-                        }
-                    }
-                    (better_routes, withdrawn_routes)
+            // Either check the given prefixes or check all of our local and configured routes
+            let prefixes_to_check: Box<dyn Iterator<Item = &str>> =
+                if let Some(ref prefixes) = prefixes {
+                    Box::new(prefixes.iter().map(|prefix| prefix.as_str()))
+                } else {
+                    let routes = configured_routes.iter().chain(local_routes.iter());
+                    Box::new(routes.map(|(prefix, _account)| prefix.as_str()))
                 };
 
-                // Update the local and forwarding tables
-                if !better_routes.is_empty() || !withdrawn_routes.is_empty() {
-                    let mut local_table = local_table.write();
-                    let mut forwarding_table = forwarding_table.write();
-                    let mut forwarding_table_updates = forwarding_table_updates.write();
-
-                    let mut new_routes: Vec<Route> = Vec::with_capacity(better_routes.len());
-
-                    for (prefix, account, mut route) in better_routes {
-                        debug!(
-                            "Setting new route for prefix: {} -> Account: {} (id: {})",
-                            prefix,
-                            account.username(),
-                            account.id(),
-                        );
-                        local_table.set_route(prefix.to_string(), account.clone(), route.clone());
-
-                        // Update the forwarding table
-
-                        // Don't advertise routes that don't start with the global prefix
-                        // or that advertise the whole global prefix
-                        let address_scheme = ilp_address.scheme();
-                        let correct_address_scheme = route.prefix.starts_with(address_scheme)
-                            && route.prefix != address_scheme;
-                        // We do want to advertise our address
-                        let is_our_address = route.prefix == &ilp_address as &str;
-                        // Don't advertise local routes because advertising only our address
-                        // will be enough to ensure the packet gets to us and we can route it
-                        // to the correct account on our node
-                        let is_local_route =
-                            route.prefix.starts_with(&ilp_address as &str) && route.path.is_empty();
-                        let not_local_route = is_our_address || !is_local_route;
-                        // Don't include routes we're also withdrawing
-                        let not_withdrawn_route = !withdrawn_routes.contains(&prefix);
-
-                        if correct_address_scheme && not_local_route && not_withdrawn_route {
-                            let old_route = forwarding_table.get_route(prefix);
-                            if old_route.is_none() || old_route.unwrap().0.id() != account.id() {
-                                route.path.insert(0, ilp_address.to_string());
-                                // Each hop hashes the auth before forwarding
-                                route.auth = hash(&route.auth);
-                                forwarding_table.set_route(
-                                    prefix.to_string(),
-                                    account.clone(),
-                                    route.clone(),
-                                );
-                                new_routes.push(route);
-                            }
+            // Check all the prefixes to see which ones we have different routes for
+            // and which ones we don't have routes for anymore
+            let mut better_routes: Vec<(&str, A, Route)> =
+                Vec::with_capacity(prefixes_to_check.size_hint().0);
+            let mut withdrawn_routes: Vec<&str> = Vec::new();
+            for prefix in prefixes_to_check {
+                // See which prefixes there is now a better route for
+                if let Some((best_next_account, best_route)) = get_best_route_for_prefix(
+                    &local_routes,
+                    &configured_routes,
+                    &incoming_tables,
+                    prefix,
+                ) {
+                    if let Some((ref next_account, ref _route)) = local_table.get_route(prefix) {
+                        if next_account.id() == best_next_account.id() {
+                            continue;
+                        } else {
+                            better_routes.push((
+                                prefix,
+                                best_next_account.clone(),
+                                best_route.clone(),
+                            ));
                         }
+                    } else {
+                        better_routes.push((prefix, best_next_account, best_route));
                     }
-
-                    for prefix in withdrawn_routes.iter() {
-                        debug!("Removed route for prefix: {}", prefix);
-                        local_table.delete_route(prefix);
-                        forwarding_table.delete_route(prefix);
-                    }
-
-                    let epoch = forwarding_table.increment_epoch();
-                    forwarding_table_updates.push((
-                        new_routes,
-                        withdrawn_routes.iter().map(|s| s.to_string()).collect(),
-                    ));
-                    debug_assert_eq!(epoch as usize + 1, forwarding_table_updates.len());
-
-                    Either::A(
-                        store.set_routes(
-                            local_table
-                                .get_simplified_table()
-                                .into_iter()
-                                .map(|(prefix, account)| (prefix.to_string(), account)),
-                        ),
-                    )
                 } else {
-                    // The routing table hasn't changed
-                    Either::B(ok(()))
+                    // No longer have a route to this prefix
+                    withdrawn_routes.push(prefix);
                 }
-            },
-        )
+            }
+            (better_routes, withdrawn_routes)
+        };
+
+        // Update the local and forwarding tables
+        if !better_routes.is_empty() || !withdrawn_routes.is_empty() {
+            let mut local_table = local_table.write().clone();
+            let mut forwarding_table = forwarding_table.write().clone();
+            let mut forwarding_table_updates = forwarding_table_updates.write().clone();
+
+            let mut new_routes: Vec<Route> = Vec::with_capacity(better_routes.len());
+
+            for (prefix, account, mut route) in better_routes {
+                debug!(
+                    "Setting new route for prefix: {} -> Account: {} (id: {})",
+                    prefix,
+                    account.username(),
+                    account.id(),
+                );
+                local_table.set_route(prefix.to_string(), account.clone(), route.clone());
+
+                // Update the forwarding table
+
+                // Don't advertise routes that don't start with the global prefix
+                // or that advertise the whole global prefix
+                let address_scheme = ilp_address.scheme();
+                let correct_address_scheme =
+                    route.prefix.starts_with(address_scheme) && route.prefix != address_scheme;
+                // We do want to advertise our address
+                let is_our_address = route.prefix == &ilp_address as &str;
+                // Don't advertise local routes because advertising only our address
+                // will be enough to ensure the packet gets to us and we can route it
+                // to the correct account on our node
+                let is_local_route =
+                    route.prefix.starts_with(&ilp_address as &str) && route.path.is_empty();
+                let not_local_route = is_our_address || !is_local_route;
+                // Don't include routes we're also withdrawing
+                let not_withdrawn_route = !withdrawn_routes.contains(&prefix);
+
+                if correct_address_scheme && not_local_route && not_withdrawn_route {
+                    let old_route = forwarding_table.get_route(prefix);
+                    if old_route.is_none() || old_route.unwrap().0.id() != account.id() {
+                        route.path.insert(0, ilp_address.to_string());
+                        // Each hop hashes the auth before forwarding
+                        route.auth = hash(&route.auth);
+                        forwarding_table.set_route(
+                            prefix.to_string(),
+                            account.clone(),
+                            route.clone(),
+                        );
+                        new_routes.push(route);
+                    }
+                }
+            }
+
+            for prefix in withdrawn_routes.iter() {
+                debug!("Removed route for prefix: {}", prefix);
+                local_table.delete_route(prefix);
+                forwarding_table.delete_route(prefix);
+            }
+
+            let epoch = forwarding_table.increment_epoch();
+            forwarding_table_updates.push((
+                new_routes,
+                withdrawn_routes.iter().map(|s| s.to_string()).collect(),
+            ));
+            debug_assert_eq!(epoch as usize + 1, forwarding_table_updates.len());
+
+            store
+                .set_routes(
+                    local_table
+                        .get_simplified_table()
+                        .into_iter()
+                        .map(|(prefix, account)| (prefix.to_string(), account)),
+                )
+                .await
+        } else {
+            // The routing table hasn't changed
+            Ok(())
+        }
     }
 
     /// Send RouteUpdateRequests to all peers that we send routing messages to
-    fn send_route_updates(&self) -> impl Future<Item = (), Error = ()> {
+    async fn send_route_updates(&self) -> Result<(), ()> {
         let self_clone = self.clone();
         let unavailable_accounts = self.unavailable_accounts.clone();
         // Check which accounts we should skip this iteration
@@ -690,95 +691,120 @@ where
             }
             skip
         };
+
         trace!("Skipping accounts: {:?}", accounts_to_skip);
-        self.store
+        let mut accounts = self
+            .store
             .get_accounts_to_send_routes_to(accounts_to_skip)
-            .and_then(move |mut accounts| {
-                let mut outgoing = self_clone.outgoing.clone();
-                let to_epoch_index = self_clone.forwarding_table.read().epoch();
-                let from_epoch_index = self_clone.last_epoch_updates_sent_for.swap(to_epoch_index, Ordering::SeqCst);
+            .await?;
 
-                let route_update_request =
-                    self_clone.create_route_update(from_epoch_index, to_epoch_index);
+        let to_epoch_index = self_clone.forwarding_table.read().epoch();
+        let from_epoch_index = self_clone
+            .last_epoch_updates_sent_for
+            .swap(to_epoch_index, Ordering::SeqCst);
 
-                let prepare = route_update_request.to_prepare();
-                accounts.sort_unstable_by_key(|a| a.id().to_string());
-                accounts.dedup_by_key(|a| a.id());
+        let route_update_request = self_clone.create_route_update(from_epoch_index, to_epoch_index);
 
-                let broadcasting = !accounts.is_empty();
-                if broadcasting {
-                    trace!(
-                        "Sending route update for epochs {} - {} to accounts: {:?} {}",
-                        from_epoch_index,
-                        to_epoch_index,
-                        route_update_request,
-                        {
-                            let account_list: Vec<String> = accounts
-                                .iter()
-                                .map(|a| {
-                                    format!(
-                                        "{} (id: {}, ilp_address: {})",
-                                        a.username(),
-                                        a.id(),
-                                        a.ilp_address()
-                                    )
-                                })
-                                .collect();
-                            account_list.join(", ")
-                        }
-                    );
-                    Either::A(
-                        join_all(accounts.into_iter().map(move |account| {
-                            outgoing
-                                .send_request(OutgoingRequest {
-                                    from: account.clone(),
-                                    to: account.clone(),
-                                    original_amount: prepare.amount(),
-                                    prepare: prepare.clone(),
-                                })
-                                .then(move |res| Ok((account, res)))
-                        }))
-                        .and_then(move |results: Vec<(A, Result<Fulfill, Reject>)>| {
-                            // Handle the results of the route broadcast attempts
-                            trace!("Updating unavailable accounts");
-                            let mut unavailable_accounts = unavailable_accounts.lock();
-                            for (account, result) in results.into_iter() {
-                                match (account.routing_relation(), result) {
-                                    (RoutingRelation::Child, Err(err)) => {
-                                        if let Some(backoff) = unavailable_accounts.get_mut(&account.id()) {
-                                            // Increase the number of intervals we'll skip
-                                            // (but don't overflow the value it's stored in)
-                                            backoff.max = backoff.max.saturating_add(1);
-                                            backoff.skip_intervals = backoff.max;
-                                        } else {
-                                            // Skip sending to this account next time
-                                            unavailable_accounts.insert(account.id(), BackoffParams {
-                                                max: 1,
-                                                skip_intervals: 1,
-                                            });
-                                        }
-                                        trace!("Error sending route update to {:?} account {} (id: {}), increased backoff to {}: {:?}",
-                                            account.routing_relation(), account.username(), account.id(), unavailable_accounts[&account.id()].max, err);
-                                    },
-                                    (_, Err(err)) => {
-                                        warn!("Error sending route update to {:?} account {} (id: {}): {:?}",
-                                            account.routing_relation(), account.username(), account.id(), err);
-                                    },
-                                    (_, Ok(_)) => {
-                                        if unavailable_accounts.remove(&account.id()).is_some() {
-                                            debug!("Account {} (id: {}) is no longer unavailable, resuming route broadcasts", account.username(), account.id());
-                                        }
-                                    }
-                                }
-                            }
-                            Ok(())
-                        }),
-                    )
-                } else {
-                    trace!("No accounts to broadcast routes to");
-                    Either::B(ok(()))
+        let prepare = route_update_request.to_prepare();
+        accounts.sort_unstable_by_key(|a| a.id().to_string());
+        accounts.dedup_by_key(|a| a.id());
+
+        let broadcasting = !accounts.is_empty();
+        if broadcasting {
+            trace!(
+                "Sending route update for epochs {} - {} to accounts: {:?} {}",
+                from_epoch_index,
+                to_epoch_index,
+                route_update_request,
+                {
+                    let account_list: Vec<String> = accounts
+                        .iter()
+                        .map(|a| {
+                            format!(
+                                "{} (id: {}, ilp_address: {})",
+                                a.username(),
+                                a.id(),
+                                a.ilp_address()
+                            )
+                        })
+                        .collect();
+                    account_list.join(", ")
                 }
-            })
+            );
+
+            // let results: Vec<(A, Result<Fulfill, Reject>)> =
+            // let results =
+            //     join_all(accounts.into_iter().map(|account| {
+            //         outgoing
+            //             .send_request(OutgoingRequest {
+            //                 from: account.clone(),
+            //                 to: account.clone(),
+            //                 original_amount: prepare.amount(),
+            //                 prepare: prepare.clone(),
+            //             })
+            //             .map(move |res| (account, res))
+            //             // Vec<result<acc, packet>>
+            //     }))
+            //     .await;
+            let mut outgoing = self_clone.outgoing.clone();
+            let mut results = Vec::new();
+            for account in accounts.into_iter() {
+                let res = outgoing
+                    .send_request(OutgoingRequest {
+                        from: account.clone(),
+                        to: account.clone(),
+                        original_amount: prepare.amount(),
+                        prepare: prepare.clone(),
+                    })
+                    .await;
+                results.push((account, res));
+            }
+
+            // Handle the results of the route broadcast attempts
+            trace!("Updating unavailable accounts");
+            let mut unavailable_accounts = unavailable_accounts.lock();
+            for (account, result) in results.into_iter() {
+                match (account.routing_relation(), result) {
+                    (RoutingRelation::Child, Err(err)) => {
+                        if let Some(backoff) = unavailable_accounts.get_mut(&account.id()) {
+                            // Increase the number of intervals we'll skip
+                            // (but don't overflow the value it's stored in)
+                            backoff.max = backoff.max.saturating_add(1);
+                            backoff.skip_intervals = backoff.max;
+                        } else {
+                            // Skip sending to this account next time
+                            unavailable_accounts.insert(
+                                account.id(),
+                                BackoffParams {
+                                    max: 1,
+                                    skip_intervals: 1,
+                                },
+                            );
+                        }
+                        trace!("Error sending route update to {:?} account {} (id: {}), increased backoff to {}: {:?}",
+                            account.routing_relation(), account.username(), account.id(), unavailable_accounts[&account.id()].max, err);
+                    }
+                    (_, Err(err)) => {
+                        warn!(
+                            "Error sending route update to {:?} account {} (id: {}): {:?}",
+                            account.routing_relation(),
+                            account.username(),
+                            account.id(),
+                            err
+                        );
+                    }
+                    (_, Ok(_)) => {
+                        if unavailable_accounts.remove(&account.id()).is_some() {
+                            debug!("Account {} (id: {}) is no longer unavailable, resuming route broadcasts", account.username(), account.id());
+                        }
+                    }
+                }
+            }
+            Ok(())
+        } else {
+            trace!("No accounts to broadcast routes to");
+            Ok(())
+        }
     }
 
     /// Create a RouteUpdateRequest representing the given range of Forwarding Routing Table epochs.
@@ -861,12 +887,12 @@ where
 
     /// Send a Route Update Request to a specific account for the given epoch range.
     /// This is used when the peer has fallen behind and has requested a specific range of updates.
-    fn send_route_update(
+    async fn send_route_update(
         &self,
         account: A,
         from_epoch_index: u32,
         to_epoch_index: u32,
-    ) -> impl Future<Item = (), Error = ()> {
+    ) -> Result<(), ()> {
         let prepare = self
             .create_route_update(from_epoch_index, to_epoch_index)
             .to_prepare();
@@ -875,7 +901,8 @@ where
             "Sending individual route update to account: {} for epochs from: {} to: {}",
             account_id, from_epoch_index, to_epoch_index
         );
-        self.outgoing
+        let result = self
+            .outgoing
             .clone()
             .send_request(OutgoingRequest {
                 from: account.clone(),
@@ -883,16 +910,15 @@ where
                 original_amount: prepare.amount(),
                 prepare,
             })
-            .and_then(|_| Ok(()))
-            .then(move |result| {
-                if let Err(err) = result {
-                    error!(
-                        "Error sending route update to account {}: {:?}",
-                        account_id, err
-                    )
-                }
-                Ok(())
-            })
+            .await;
+
+        if let Err(err) = result {
+            error!(
+                "Error sending route update to account {}: {:?}",
+                account_id, err
+            )
+        }
+        Ok(())
     }
 }
 
@@ -970,6 +996,7 @@ fn get_best_route_for_prefix<A: CcpRoutingAccount>(
     }
 }
 
+#[async_trait]
 impl<I, O, S, A> IncomingService<A> for CcpRouteManager<I, O, S, A>
 where
     I: IncomingService<A> + Clone + Send + Sync + 'static,
@@ -977,18 +1004,16 @@ where
     S: AddressStore + RouteManagerStore<Account = A> + Clone + Send + Sync + 'static,
     A: CcpRoutingAccount + Send + Sync + 'static,
 {
-    type Future = BoxedIlpFuture;
-
     /// Handle the IncomingRequest if it is a CCP protocol message or
     /// pass it on to the next handler if not
-    fn handle_request(&mut self, request: IncomingRequest<A>) -> Self::Future {
+    async fn handle_request(&mut self, request: IncomingRequest<A>) -> IlpResult {
         let destination = request.prepare.destination();
         if destination == *CCP_CONTROL_DESTINATION {
-            Box::new(self.handle_route_control_request(request))
+            self.handle_route_control_request(request).await
         } else if destination == *CCP_UPDATE_DESTINATION {
-            Box::new(self.handle_route_update_request(request))
+            self.handle_route_update_request(request).await
         } else {
-            Box::new(self.next_incoming.handle_request(request))
+            self.next_incoming.handle_request(request).await
         }
     }
 }
@@ -1143,26 +1168,26 @@ mod handle_route_control_request {
     use crate::test_helpers::*;
     use std::time::{Duration, SystemTime};
 
-    #[test]
-    fn handles_valid_request() {
+    #[tokio::test]
+    async fn handles_valid_request() {
         test_service_with_routes()
             .0
             .handle_request(IncomingRequest {
                 prepare: CONTROL_REQUEST.to_prepare(),
                 from: ROUTING_ACCOUNT.clone(),
             })
-            .wait()
+            .await
             .unwrap();
     }
 
-    #[test]
-    fn rejects_from_non_sending_account() {
+    #[tokio::test]
+    async fn rejects_from_non_sending_account() {
         let result = test_service()
             .handle_request(IncomingRequest {
                 prepare: CONTROL_REQUEST.to_prepare(),
                 from: NON_ROUTING_ACCOUNT.clone(),
             })
-            .wait();
+            .await;
         assert!(result.is_err());
         assert_eq!(
             str::from_utf8(result.unwrap_err().message()).unwrap(),
@@ -1170,8 +1195,8 @@ mod handle_route_control_request {
         );
     }
 
-    #[test]
-    fn rejects_invalid_packet() {
+    #[tokio::test]
+    async fn rejects_invalid_packet() {
         let result = test_service()
             .handle_request(IncomingRequest {
                 prepare: PrepareBuilder {
@@ -1184,7 +1209,7 @@ mod handle_route_control_request {
                 .build(),
                 from: ROUTING_ACCOUNT.clone(),
             })
-            .wait();
+            .await;
         assert!(result.is_err());
         assert_eq!(
             str::from_utf8(result.unwrap_err().message()).unwrap(),
@@ -1192,11 +1217,11 @@ mod handle_route_control_request {
         );
     }
 
-    #[test]
-    fn sends_update_in_response() {
+    #[tokio::test]
+    async fn sends_update_in_response() {
         let (mut service, outgoing_requests) = test_service_with_routes();
         (*service.forwarding_table.write()).set_id([0; 16]);
-        service.update_best_routes(None).wait().unwrap();
+        service.update_best_routes(None).await.unwrap();
         service
             .handle_request(IncomingRequest {
                 from: ROUTING_ACCOUNT.clone(),
@@ -1208,7 +1233,7 @@ mod handle_route_control_request {
                 }
                 .to_prepare(),
             })
-            .wait()
+            .await
             .unwrap();
         let request: &OutgoingRequest<TestAccount> = &outgoing_requests.lock()[0];
         assert_eq!(request.to.id(), ROUTING_ACCOUNT.id());
@@ -1220,10 +1245,10 @@ mod handle_route_control_request {
         assert_eq!(update.new_routes.len(), 3);
     }
 
-    #[test]
-    fn sends_whole_table_if_id_is_different() {
+    #[tokio::test]
+    async fn sends_whole_table_if_id_is_different() {
         let (mut service, outgoing_requests) = test_service_with_routes();
-        service.update_best_routes(None).wait().unwrap();
+        service.update_best_routes(None).await.unwrap();
         service
             .handle_request(IncomingRequest {
                 from: ROUTING_ACCOUNT.clone(),
@@ -1235,7 +1260,7 @@ mod handle_route_control_request {
                 }
                 .to_prepare(),
             })
-            .wait()
+            .await
             .unwrap();
         let routing_table_id = service.forwarding_table.read().id();
         let request: &OutgoingRequest<TestAccount> = &outgoing_requests.lock()[0];
@@ -1259,8 +1284,8 @@ mod handle_route_update_request {
         time::{Duration, SystemTime},
     };
 
-    #[test]
-    fn handles_valid_request() {
+    #[tokio::test]
+    async fn handles_valid_request() {
         let mut service = test_service();
         let mut update = UPDATE_REQUEST_SIMPLE.clone();
         update.to_epoch_index = 1;
@@ -1271,18 +1296,18 @@ mod handle_route_update_request {
                 prepare: update.to_prepare(),
                 from: ROUTING_ACCOUNT.clone(),
             })
-            .wait()
+            .await
             .unwrap();
     }
 
-    #[test]
-    fn rejects_from_child_account() {
+    #[tokio::test]
+    async fn rejects_from_child_account() {
         let result = test_service()
             .handle_request(IncomingRequest {
                 prepare: UPDATE_REQUEST_SIMPLE.to_prepare(),
                 from: CHILD_ACCOUNT.clone(),
             })
-            .wait();
+            .await;
         assert!(result.is_err());
         assert_eq!(
             str::from_utf8(result.unwrap_err().message()).unwrap(),
@@ -1290,14 +1315,14 @@ mod handle_route_update_request {
         );
     }
 
-    #[test]
-    fn rejects_from_non_routing_account() {
+    #[tokio::test]
+    async fn rejects_from_non_routing_account() {
         let result = test_service()
             .handle_request(IncomingRequest {
                 prepare: UPDATE_REQUEST_SIMPLE.to_prepare(),
                 from: NON_ROUTING_ACCOUNT.clone(),
             })
-            .wait();
+            .await;
         assert!(result.is_err());
         assert_eq!(
             str::from_utf8(result.unwrap_err().message()).unwrap(),
@@ -1305,8 +1330,8 @@ mod handle_route_update_request {
         );
     }
 
-    #[test]
-    fn rejects_invalid_packet() {
+    #[tokio::test]
+    async fn rejects_invalid_packet() {
         let result = test_service()
             .handle_request(IncomingRequest {
                 prepare: PrepareBuilder {
@@ -1319,7 +1344,7 @@ mod handle_route_update_request {
                 .build(),
                 from: ROUTING_ACCOUNT.clone(),
             })
-            .wait();
+            .await;
         assert!(result.is_err());
         assert_eq!(
             str::from_utf8(result.unwrap_err().message()).unwrap(),
@@ -1327,8 +1352,8 @@ mod handle_route_update_request {
         );
     }
 
-    #[test]
-    fn adds_table_on_first_request() {
+    #[tokio::test]
+    async fn adds_table_on_first_request() {
         let mut service = test_service();
         let mut update = UPDATE_REQUEST_SIMPLE.clone();
         update.to_epoch_index = 1;
@@ -1339,13 +1364,13 @@ mod handle_route_update_request {
                 prepare: update.to_prepare(),
                 from: ROUTING_ACCOUNT.clone(),
             })
-            .wait()
+            .await
             .unwrap();
         assert_eq!(service.incoming_tables.read().len(), 1);
     }
 
-    #[test]
-    fn filters_routes_with_other_address_scheme() {
+    #[tokio::test]
+    async fn filters_routes_with_other_address_scheme() {
         let service = test_service();
         let mut request = UPDATE_REQUEST_SIMPLE.clone();
         request.new_routes.push(Route {
@@ -1365,8 +1390,8 @@ mod handle_route_update_request {
         assert_eq!(request.new_routes[0].prefix, "example.valid".to_string());
     }
 
-    #[test]
-    fn filters_routes_for_address_scheme() {
+    #[tokio::test]
+    async fn filters_routes_for_address_scheme() {
         let service = test_service();
         let mut request = UPDATE_REQUEST_SIMPLE.clone();
         request.new_routes.push(Route {
@@ -1386,8 +1411,8 @@ mod handle_route_update_request {
         assert_eq!(request.new_routes[0].prefix, "example.valid".to_string());
     }
 
-    #[test]
-    fn filters_routing_loops() {
+    #[tokio::test]
+    async fn filters_routing_loops() {
         let service = test_service();
         let mut request = UPDATE_REQUEST_SIMPLE.clone();
         request.new_routes.push(Route {
@@ -1411,8 +1436,8 @@ mod handle_route_update_request {
         assert_eq!(request.new_routes[0].prefix, "example.valid".to_string());
     }
 
-    #[test]
-    fn filters_own_prefix_routes() {
+    #[tokio::test]
+    async fn filters_own_prefix_routes() {
         let service = test_service();
         let mut request = UPDATE_REQUEST_SIMPLE.clone();
         request.new_routes.push(Route {
@@ -1432,8 +1457,8 @@ mod handle_route_update_request {
         assert_eq!(request.new_routes[0].prefix, "example.valid".to_string());
     }
 
-    #[test]
-    fn updates_local_routing_table() {
+    #[tokio::test]
+    async fn updates_local_routing_table() {
         let mut service = test_service();
         let mut request = UPDATE_REQUEST_COMPLEX.clone();
         request.to_epoch_index = 1;
@@ -1443,7 +1468,7 @@ mod handle_route_update_request {
                 from: ROUTING_ACCOUNT.clone(),
                 prepare: request.to_prepare(),
             })
-            .wait()
+            .await
             .unwrap();
         assert_eq!(
             (*service.local_table.read())
@@ -1463,8 +1488,8 @@ mod handle_route_update_request {
         );
     }
 
-    #[test]
-    fn writes_local_routing_table_to_store() {
+    #[tokio::test]
+    async fn writes_local_routing_table_to_store() {
         let mut service = test_service();
         let mut request = UPDATE_REQUEST_COMPLEX.clone();
         request.to_epoch_index = 1;
@@ -1474,13 +1499,12 @@ mod handle_route_update_request {
                 from: ROUTING_ACCOUNT.clone(),
                 prepare: request.to_prepare(),
             })
-            .wait()
+            .await
             .unwrap();
         assert_eq!(
             service
                 .store
                 .routes
-                .lock()
                 .get(&"example.prefix1"[..])
                 .unwrap()
                 .id(),
@@ -1490,7 +1514,6 @@ mod handle_route_update_request {
             service
                 .store
                 .routes
-                .lock()
                 .get(&"example.prefix2"[..])
                 .unwrap()
                 .id(),
@@ -1498,8 +1521,8 @@ mod handle_route_update_request {
         );
     }
 
-    #[test]
-    fn doesnt_overwrite_configured_or_local_routes() {
+    #[tokio::test]
+    async fn doesnt_overwrite_configured_or_local_routes() {
         let mut service = test_service();
         let id1 = Uuid::from_slice(&[1; 16]).unwrap();
         let id2 = Uuid::from_slice(&[2; 16]).unwrap();
@@ -1523,7 +1546,7 @@ mod handle_route_update_request {
                 from: ROUTING_ACCOUNT.clone(),
                 prepare: request.to_prepare(),
             })
-            .wait()
+            .await
             .unwrap();
         assert_eq!(
             (*service.local_table.read())
@@ -1543,8 +1566,8 @@ mod handle_route_update_request {
         );
     }
 
-    #[test]
-    fn removes_withdrawn_routes() {
+    #[tokio::test]
+    async fn removes_withdrawn_routes() {
         let mut service = test_service();
         let mut request = UPDATE_REQUEST_COMPLEX.clone();
         request.to_epoch_index = 1;
@@ -1554,7 +1577,7 @@ mod handle_route_update_request {
                 from: ROUTING_ACCOUNT.clone(),
                 prepare: request.to_prepare(),
             })
-            .wait()
+            .await
             .unwrap();
         service
             .handle_request(IncomingRequest {
@@ -1571,7 +1594,7 @@ mod handle_route_update_request {
                 }
                 .to_prepare(),
             })
-            .wait()
+            .await
             .unwrap();
 
         assert_eq!(
@@ -1587,8 +1610,8 @@ mod handle_route_update_request {
             .is_none());
     }
 
-    #[test]
-    fn sends_control_request_if_routing_table_id_changed() {
+    #[tokio::test]
+    async fn sends_control_request_if_routing_table_id_changed() {
         let (mut service, outgoing_requests) = test_service_with_routes();
         // First request is valid
         let mut request1 = UPDATE_REQUEST_COMPLEX.clone();
@@ -1599,7 +1622,7 @@ mod handle_route_update_request {
                 from: ROUTING_ACCOUNT.clone(),
                 prepare: request1.to_prepare(),
             })
-            .wait()
+            .await
             .unwrap();
 
         // Second has a gap in epochs
@@ -1612,7 +1635,7 @@ mod handle_route_update_request {
                 from: ROUTING_ACCOUNT.clone(),
                 prepare: request2.to_prepare(),
             })
-            .wait()
+            .await
             .unwrap_err();
         assert_eq!(err.code(), ErrorCode::F00_BAD_REQUEST);
 
@@ -1625,8 +1648,8 @@ mod handle_route_update_request {
         );
     }
 
-    #[test]
-    fn sends_control_request_if_missing_epochs() {
+    #[tokio::test]
+    async fn sends_control_request_if_missing_epochs() {
         let (mut service, outgoing_requests) = test_service_with_routes();
 
         // First request is valid
@@ -1638,7 +1661,7 @@ mod handle_route_update_request {
                 from: ROUTING_ACCOUNT.clone(),
                 prepare: request.to_prepare(),
             })
-            .wait()
+            .await
             .unwrap();
 
         // Second has a gap in epochs
@@ -1650,7 +1673,7 @@ mod handle_route_update_request {
                 from: ROUTING_ACCOUNT.clone(),
                 prepare: request.to_prepare(),
             })
-            .wait()
+            .await
             .unwrap_err();
         assert_eq!(err.code(), ErrorCode::F00_BAD_REQUEST);
 
@@ -1665,8 +1688,8 @@ mod create_route_update {
     use super::*;
     use crate::test_helpers::*;
 
-    #[test]
-    fn heartbeat_message_for_empty_table() {
+    #[tokio::test]
+    async fn heartbeat_message_for_empty_table() {
         let service = test_service();
         let update = service.create_route_update(0, 0);
         assert_eq!(update.from_epoch_index, 0);
@@ -1678,8 +1701,8 @@ mod create_route_update {
         assert!(update.withdrawn_routes.is_empty());
     }
 
-    #[test]
-    fn includes_the_given_range_of_epochs() {
+    #[tokio::test]
+    async fn includes_the_given_range_of_epochs() {
         let service = test_service();
         (*service.forwarding_table.write()).set_epoch(4);
         *service.forwarding_table_updates.write() = vec![
@@ -1746,10 +1769,10 @@ mod send_route_updates {
     use interledger_service::*;
     use std::{collections::HashSet, iter::FromIterator, str::FromStr};
 
-    #[test]
-    fn broadcasts_to_all_accounts_we_send_updates_to() {
+    #[tokio::test]
+    async fn broadcasts_to_all_accounts_we_send_updates_to() {
         let (service, outgoing_requests) = test_service_with_routes();
-        service.send_route_updates().wait().unwrap();
+        service.send_route_updates().await.unwrap();
         let accounts: HashSet<Uuid> = outgoing_requests
             .lock()
             .iter()
@@ -1765,14 +1788,14 @@ mod send_route_updates {
         assert_eq!(accounts, expected);
     }
 
-    #[test]
-    fn broadcasts_configured_and_local_routes() {
+    #[tokio::test]
+    async fn broadcasts_configured_and_local_routes() {
         let (service, outgoing_requests) = test_service_with_routes();
 
         // This is normally spawned as a task when the service is created
-        service.update_best_routes(None).wait().unwrap();
+        service.update_best_routes(None).await.unwrap();
 
-        service.send_route_updates().wait().unwrap();
+        service.send_route_updates().await.unwrap();
         let update = RouteUpdateRequest::try_from(&outgoing_requests.lock()[0].prepare).unwrap();
         assert_eq!(update.new_routes.len(), 3);
         let prefixes: Vec<&str> = update
@@ -1784,12 +1807,12 @@ mod send_route_updates {
         assert!(prefixes.contains(&"example.configured.1"));
     }
 
-    #[test]
-    fn broadcasts_received_routes() {
+    #[tokio::test]
+    async fn broadcasts_received_routes() {
         let (service, outgoing_requests) = test_service_with_routes();
 
         // This is normally spawned as a task when the service is created
-        service.update_best_routes(None).wait().unwrap();
+        service.update_best_routes(None).await.unwrap();
 
         service
             .handle_route_update_request(IncomingRequest {
@@ -1811,10 +1834,10 @@ mod send_route_updates {
                 }
                 .to_prepare(),
             })
-            .wait()
+            .await
             .unwrap();
 
-        service.send_route_updates().wait().unwrap();
+        service.send_route_updates().await.unwrap();
         let update = RouteUpdateRequest::try_from(&outgoing_requests.lock()[0].prepare).unwrap();
         assert_eq!(update.new_routes.len(), 4);
         let prefixes: Vec<&str> = update
@@ -1827,13 +1850,13 @@ mod send_route_updates {
         assert!(prefixes.contains(&"example.remote"));
     }
 
-    #[test]
-    fn broadcasts_withdrawn_routes() {
+    #[tokio::test]
+    async fn broadcasts_withdrawn_routes() {
         let id10 = Uuid::from_slice(&[10; 16]).unwrap();
         let (service, outgoing_requests) = test_service_with_routes();
 
         // This is normally spawned as a task when the service is created
-        service.update_best_routes(None).wait().unwrap();
+        service.update_best_routes(None).await.unwrap();
 
         service
             .handle_route_update_request(IncomingRequest {
@@ -1855,7 +1878,7 @@ mod send_route_updates {
                 }
                 .to_prepare(),
             })
-            .wait()
+            .await
             .unwrap();
         service
             .handle_route_update_request(IncomingRequest {
@@ -1872,10 +1895,10 @@ mod send_route_updates {
                 }
                 .to_prepare(),
             })
-            .wait()
+            .await
             .unwrap();
 
-        service.send_route_updates().wait().unwrap();
+        service.send_route_updates().await.unwrap();
         let update = RouteUpdateRequest::try_from(&outgoing_requests.lock()[0].prepare).unwrap();
         assert_eq!(update.new_routes.len(), 3);
         let prefixes: Vec<&str> = update
@@ -1890,8 +1913,8 @@ mod send_route_updates {
         assert_eq!(update.withdrawn_routes[0], "example.remote");
     }
 
-    #[test]
-    fn backs_off_sending_to_unavailable_child_accounts() {
+    #[tokio::test]
+    async fn backs_off_sending_to_unavailable_child_accounts() {
         let id1 = Uuid::from_slice(&[1; 16]).unwrap();
         let id2 = Uuid::from_slice(&[2; 16]).unwrap();
         let local_routes = HashMap::from_iter(vec![
@@ -1932,18 +1955,18 @@ mod send_route_updates {
             store,
             outgoing,
             incoming_service_fn(|_request| {
-                Box::new(err(RejectBuilder {
+                Err(RejectBuilder {
                     code: ErrorCode::F02_UNREACHABLE,
                     message: b"No other incoming handler!",
                     data: &[],
                     triggered_by: Some(&EXAMPLE_CONNECTOR),
                 }
-                .build()))
+                .build())
             }),
         )
         .ilp_address(Address::from_str("example.connector").unwrap())
         .to_service();
-        service.send_route_updates().wait().unwrap();
+        service.send_route_updates().await.unwrap();
 
         // The first time, the child request is rejected
         assert_eq!(outgoing_requests.lock().len(), 2);
@@ -1957,7 +1980,7 @@ mod send_route_updates {
         }
 
         *outgoing_requests.lock() = Vec::new();
-        service.send_route_updates().wait().unwrap();
+        service.send_route_updates().await.unwrap();
 
         // When we send again, we skip the child
         assert_eq!(outgoing_requests.lock().len(), 1);
@@ -1971,7 +1994,7 @@ mod send_route_updates {
         }
 
         *outgoing_requests.lock() = Vec::new();
-        service.send_route_updates().wait().unwrap();
+        service.send_route_updates().await.unwrap();
 
         // When we send again, we try the child but it still won't work
         assert_eq!(outgoing_requests.lock().len(), 2);
@@ -1985,8 +2008,8 @@ mod send_route_updates {
         }
     }
 
-    #[test]
-    fn resets_backoff_on_route_control_request() {
+    #[tokio::test]
+    async fn resets_backoff_on_route_control_request() {
         let id1 = Uuid::from_slice(&[1; 16]).unwrap();
         let id2 = Uuid::from_slice(&[2; 16]).unwrap();
         let child_account = TestAccount {
@@ -2028,18 +2051,18 @@ mod send_route_updates {
             store,
             outgoing,
             incoming_service_fn(|_request| {
-                Box::new(err(RejectBuilder {
+                Err(RejectBuilder {
                     code: ErrorCode::F02_UNREACHABLE,
                     message: b"No other incoming handler!",
                     data: &[],
                     triggered_by: Some(&EXAMPLE_CONNECTOR),
                 }
-                .build()))
+                .build())
             }),
         )
         .ilp_address(Address::from_str("example.connector").unwrap())
         .to_service();
-        service.send_route_updates().wait().unwrap();
+        service.send_route_updates().await.unwrap();
 
         // The first time, the child request is rejected
         assert_eq!(outgoing_requests.lock().len(), 2);
@@ -2057,7 +2080,7 @@ mod send_route_updates {
                 prepare: CONTROL_REQUEST.to_prepare(),
                 from: child_account,
             })
-            .wait()
+            .await
             .unwrap();
         {
             let lock = service.unavailable_accounts.lock();
@@ -2065,7 +2088,7 @@ mod send_route_updates {
         }
 
         *outgoing_requests.lock() = Vec::new();
-        service.send_route_updates().wait().unwrap();
+        service.send_route_updates().await.unwrap();
 
         // When we send again, we don't skip the child because we got a request from them
         assert_eq!(outgoing_requests.lock().len(), 2);

--- a/crates/interledger-ccp/src/server.rs
+++ b/crates/interledger-ccp/src/server.rs
@@ -681,7 +681,6 @@ where
 
             update_routes.await
         } else {
-            dbg!("not chagned");
             // The routing table hasn't changed
             Ok(())
         }

--- a/crates/interledger-http/Cargo.toml
+++ b/crates/interledger-http/Cargo.toml
@@ -9,22 +9,26 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 
 [dependencies]
 bytes = { version = "0.4.12", default-features = false }
-futures = { version = "0.1.29", default-features = false }
+bytes05 = { package = "bytes", version = "0.5", default-features = false }
+futures = { version = "0.3", default-features = false }
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 log = { version = "0.4.8", default-features = false }
-reqwest = { version = "0.9.22", default-features = false, features = ["default-tls"] }
+reqwest = { version = "0.10.0", default-features = false, features = ["default-tls"] }
 url = { version = "2.1.0", default-features = false }
-warp = { version = "0.1.20", default-features = false }
+# warp = { version = "0.1.20", default-features = false }
+warp = { git = "https://github.com/seanmonstar/warp.git" }
 serde = { version = "1.0.101", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.41", default-features = false }
 serde_path_to_error = { version = "0.1", default-features = false }
-http = { version = "0.1.18", default-features = false }
+http = { version = "0.2.0", default-features = false }
 chrono = { version = "0.4.9", features = ["clock"], default-features = false }
 regex = { version ="1.3.1", default-features = false, features = ["std"] }
 lazy_static = { version ="1.4.0", default-features = false }
 mime = { version ="0.3.14", default-features = false }
 secrecy = "0.5.2"
+async-trait = "0.1.22"
 
 [dev-dependencies]
 uuid = { version = "0.8.1", features=["v4"]}
+tokio = { version = "0.2.6", features = ["rt-core", "macros"]}

--- a/crates/interledger-http/src/client.rs
+++ b/crates/interledger-http/src/client.rs
@@ -1,12 +1,13 @@
 use super::{HttpAccount, HttpStore};
+use async_trait::async_trait;
 use bytes::BytesMut;
-use futures::{future::result, Future, Stream};
-use interledger_packet::{Address, ErrorCode, Fulfill, Packet, Reject, RejectBuilder};
+use futures::future::TryFutureExt;
+use interledger_packet::{Address, ErrorCode, Packet, RejectBuilder};
 use interledger_service::*;
 use log::{error, trace};
 use reqwest::{
     header::{HeaderMap, HeaderName, HeaderValue},
-    r#async::{Chunk, Client, ClientBuilder, Response as HttpResponse},
+    Client, ClientBuilder, Response as HttpResponse,
 };
 use secrecy::{ExposeSecret, SecretString};
 use std::{convert::TryFrom, marker::PhantomData, sync::Arc, time::Duration};
@@ -46,18 +47,18 @@ where
     }
 }
 
+#[async_trait]
 impl<S, O, A> OutgoingService<A> for HttpClientService<S, O, A>
 where
-    S: AddressStore + HttpStore,
-    O: OutgoingService<A>,
-    A: HttpAccount,
+    S: AddressStore + HttpStore + Clone,
+    O: OutgoingService<A> + Clone + Sync + Send,
+    A: HttpAccount + Clone + Sync + Send,
 {
-    type Future = BoxedIlpFuture;
-
     /// Send an OutgoingRequest to a peer that implements the ILP-Over-HTTP.
-    fn send_request(&mut self, request: OutgoingRequest<A>) -> Self::Future {
+    async fn send_request(&mut self, request: OutgoingRequest<A>) -> IlpResult {
         let ilp_address = self.store.get_ilp_address();
         let ilp_address_clone = ilp_address.clone();
+        let self_clone = self.clone();
         if let Some(url) = request.to.get_http_url() {
             trace!(
                 "Sending outgoing ILP over HTTP packet to account: {} (URL: {})",
@@ -68,51 +69,43 @@ where
                 .to
                 .get_http_auth_token()
                 .unwrap_or_else(|| SecretString::new("".to_owned()));
-            Box::new(
-                self.client
-                    .post(url.as_ref())
-                    .header(
-                        "authorization",
-                        &format!("Bearer {}", token.expose_secret()),
-                    )
-                    .body(BytesMut::from(request.prepare).freeze())
-                    .send()
-                    .map_err(move |err| {
-                        error!("Error sending HTTP request: {:?}", err);
-                        let code = if err.is_client_error() {
-                            ErrorCode::F00_BAD_REQUEST
-                        } else {
-                            ErrorCode::T01_PEER_UNREACHABLE
-                        };
-                        let message = if let Some(status) = err.status() {
-                            format!("Error sending ILP over HTTP request: {}", status)
-                        } else if let Some(err) = err.get_ref() {
-                            format!("Error sending ILP over HTTP request: {:?}", err)
-                        } else {
-                            "Error sending ILP over HTTP request".to_string()
-                        };
-                        RejectBuilder {
-                            code,
-                            message: message.as_str().as_bytes(),
-                            triggered_by: Some(&ilp_address),
-                            data: &[],
+            let header = format!("Bearer {}", token.expose_secret());
+            let body = request.prepare.as_ref().to_owned();
+            let resp = self_clone
+                .client
+                .post(url.as_ref())
+                .header("authorization", &header)
+                .body(body)
+                .send()
+                .map_err(move |err| {
+                    error!("Error sending HTTP request: {:?}", err);
+                    let mut code = ErrorCode::T01_PEER_UNREACHABLE;
+                    if let Some(status) = err.status() {
+                        if status.is_client_error() {
+                            code = ErrorCode::F00_BAD_REQUEST
                         }
-                        .build()
-                    })
-                    .and_then(move |resp| parse_packet_from_response(resp, ilp_address_clone)),
-            )
+                    };
+
+                    let message = format!("Error sending ILP over HTTP request: {}", err);
+                    RejectBuilder {
+                        code,
+                        message: message.as_bytes(),
+                        triggered_by: Some(&ilp_address),
+                        data: &[],
+                    }
+                    .build()
+                })
+                .await?;
+            parse_packet_from_response(resp, ilp_address_clone).await
         } else {
-            Box::new(self.next.send_request(request))
+            self.next.send_request(request).await
         }
     }
 }
 
-fn parse_packet_from_response(
-    response: HttpResponse,
-    ilp_address: Address,
-) -> impl Future<Item = Fulfill, Error = Reject> {
+async fn parse_packet_from_response(response: HttpResponse, ilp_address: Address) -> IlpResult {
     let ilp_address_clone = ilp_address.clone();
-    result(response.error_for_status().map_err(|err| {
+    let response = response.error_for_status().map_err(|err| {
         error!("HTTP error sending ILP over HTTP packet: {:?}", err);
         let code = if let Some(status) = err.status() {
             if status.is_client_error() {
@@ -131,34 +124,33 @@ fn parse_packet_from_response(
             data: &[],
         }
         .build()
-    }))
-    .and_then(move |response: HttpResponse| {
-        let ilp_address_clone = ilp_address.clone();
-        let decoder = response.into_body();
-        decoder.concat2().map_err(move |err| {
+    })?;
+
+    let ilp_address_clone = ilp_address.clone();
+    let body = response
+        .bytes()
+        .map_err(|err| {
             error!("Error getting HTTP response body: {:?}", err);
             RejectBuilder {
                 code: ErrorCode::T01_PEER_UNREACHABLE,
                 message: &[],
-                triggered_by: Some(&ilp_address_clone.clone()),
+                triggered_by: Some(&ilp_address_clone),
                 data: &[],
             }
             .build()
         })
-    })
-    .and_then(move |body: Chunk| {
-        // TODO can we get the body as a BytesMut so we don't need to copy?
-        let body = BytesMut::from(body.to_vec());
-        match Packet::try_from(body) {
-            Ok(Packet::Fulfill(fulfill)) => Ok(fulfill),
-            Ok(Packet::Reject(reject)) => Err(reject),
-            _ => Err(RejectBuilder {
-                code: ErrorCode::T01_PEER_UNREACHABLE,
-                message: &[],
-                triggered_by: Some(&ilp_address_clone.clone()),
-                data: &[],
-            }
-            .build()),
+        .await?;
+    // TODO can we get the body as a BytesMut so we don't need to copy?
+    let body = BytesMut::from(body.to_vec());
+    match Packet::try_from(body) {
+        Ok(Packet::Fulfill(fulfill)) => Ok(fulfill),
+        Ok(Packet::Reject(reject)) => Err(reject),
+        _ => Err(RejectBuilder {
+            code: ErrorCode::T01_PEER_UNREACHABLE,
+            message: &[],
+            triggered_by: Some(&ilp_address_clone),
+            data: &[],
         }
-    })
+        .build()),
+    }
 }

--- a/crates/interledger-http/src/client.rs
+++ b/crates/interledger-http/src/client.rs
@@ -104,7 +104,6 @@ where
 }
 
 async fn parse_packet_from_response(response: HttpResponse, ilp_address: Address) -> IlpResult {
-    let ilp_address_clone = ilp_address.clone();
     let response = response.error_for_status().map_err(|err| {
         error!("HTTP error sending ILP over HTTP packet: {:?}", err);
         let code = if let Some(status) = err.status() {

--- a/crates/interledger-http/src/error/mod.rs
+++ b/crates/interledger-http/src/error/mod.rs
@@ -322,7 +322,7 @@ pub async fn default_rejection_handler(err: warp::Rejection) -> Result<impl Repl
         Ok(api_error.clone().into_response())
     } else if let Some(json_error) = err.find::<JsonDeserializeError>() {
         Ok(json_error.clone().into_response())
-    } else if let Some(_) = err.find::<warp::reject::MethodNotAllowed>() {
+    } else if err.find::<warp::reject::MethodNotAllowed>().is_some() {
         Ok(ApiError::from_api_error_type(&DEFAULT_METHOD_NOT_ALLOWED_TYPE).into_response())
     } else {
         Err(err)

--- a/crates/interledger-http/src/error/mod.rs
+++ b/crates/interledger-http/src/error/mod.rs
@@ -12,7 +12,12 @@ use std::{
     error::Error as StdError,
     fmt::{self, Display},
 };
-use warp::{reject::custom, reply::json, reply::Response, Rejection, Reply};
+use warp::{
+    reject::{custom, Reject},
+    reply::json,
+    reply::Response,
+    Rejection, Reply,
+};
 
 /// API error type prefix of problems.
 /// This URL prefix is currently not published but we assume that in the future.
@@ -236,6 +241,8 @@ impl From<ApiError> for Rejection {
     }
 }
 
+impl Reject for ApiError {}
+
 lazy_static! {
     static ref MISSING_FIELD_REGEX: Regex = Regex::new("missing field `(.*)`").unwrap();
 }
@@ -248,6 +255,7 @@ pub struct JsonDeserializeError {
 }
 
 impl StdError for JsonDeserializeError {}
+impl Reject for JsonDeserializeError {}
 
 impl Display for JsonDeserializeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -310,11 +318,11 @@ impl From<JsonDeserializeError> for Rejection {
 
 // Receives `ApiError`s and `JsonDeserializeError` and return it in the RFC7807 format.
 pub fn default_rejection_handler(err: warp::Rejection) -> Result<Response, Rejection> {
-    if let Some(api_error) = err.find_cause::<ApiError>() {
+    if let Some(api_error) = err.find::<ApiError>() {
         Ok(api_error.clone().into_response())
-    } else if let Some(json_error) = err.find_cause::<JsonDeserializeError>() {
+    } else if let Some(json_error) = err.find::<JsonDeserializeError>() {
         Ok(json_error.clone().into_response())
-    } else if err.status() == http::status::StatusCode::METHOD_NOT_ALLOWED {
+    } else if let Some(_) = err.find::<warp::reject::MethodNotAllowed>() {
         Ok(ApiError::from_api_error_type(&DEFAULT_METHOD_NOT_ALLOWED_TYPE).into_response())
     } else {
         Err(err)

--- a/crates/interledger-http/src/error/mod.rs
+++ b/crates/interledger-http/src/error/mod.rs
@@ -317,7 +317,7 @@ impl From<JsonDeserializeError> for Rejection {
 }
 
 // Receives `ApiError`s and `JsonDeserializeError` and return it in the RFC7807 format.
-pub fn default_rejection_handler(err: warp::Rejection) -> Result<Response, Rejection> {
+pub async fn default_rejection_handler(err: warp::Rejection) -> Result<impl Reply, Rejection> {
     if let Some(api_error) = err.find::<ApiError>() {
         Ok(api_error.clone().into_response())
     } else if let Some(json_error) = err.find::<JsonDeserializeError>() {

--- a/crates/interledger-http/src/lib.rs
+++ b/crates/interledger-http/src/lib.rs
@@ -2,15 +2,10 @@
 //!
 //! Client and server implementations of the [ILP-Over-HTTP](https://github.com/interledger/rfcs/blob/master/0035-ilp-over-http/0035-ilp-over-http.md) bilateral communication protocol.
 //! This protocol is intended primarily for server-to-server communication between peers on the Interledger network.
-use bytes::Buf;
-use error::*;
-use futures::Future;
+use async_trait::async_trait;
 use interledger_service::{Account, Username};
-use mime::Mime;
 use secrecy::SecretString;
-use serde::de::DeserializeOwned;
 use url::Url;
-use warp::{self, filters::body::FullBody, Filter, Rejection};
 
 mod client;
 mod server;
@@ -28,124 +23,15 @@ pub trait HttpAccount: Account {
 
 /// The interface for Stores that can be used with the HttpServerService.
 // TODO do we need all of these constraints?
+#[async_trait]
 pub trait HttpStore: Clone + Send + Sync + 'static {
     type Account: HttpAccount;
 
     /// Load account details based on the full HTTP Authorization header
     /// received on the incoming HTTP request.
-    fn get_account_from_http_auth(
+    async fn get_account_from_http_auth(
         &self,
         username: &Username,
         token: &str,
-    ) -> Box<dyn Future<Item = Self::Account, Error = ()> + Send>;
-}
-
-pub fn deserialize_json<T: DeserializeOwned + Send>(
-) -> impl Filter<Extract = (T,), Error = Rejection> + Copy {
-    warp::header::<String>("content-type")
-        .and(warp::body::concat())
-        .and_then(|content_type: String, buf: FullBody| {
-            let mime_type: Mime = content_type.parse().map_err::<Rejection, _>(|_| {
-                error::ApiError::bad_request()
-                    .detail("Invalid content-type header.")
-                    .into()
-            })?;
-            if mime_type.type_() != mime::APPLICATION_JSON.type_() {
-                return Err(error::ApiError::bad_request()
-                    .detail("Invalid content-type.")
-                    .into());
-            } else if let Some(charset) = mime_type.get_param("charset") {
-                // Charset should be UTF-8
-                // https://tools.ietf.org/html/rfc8259#section-8.1
-                if charset != mime::UTF_8 {
-                    return Err(error::ApiError::bad_request()
-                        .detail("Charset should be UTF-8.")
-                        .into());
-                }
-            }
-
-            let deserializer = &mut serde_json::Deserializer::from_slice(&buf.bytes());
-            serde_path_to_error::deserialize(deserializer).map_err(|err| {
-                warp::reject::custom(JsonDeserializeError {
-                    category: err.inner().classify(),
-                    detail: err.inner().to_string(),
-                    path: err.path().clone(),
-                })
-            })
-        })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::deserialize_json;
-    use serde::Deserialize;
-    use warp::test::request;
-
-    #[derive(Deserialize, Clone)]
-    struct TestJsonStruct {
-        string_value: String,
-    }
-
-    #[test]
-    fn deserialize_json_header() {
-        let json_filter = deserialize_json::<TestJsonStruct>();
-        let body_correct = r#"{"string_value": "some string value"}"#;
-        let body_incorrect = r#"{"other_key": 0}"#;
-
-        // `content-type` should be provided.
-        assert_eq!(request().body(body_correct).matches(&json_filter), false);
-
-        // Should accept only "application/json" or "application/json; charset=utf-8"
-        assert_eq!(
-            request()
-                .body(body_correct)
-                .header("content-type", "text/plain")
-                .matches(&json_filter),
-            false
-        );
-        assert_eq!(
-            request()
-                .body(body_correct)
-                .header("content-type", "application/json")
-                .matches(&json_filter),
-            true
-        );
-        assert_eq!(
-            request()
-                .body(body_correct)
-                .header("content-type", "application/json; charset=ascii")
-                .matches(&json_filter),
-            false
-        );
-        assert_eq!(
-            request()
-                .body(body_correct)
-                .header("content-type", "application/json; charset=utf-8")
-                .matches(&json_filter),
-            true
-        );
-        assert_eq!(
-            request()
-                .body(body_correct)
-                .header("content-type", "application/json; charset=UTF-8")
-                .matches(&json_filter),
-            true
-        );
-
-        // Should accept only bodies that can be deserialized
-        assert_eq!(
-            request()
-                .body(body_incorrect)
-                .header("content-type", "application/json")
-                .matches(&json_filter),
-            false
-        );
-        assert_eq!(
-            request()
-                .body(body_incorrect)
-                .header("content-type", "application/json; charset=utf-8")
-                .matches(&json_filter),
-            false
-        );
-    }
+    ) -> Result<Self::Account, ()>;
 }

--- a/crates/interledger-http/src/server.rs
+++ b/crates/interledger-http/src/server.rs
@@ -110,8 +110,8 @@ where
             .and(warp::header::<SecretString>("authorization"))
             .and(warp::body::content_length_limit(MAX_PACKET_SIZE))
             .and(warp::body::bytes())
-            .and(with_store.clone())
-            .and(with_incoming.clone())
+            .and(with_store)
+            .and(with_incoming)
             .and_then(ilp_over_http)
     }
 

--- a/crates/interledger-ildcp/Cargo.toml
+++ b/crates/interledger-ildcp/Cargo.toml
@@ -10,8 +10,13 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 [dependencies]
 bytes = { version = "0.4.12", default-features = false }
 byteorder = { version = "1.3.2", default-features = false }
-futures = { version = "0.1.29", default-features = false }
+futures = { version = "0.3", default-features = false }
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 lazy_static = { version = "1.4.0", default-features = false }
 log = { version = "0.4.8", default-features = false }
+async-trait = "0.1.22"
+
+[dev-dependencies]
+tokio = { version = "0.2.6", features = ["macros","rt-core"]}
+uuid = { version = "0.8.1", features = ["v4"] }

--- a/crates/interledger-ildcp/src/client.rs
+++ b/crates/interledger-ildcp/src/client.rs
@@ -4,7 +4,7 @@ use interledger_service::*;
 use log::{debug, error};
 use std::convert::TryFrom;
 
-/// Get the ILP address and asset details for a given account.
+/// Sends an ILDCP Request and receives the ILP address and asset details for a given account.
 pub async fn get_ildcp_info<S, A>(service: &mut S, account: A) -> Result<IldcpResponse, ()>
 where
     S: IncomingService<A>,

--- a/crates/interledger-ildcp/src/client.rs
+++ b/crates/interledger-ildcp/src/client.rs
@@ -1,34 +1,30 @@
 use super::packet::*;
-use futures::Future;
+use futures::future::TryFutureExt;
 use interledger_service::*;
 use log::{debug, error};
 use std::convert::TryFrom;
 
 /// Get the ILP address and asset details for a given account.
-pub fn get_ildcp_info<S, A>(
-    service: &mut S,
-    account: A,
-) -> impl Future<Item = IldcpResponse, Error = ()>
+pub async fn get_ildcp_info<S, A>(service: &mut S, account: A) -> Result<IldcpResponse, ()>
 where
     S: IncomingService<A>,
     A: Account,
 {
     let prepare = IldcpRequest {}.to_prepare();
-    service
+    let fulfill = service
         .handle_request(IncomingRequest {
             from: account,
             prepare,
         })
         .map_err(|err| error!("Error getting ILDCP info: {:?}", err))
-        .and_then(|fulfill| {
-            let response =
-                IldcpResponse::try_from(fulfill.into_data().freeze()).map_err(|err| {
-                    error!(
-                        "Unable to parse ILDCP response from fulfill packet: {:?}",
-                        err
-                    );
-                })?;
-            debug!("Got ILDCP response: {:?}", response);
-            Ok(response)
-        })
+        .await?;
+
+    let response = IldcpResponse::try_from(fulfill.into_data().freeze()).map_err(|err| {
+        error!(
+            "Unable to parse ILDCP response from fulfill packet: {:?}",
+            err
+        );
+    })?;
+    debug!("Got ILDCP response: {:?}", response);
+    Ok(response)
 }

--- a/crates/interledger-ildcp/src/server.rs
+++ b/crates/interledger-ildcp/src/server.rs
@@ -1,6 +1,6 @@
 use super::packet::*;
 use super::Account;
-use futures::future::ok;
+use async_trait::async_trait;
 use interledger_packet::*;
 use interledger_service::*;
 use log::debug;
@@ -27,14 +27,13 @@ where
     }
 }
 
+#[async_trait]
 impl<I, A> IncomingService<A> for IldcpService<I, A>
 where
-    I: IncomingService<A>,
+    I: IncomingService<A> + Send,
     A: Account,
 {
-    type Future = BoxedIlpFuture;
-
-    fn handle_request(&mut self, request: IncomingRequest<A>) -> Self::Future {
+    async fn handle_request(&mut self, request: IncomingRequest<A>) -> IlpResult {
         if is_ildcp_request(&request.prepare) {
             let from = request.from.ilp_address();
             let builder = IldcpResponseBuilder {
@@ -44,10 +43,72 @@ where
             };
             debug!("Responding to query for ildcp info by account: {:?}", from);
             let response = builder.build();
-            let fulfill = Fulfill::from(response);
-            Box::new(ok(fulfill))
+            Ok(Fulfill::from(response))
         } else {
-            Box::new(self.next.handle_request(request))
+            self.next.handle_request(request).await
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::get_ildcp_info;
+    use lazy_static::lazy_static;
+    use std::str::FromStr;
+    use uuid::Uuid;
+
+    lazy_static! {
+        pub static ref ALICE: Username = Username::from_str("alice").unwrap();
+        pub static ref EXAMPLE_ADDRESS: Address = Address::from_str("example.alice").unwrap();
+    }
+
+    #[derive(Clone, Debug, Copy)]
+    struct TestAccount;
+
+    impl Account for TestAccount {
+        fn id(&self) -> Uuid {
+            Uuid::new_v4()
+        }
+
+        fn username(&self) -> &Username {
+            &ALICE
+        }
+
+        fn asset_scale(&self) -> u8 {
+            9
+        }
+
+        fn asset_code(&self) -> &str {
+            "XYZ"
+        }
+
+        fn ilp_address(&self) -> &Address {
+            &EXAMPLE_ADDRESS
+        }
+    }
+
+    #[tokio::test]
+    async fn handles_request() {
+        let from = TestAccount;
+        let prepare = IldcpRequest {}.to_prepare();
+        let req = IncomingRequest { from, prepare };
+        let mut service = IldcpService::new(incoming_service_fn(|_| {
+            Err(RejectBuilder {
+                code: ErrorCode::F02_UNREACHABLE,
+                message: b"No other incoming handler!",
+                data: &[],
+                triggered_by: None,
+            }
+            .build())
+        }));
+
+        let result = service.handle_request(req).await.unwrap();
+        assert_eq!(result.data().len(), 19);
+
+        let ildpc_info = get_ildcp_info(&mut service, from).await.unwrap();
+        assert_eq!(ildpc_info.ilp_address(), EXAMPLE_ADDRESS.clone());
+        assert_eq!(ildpc_info.asset_code(), b"XYZ");
+        assert_eq!(ildpc_info.asset_scale(), 9);
     }
 }

--- a/crates/interledger-packet/Cargo.toml
+++ b/crates/interledger-packet/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 
 [dependencies]
 byteorder = { version = "1.3.2", default-features = false }
+bytes05 = { package = "bytes", version = "0.5", default-features = false, features = ["serde"] }
 bytes = { version = "0.4.12", default-features = false, features = ["serde"] }
 chrono = { version = "0.4.9", default-features = false }
 hex = { version = "0.4.0", default-features = false }

--- a/crates/interledger-packet/src/errors.rs
+++ b/crates/interledger-packet/src/errors.rs
@@ -41,7 +41,7 @@ quick_error! {
             description(descr)
             display("Invalid Packet {}", descr)
         }
-        Other(err: Box<dyn std::error::Error>) {
+        Other(err: Box<dyn std::error::Error + Send>) {
             cause(&**err)
             description(err.description())
             display("Error {}", err.description())

--- a/crates/interledger-packet/src/packet.rs
+++ b/crates/interledger-packet/src/packet.rs
@@ -359,6 +359,15 @@ impl From<Fulfill> for BytesMut {
     }
 }
 
+impl From<Fulfill> for bytes05::BytesMut {
+    fn from(fulfill: Fulfill) -> Self {
+        // bytes 0.4
+        let b = fulfill.buffer.as_ref();
+        // convert to Bytes05
+        bytes05::BytesMut::from(b)
+    }
+}
+
 impl fmt::Debug for Fulfill {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter
@@ -478,6 +487,15 @@ impl AsRef<[u8]> for Reject {
 impl From<Reject> for BytesMut {
     fn from(reject: Reject) -> Self {
         reject.buffer
+    }
+}
+
+impl From<Reject> for bytes05::BytesMut {
+    fn from(reject: Reject) -> Self {
+        // bytes 0.4
+        let b = reject.buffer.as_ref();
+        // convert to Bytes05
+        bytes05::BytesMut::from(b)
     }
 }
 

--- a/crates/interledger-router/Cargo.toml
+++ b/crates/interledger-router/Cargo.toml
@@ -14,6 +14,8 @@ interledger-service = { path = "../interledger-service", version = "^0.4.0", def
 log = { version = "0.4.8", default-features = false }
 parking_lot = { version = "0.9.0", default-features = false }
 uuid = { version = "0.8.1", default-features = false, features = ["v4"]}
+async-trait = "0.1.22"
 
 [dev-dependencies]
 lazy_static = { version = "1.4.0", default-features = false }
+tokio = { version = "0.2.6", features = ["rt-core", "macros"]}

--- a/crates/interledger-router/src/router.rs
+++ b/crates/interledger-router/src/router.rs
@@ -1,5 +1,5 @@
 use super::RouterStore;
-use futures::{future::err, Future};
+use async_trait::async_trait;
 use interledger_packet::{ErrorCode, RejectBuilder};
 use interledger_service::*;
 use log::{error, trace};
@@ -38,19 +38,18 @@ where
     }
 }
 
+#[async_trait]
 impl<S, O> IncomingService<S::Account> for Router<S, O>
 where
     S: AddressStore + RouterStore,
     O: OutgoingService<S::Account> + Clone + Send + 'static,
 {
-    type Future = BoxedIlpFuture;
-
     /// Figures out the next node to pass the received Prepare packet to.
     ///
     /// Firstly, it checks if there is a direct path for that account and uses that.
     /// If not it scans through the routing table and checks if the route prefix matches
     /// the prepare packet's destination or if it's a catch-all address (i.e. empty prefix)
-    fn handle_request(&mut self, request: IncomingRequest<S::Account>) -> Self::Future {
+    async fn handle_request(&mut self, request: IncomingRequest<S::Account>) -> IlpResult {
         let destination = request.prepare.destination();
         let mut next_hop = None;
         let routing_table = self.store.routing_table();
@@ -92,24 +91,22 @@ where
 
         if let Some(account_id) = next_hop {
             let mut next = self.next.clone();
-            Box::new(
-                self.store
-                    .get_accounts(vec![account_id])
-                    .map_err(move |_| {
-                        error!("No record found for account: {}", account_id);
-                        RejectBuilder {
-                            code: ErrorCode::F02_UNREACHABLE,
-                            message: &[],
-                            triggered_by: Some(&ilp_address),
-                            data: &[],
-                        }
-                        .build()
-                    })
-                    .and_then(move |mut accounts| {
-                        let request = request.into_outgoing(accounts.remove(0));
-                        next.send_request(request)
-                    }),
-            )
+            match self.store.get_accounts(vec![account_id]).await {
+                Ok(mut accounts) => {
+                    let request = request.into_outgoing(accounts.remove(0));
+                    next.send_request(request).await
+                }
+                Err(_) => {
+                    error!("No record found for account: {}", account_id);
+                    Err(RejectBuilder {
+                        code: ErrorCode::F02_UNREACHABLE,
+                        message: &[],
+                        triggered_by: Some(&ilp_address),
+                        data: &[],
+                    }
+                    .build())
+                }
+            }
         } else {
             error!(
                 "No route found for request {}: {:?}",
@@ -129,13 +126,13 @@ where
                 },
                 request
             );
-            Box::new(err(RejectBuilder {
+            Err(RejectBuilder {
                 code: ErrorCode::F02_UNREACHABLE,
                 message: &[],
                 triggered_by: Some(&ilp_address),
                 data: &[],
             }
-            .build()))
+            .build())
         }
     }
 }
@@ -190,36 +187,29 @@ mod tests {
         routes: HashMap<String, Uuid>,
     }
 
+    #[async_trait]
     impl AccountStore for TestStore {
         type Account = TestAccount;
 
-        fn get_accounts(
-            &self,
-            account_ids: Vec<Uuid>,
-        ) -> Box<dyn Future<Item = Vec<TestAccount>, Error = ()> + Send> {
-            Box::new(ok(account_ids.into_iter().map(TestAccount).collect()))
+        async fn get_accounts(&self, account_ids: Vec<Uuid>) -> Result<Vec<TestAccount>, ()> {
+            Ok(account_ids.into_iter().map(TestAccount).collect())
         }
 
         // stub implementation (not used in these tests)
-        fn get_account_id_from_username(
-            &self,
-            _username: &Username,
-        ) -> Box<dyn Future<Item = Uuid, Error = ()> + Send> {
-            Box::new(ok(Uuid::new_v4()))
+        async fn get_account_id_from_username(&self, _username: &Username) -> Result<Uuid, ()> {
+            Ok(Uuid::new_v4())
         }
     }
 
+    #[async_trait]
     impl AddressStore for TestStore {
         /// Saves the ILP Address in the store's memory and database
-        fn set_ilp_address(
-            &self,
-            _ilp_address: Address,
-        ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
-            unimplemented!()
+        async fn set_ilp_address(&self, _ilp_address: Address) -> Result<(), ()> {
+            Ok(())
         }
 
-        fn clear_ilp_address(&self) -> Box<dyn Future<Item = (), Error = ()> + Send> {
-            unimplemented!()
+        async fn clear_ilp_address(&self) -> Result<(), ()> {
+            Ok(())
         }
 
         /// Get's the store's ilp address from memory
@@ -234,8 +224,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn empty_routing_table() {
+    #[tokio::test]
+    async fn empty_routing_table() {
         let mut router = Router::new(
             TestStore {
                 routes: HashMap::new(),
@@ -261,12 +251,12 @@ mod tests {
                 }
                 .build(),
             })
-            .wait();
+            .await;
         assert!(result.is_err());
     }
 
-    #[test]
-    fn no_route() {
+    #[tokio::test]
+    async fn no_route() {
         let mut router = Router::new(
             TestStore {
                 routes: HashMap::from_iter(
@@ -294,12 +284,12 @@ mod tests {
                 }
                 .build(),
             })
-            .wait();
+            .await;
         assert!(result.is_err());
     }
 
-    #[test]
-    fn finds_exact_route() {
+    #[tokio::test]
+    async fn finds_exact_route() {
         let mut router = Router::new(
             TestStore {
                 routes: HashMap::from_iter(
@@ -327,12 +317,12 @@ mod tests {
                 }
                 .build(),
             })
-            .wait();
+            .await;
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn catch_all_route() {
+    #[tokio::test]
+    async fn catch_all_route() {
         let mut router = Router::new(
             TestStore {
                 routes: HashMap::from_iter(vec![(String::new(), Uuid::new_v4())].into_iter()),
@@ -358,12 +348,12 @@ mod tests {
                 }
                 .build(),
             })
-            .wait();
+            .await;
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn finds_matching_prefix() {
+    #[tokio::test]
+    async fn finds_matching_prefix() {
         let mut router = Router::new(
             TestStore {
                 routes: HashMap::from_iter(
@@ -391,12 +381,12 @@ mod tests {
                 }
                 .build(),
             })
-            .wait();
+            .await;
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn finds_longest_matching_prefix() {
+    #[tokio::test]
+    async fn finds_longest_matching_prefix() {
         let id0 = Uuid::from_slice(&[0; 16]).unwrap();
         let id1 = Uuid::from_slice(&[1; 16]).unwrap();
         let id2 = Uuid::from_slice(&[2; 16]).unwrap();
@@ -436,7 +426,7 @@ mod tests {
                 }
                 .build(),
             })
-            .wait();
+            .await;
         assert!(result.is_ok());
         assert_eq!(to.lock().take().unwrap().0, id2);
     }

--- a/crates/interledger-service-util/Cargo.toml
+++ b/crates/interledger-service-util/Cargo.toml
@@ -11,19 +11,19 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 bytes = { version = "0.4.12", default-features = false }
 byteorder = { version = "1.3.2", default-features = false }
 chrono = { version = "0.4.9", default-features = false, features = ["clock"] }
-futures = { version = "0.1.29", default-features = false }
+futures = { version = "0.3.1", default-features = false }
 hex = { version = "0.4.0", default-features = false }
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 interledger-settlement = { path = "../interledger-settlement", version = "^0.3.0", default-features = false, features = ["settlement_api"] }
 lazy_static = { version = "1.4.0", default-features = false }
 log = { version = "0.4.8", default-features = false }
-reqwest = { version = "0.9.22", default-features = false, features = ["default-tls"] }
+reqwest = { version = "0.10.0", default-features = false, features = ["default-tls"] }
 ring = { version = "0.16.9", default-features = false }
 secrecy = { version = "0.5.1", default-features = false, features = ["alloc", "serde"] }
 serde = { version = "1.0.101", default-features = false, features = ["derive"]}
-tokio = { version = "0.1.22", default-features = false }
-tokio-executor = { version = "0.1.8", default-features = false }
+tokio = { version = "0.2.6", default-features = false, features = ["macros", "time"] }
+async-trait = "0.1.22"
 
 [dev-dependencies]
 uuid = { version = "0.8.1", default-features = false}

--- a/crates/interledger-service-util/src/balance_service.rs
+++ b/crates/interledger-service-util/src/balance_service.rs
@@ -1,5 +1,6 @@
-use futures::Future;
-use interledger_packet::{ErrorCode, Fulfill, Reject, RejectBuilder};
+use async_trait::async_trait;
+use futures::TryFutureExt;
+use interledger_packet::{ErrorCode, RejectBuilder};
 use interledger_service::*;
 use interledger_settlement::{
     api::SettlementClient,
@@ -7,32 +8,31 @@ use interledger_settlement::{
 };
 use log::{debug, error};
 use std::marker::PhantomData;
-use tokio_executor::spawn;
 
+#[async_trait]
 pub trait BalanceStore: AccountStore {
     /// Fetch the current balance for the given account.
-    fn get_balance(&self, account: Self::Account)
-        -> Box<dyn Future<Item = i64, Error = ()> + Send>;
+    async fn get_balance(&self, account: Self::Account) -> Result<i64, ()>;
 
-    fn update_balances_for_prepare(
+    async fn update_balances_for_prepare(
         &self,
         from_account: Self::Account,
         incoming_amount: u64,
-    ) -> Box<dyn Future<Item = (), Error = ()> + Send>;
+    ) -> Result<(), ()>;
 
     /// Increases the account's balance, and returns the updated balance
     /// along with the amount which should be settled
-    fn update_balances_for_fulfill(
+    async fn update_balances_for_fulfill(
         &self,
         to_account: Self::Account,
         outgoing_amount: u64,
-    ) -> Box<dyn Future<Item = (i64, u64), Error = ()> + Send>;
+    ) -> Result<(i64, u64), ()>;
 
-    fn update_balances_for_reject(
+    async fn update_balances_for_reject(
         &self,
         from_account: Self::Account,
         incoming_amount: u64,
-    ) -> Box<dyn Future<Item = (), Error = ()> + Send>;
+    ) -> Result<(), ()>;
 }
 
 /// # Balance Service
@@ -64,6 +64,7 @@ where
     }
 }
 
+#[async_trait]
 impl<S, O, A> OutgoingService<A> for BalanceService<S, O, A>
 where
     S: AddressStore
@@ -74,10 +75,8 @@ where
         + Sync
         + 'static,
     O: OutgoingService<A> + Send + Clone + 'static,
-    A: SettlementAccount + 'static,
+    A: SettlementAccount + Send + Sync + 'static,
 {
-    type Future = BoxedIlpFuture;
-
     /// On send message:
     /// 1. Calls `store.update_balances_for_prepare` with the prepare.
     /// If it fails, it replies with a reject
@@ -86,21 +85,17 @@ where
     ///       INDEPENDENTLY of if the call suceeds or fails. This makes a `sendMoney` call if the fulfill puts the account's balance over the `settle_threshold`
     ///     - if it returns an reject calls `store.update_balances_for_reject` and replies with the fulfill
     ///       INDEPENDENTLY of if the call suceeds or fails
-    fn send_request(
-        &mut self,
-        request: OutgoingRequest<A>,
-    ) -> Box<dyn Future<Item = Fulfill, Error = Reject> + Send> {
+    async fn send_request(&mut self, request: OutgoingRequest<A>) -> IlpResult {
         // Don't bother touching the store for zero-amount packets.
         // Note that it is possible for the original_amount to be >0 while the
         // prepare.amount is 0, because the original amount could be rounded down
         // to 0 when exchange rate and scale change are applied.
         if request.prepare.amount() == 0 && request.original_amount == 0 {
-            return Box::new(self.next.send_request(request));
+            return self.next.send_request(request).await;
         }
 
         let mut next = self.next.clone();
         let store = self.store.clone();
-        let store_clone = store.clone();
         let from = request.from.clone();
         let from_clone = from.clone();
         let from_id = from.id();
@@ -123,79 +118,92 @@ where
         //  _eventually_ be completed. Because of this settlement_engine guarantee, the Connector can
         // operate as-if the settlement engine has completed. Finally, if the request to the settlement-engine
         // fails, this amount will be re-added back to balance.
-        Box::new(
-            self.store
-                .update_balances_for_prepare(
-                    from.clone(),
-                    incoming_amount,
-                )
-                .map_err(move |_| {
-                    debug!("Rejecting packet because it would exceed a balance limit");
-                    RejectBuilder {
-                        code: ErrorCode::T04_INSUFFICIENT_LIQUIDITY,
-                        message: &[],
-                        triggered_by: Some(&ilp_address),
-                        data: &[],
+        self.store
+            .update_balances_for_prepare(from.clone(), incoming_amount)
+            .map_err(move |_| {
+                debug!("Rejecting packet because it would exceed a balance limit");
+                RejectBuilder {
+                    code: ErrorCode::T04_INSUFFICIENT_LIQUIDITY,
+                    message: &[],
+                    triggered_by: Some(&ilp_address),
+                    data: &[],
+                }
+                .build()
+            })
+            .await?;
+
+        match next.send_request(request).await {
+            Ok(fulfill) => {
+                // We will spawn a task to update the balances in the database
+                // so that we DO NOT wait for the database before sending the
+                // Fulfill packet back to our peer. Due to how the flow of ILP
+                // packets work, once we get the Fulfill back from the next node
+                // we need to propagate it backwards ASAP. If we do not give the
+                // previous node the fulfillment in time, they won't pay us back
+                // for the packet we forwarded. Note this means that we will
+                // relay the fulfillment _even if saving to the DB fails._
+                tokio::spawn(async move {
+                    let (balance, amount_to_settle) = match store
+                        .update_balances_for_fulfill(to.clone(), outgoing_amount)
+                        .await
+                    {
+                        Ok(r) => r,
+                        Err(_) => {
+                            error!("Error applying balance changes for fulfill from account: {} to account: {}. Incoming amount was: {}, outgoing amount was: {}", from_id, to_id, incoming_amount, outgoing_amount);
+                            return Err(());
+                        }
+                    };
+                    debug!(
+                        "Account balance after fulfill: {}. Amount that needs to be settled: {}",
+                        balance, amount_to_settle
+                    );
+                    if amount_to_settle > 0 && to_has_engine {
+                        // Note that if this program crashes after changing the balance (in the PROCESS_FULFILL script)
+                        // and the send_settlement fails but the program isn't alive to hear that, the balance will be incorrect.
+                        // No other instance will know that it was trying to send an outgoing settlement. We could
+                        // make this more robust by saving something to the DB about the outgoing settlement when we change the balance
+                        // but then we would also need to prevent a situation where every connector instance is polling the
+                        // settlement engine for the status of each
+                        // outgoing settlement and putting unnecessary
+                        // load on the settlement engine.
+                        tokio::spawn(async move {
+                            if settlement_client
+                                .send_settlement(to, amount_to_settle)
+                                .await
+                                .is_err()
+                            {
+                                store.refund_settlement(to_id, amount_to_settle).await?;
+                            }
+                            Ok::<(), ()>(())
+                        });
                     }
-                    .build()
-                })
-                .and_then(move |_| {
-                    next.send_request(request)
-                        .and_then(move |fulfill| {
-                            // We will spawn a task to update the balances in the database
-                            // so that we DO NOT wait for the database before sending the
-                            // Fulfill packet back to our peer. Due to how the flow of ILP
-                            // packets work, once we get the Fulfill back from the next node
-                            // we need to propagate it backwards ASAP. If we do not give the
-                            // previous node the fulfillment in time, they won't pay us back
-                            // for the packet we forwarded. Note this means that we will
-                            // relay the fulfillment _even if saving to the DB fails._
-                            let fulfill_balance_update = store.update_balances_for_fulfill(
-                                to.clone(),
-                                outgoing_amount,
-                            )
-                            .map_err(move |_| error!("Error applying balance changes for fulfill from account: {} to account: {}. Incoming amount was: {}, outgoing amount was: {}", from_id, to_id, incoming_amount, outgoing_amount))
-                            .and_then(move |(balance, amount_to_settle)| {
-                                debug!("Account balance after fulfill: {}. Amount that needs to be settled: {}", balance, amount_to_settle);
-                                if amount_to_settle > 0 && to_has_engine {
-                                    // Note that if this program crashes after changing the balance (in the PROCESS_FULFILL script)
-                                    // and the send_settlement fails but the program isn't alive to hear that, the balance will be incorrect.
-                                    // No other instance will know that it was trying to send an outgoing settlement. We could
-                                    // make this more robust by saving something to the DB about the outgoing settlement when we change the balance
-                                    // but then we would also need to prevent a situation where every connector instance is polling the
-                                    // settlement engine for the status of each
-                                    // outgoing settlement and putting unnecessary
-                                    // load on the settlement engine.
-                                    spawn(settlement_client
-                                        .send_settlement(to, amount_to_settle)
-                                        .or_else(move |_| store.refund_settlement(to_id, amount_to_settle)));
-                                }
-                                Ok(())
-                            });
+                    Ok(())
+                });
 
-                            spawn(fulfill_balance_update);
+                Ok(fulfill)
+            }
+            Err(reject) => {
+                // Similar to the logic for handling the Fulfill packet above, we
+                // spawn a task to update the balance for the Reject in parallel
+                // rather than waiting for the database to update before relaying
+                // the packet back. In this case, the only substantive difference
+                // would come from if the DB operation fails or takes too long.
+                // The packet is already rejected so it's more useful for the sender
+                // to get the error message from the original Reject packet rather
+                // than a less specific one saying that this node had an "internal
+                // error" caused by a database issue.
+                tokio::spawn({
+                    let store_clone = self.store.clone();
+                    async move {
+                        store_clone.update_balances_for_reject(
+                            from_clone.clone(),
+                            incoming_amount,
+                        ).map_err(move |_| error!("Error rolling back balance change for accounts: {} and {}. Incoming amount was: {}, outgoing amount was: {}", from_clone.id(), to_clone.id(), incoming_amount, outgoing_amount)).await
+                    }
+                });
 
-                            Ok(fulfill)
-                        })
-                        .or_else(move |reject| {
-                            // Similar to the logic for handling the Fulfill packet above, we
-                            // spawn a task to update the balance for the Reject in parallel
-                            // rather than waiting for the database to update before relaying
-                            // the packet back. In this case, the only substantive difference
-                            // would come from if the DB operation fails or takes too long.
-                            // The packet is already rejected so it's more useful for the sender
-                            // to get the error message from the original Reject packet rather
-                            // than a less specific one saying that this node had an "internal
-                            // error" caused by a database issue.
-                            let reject_balance_update = store_clone.update_balances_for_reject(
-                                from_clone.clone(),
-                                incoming_amount,
-                            ).map_err(move |_| error!("Error rolling back balance change for accounts: {} and {}. Incoming amount was: {}, outgoing amount was: {}", from_clone.id(), to_clone.id(), incoming_amount, outgoing_amount));
-                            spawn(reject_balance_update);
-
-                            Err(reject)
-                        })
-                }),
-        )
+                Err(reject)
+            }
+        }
     }
 }

--- a/crates/interledger-service-util/src/echo_service.rs
+++ b/crates/interledger-service-util/src/echo_service.rs
@@ -1,7 +1,7 @@
+use async_trait::async_trait;
 use byteorder::ReadBytesExt;
 use bytes::{BufMut, BytesMut};
 use core::borrow::Borrow;
-use futures::future::err;
 use interledger_packet::{
     oer::BufOerExt, Address, ErrorCode, Prepare, PrepareBuilder, RejectBuilder,
 };
@@ -49,20 +49,19 @@ where
     }
 }
 
+#[async_trait]
 impl<I, S, A> IncomingService<A> for EchoService<I, S, A>
 where
-    I: IncomingService<A>,
-    S: AddressStore,
-    A: Account,
+    I: IncomingService<A> + Send,
+    S: AddressStore + Send,
+    A: Account + Send,
 {
-    type Future = BoxedIlpFuture;
-
-    fn handle_request(&mut self, mut request: IncomingRequest<A>) -> Self::Future {
+    async fn handle_request(&mut self, mut request: IncomingRequest<A>) -> IlpResult {
         let ilp_address = self.store.get_ilp_address();
         let should_echo = request.prepare.destination() == ilp_address
             && request.prepare.data().starts_with(ECHO_PREFIX.as_bytes());
         if !should_echo {
-            return Box::new(self.next.handle_request(request));
+            return self.next.handle_request(request).await;
         }
         debug!("Responding to Echo protocol request: {:?}", request);
 
@@ -78,23 +77,23 @@ where
             Ok(value) => value,
             Err(error) => {
                 eprintln!("Could not read packet type: {:?}", error);
-                return Box::new(err(RejectBuilder {
+                return Err(RejectBuilder {
                     code: ErrorCode::F01_INVALID_PACKET,
                     message: b"Could not read echo packet type.",
                     triggered_by: Some(&ilp_address),
                     data: &[],
                 }
-                .build()));
+                .build());
             }
         };
         if echo_packet_type == EchoPacketType::Response as u8 {
             // if the echo packet type is Response, just pass it to the next service
             // so that the initiator could handle this packet
-            return Box::new(self.next.handle_request(request));
+            return self.next.handle_request(request).await;
         }
         if echo_packet_type != EchoPacketType::Request as u8 {
             eprintln!("The packet type is not acceptable: {}", echo_packet_type);
-            return Box::new(err(RejectBuilder {
+            return Err(RejectBuilder {
                 code: ErrorCode::F01_INVALID_PACKET,
                 message: format!(
                     "The echo packet type: {} is not acceptable.",
@@ -104,7 +103,7 @@ where
                 triggered_by: Some(&ilp_address),
                 data: &[],
             }
-            .build()));
+            .build());
         }
 
         // check source address
@@ -116,24 +115,24 @@ where
                         "Could not parse source address from echo packet: {:?}",
                         error
                     );
-                    return Box::new(err(RejectBuilder {
+                    return Err(RejectBuilder {
                         code: ErrorCode::F01_INVALID_PACKET,
                         message: b"Could not parse source address from Echo packet",
                         triggered_by: Some(&ilp_address),
                         data: &[],
                     }
-                    .build()));
+                    .build());
                 }
             },
             Err(error) => {
                 eprintln!("Could not read source address: {:?}", error);
-                return Box::new(err(RejectBuilder {
+                return Err(RejectBuilder {
                     code: ErrorCode::F01_INVALID_PACKET,
                     message: b"Could not read source address.",
                     triggered_by: Some(&ilp_address),
                     data: &[],
                 }
-                .build()));
+                .build());
             }
         };
 
@@ -150,7 +149,7 @@ where
         }
         .build();
 
-        Box::new(self.next.handle_request(request))
+        self.next.handle_request(request).await
     }
 }
 
@@ -214,7 +213,6 @@ impl<'a> EchoResponseBuilder<'a> {
 #[cfg(test)]
 mod echo_tests {
     use super::*;
-    use futures::future::Future;
     use interledger_packet::{FulfillBuilder, PrepareBuilder};
     use interledger_service::incoming_service_fn;
     use lazy_static::lazy_static;
@@ -232,16 +230,14 @@ mod echo_tests {
     #[derive(Clone)]
     struct TestStore(Address);
 
+    #[async_trait]
     impl AddressStore for TestStore {
         /// Saves the ILP Address in the store's memory and database
-        fn set_ilp_address(
-            &self,
-            _ilp_address: Address,
-        ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        async fn set_ilp_address(&self, _ilp_address: Address) -> Result<(), ()> {
             unimplemented!()
         }
 
-        fn clear_ilp_address(&self) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        async fn clear_ilp_address(&self) -> Result<(), ()> {
             unimplemented!()
         }
 
@@ -279,8 +275,8 @@ mod echo_tests {
 
     /// If the destination of the packet is not destined to the node's address,
     /// the node should not echo the packet.
-    #[test]
-    fn test_echo_packet_not_destined() {
+    #[tokio::test]
+    async fn test_echo_packet_not_destined() {
         let amount = 1;
         let expires_at = SystemTime::now() + Duration::from_secs(30);
         let fulfillment = &get_random_fulfillment();
@@ -319,14 +315,14 @@ mod echo_tests {
         // test
         let result = echo_service
             .handle_request(IncomingRequest { prepare, from })
-            .wait();
+            .await;
         assert!(result.is_ok());
     }
 
     /// Even if the destination of the packet is the node's address,
     /// packets that don't have a correct echo prefix will not be handled as echo packets.
-    #[test]
-    fn test_echo_packet_without_echo_prefix() {
+    #[tokio::test]
+    async fn test_echo_packet_without_echo_prefix() {
         let amount = 1;
         let expires_at = SystemTime::now() + Duration::from_secs(30);
         let fulfillment = &get_random_fulfillment();
@@ -365,14 +361,14 @@ mod echo_tests {
         // test
         let result = echo_service
             .handle_request(IncomingRequest { prepare, from })
-            .wait();
+            .await;
         assert!(result.is_ok());
     }
 
     /// If the destination of the packet is the node's address and the echo packet type is
     /// request, the service will echo the packet modifying destination to the `source_address`.
-    #[test]
-    fn test_echo_packet() {
+    #[tokio::test]
+    async fn test_echo_packet() {
         let amount = 1;
         let expires_at = SystemTime::now() + Duration::from_secs(30);
         let fulfillment = &get_random_fulfillment();
@@ -411,13 +407,13 @@ mod echo_tests {
         // test
         let result = echo_service
             .handle_request(IncomingRequest { prepare, from })
-            .wait();
+            .await;
         assert!(result.is_ok());
     }
 
     /// If echo packet type is neither `1` nor `2`, the packet is considered to be malformed.
-    #[test]
-    fn test_invalid_echo_packet_type() {
+    #[tokio::test]
+    async fn test_invalid_echo_packet_type() {
         let amount = 1;
         let expires_at = SystemTime::now() + Duration::from_secs(30);
         let fulfillment = &get_random_fulfillment();
@@ -452,14 +448,14 @@ mod echo_tests {
         // test
         let result = echo_service
             .handle_request(IncomingRequest { prepare, from })
-            .wait();
+            .await;
         assert!(result.is_err());
     }
 
     /// Even if the destination of the packet is the node's address and the data starts with
     /// echo prefix correctly, `source_address` may be broken. This is the case.
-    #[test]
-    fn test_invalid_source_address() {
+    #[tokio::test]
+    async fn test_invalid_source_address() {
         let amount = 1;
         let expires_at = SystemTime::now() + Duration::from_secs(30);
         let fulfillment = &get_random_fulfillment();
@@ -494,7 +490,7 @@ mod echo_tests {
         // test
         let result = echo_service
             .handle_request(IncomingRequest { prepare, from })
-            .wait();
+            .await;
         assert!(result.is_err());
     }
 

--- a/crates/interledger-service-util/src/exchange_rate_providers/coincap.rs
+++ b/crates/interledger-service-util/src/exchange_rate_providers/coincap.rs
@@ -1,7 +1,7 @@
-use futures::Future;
+use futures::TryFutureExt;
 use lazy_static::lazy_static;
 use log::{error, warn};
-use reqwest::{r#async::Client, Url};
+use reqwest::{Client, Url};
 use serde::Deserialize;
 use std::{collections::HashMap, str::FromStr};
 
@@ -25,50 +25,50 @@ struct RateResponse {
     data: Vec<Rate>,
 }
 
-pub fn query_coincap(client: &Client) -> impl Future<Item = HashMap<String, f64>, Error = ()> {
-    query_coincap_endpoint(client, COINCAP_ASSETS_URL.clone())
-        .join(query_coincap_endpoint(client, COINCAP_RATES_URL.clone()))
-        .and_then(|(assets, rates)| {
-            let all_rates: HashMap<String, f64> = assets
-                .data
-                .into_iter()
-                .chain(rates.data.into_iter())
-                .filter_map(|record| match f64::from_str(record.rate_usd.as_str()) {
-                    Ok(rate) => Some((record.symbol.to_uppercase(), rate)),
-                    Err(err) => {
-                        warn!(
-                            "Unable to parse {} rate as an f64: {} {:?}",
-                            record.symbol, record.rate_usd, err
-                        );
-                        None
-                    }
-                })
-                .collect();
-            Ok(all_rates)
+pub async fn query_coincap(client: &Client) -> Result<HashMap<String, f64>, ()> {
+    let (assets, rates) = futures::future::join(
+        query_coincap_endpoint(client, COINCAP_ASSETS_URL.clone()),
+        query_coincap_endpoint(client, COINCAP_RATES_URL.clone()),
+    )
+    .await;
+
+    let all_rates: HashMap<String, f64> = assets?
+        .data
+        .into_iter()
+        .chain(rates?.data.into_iter())
+        .filter_map(|record| match f64::from_str(record.rate_usd.as_str()) {
+            Ok(rate) => Some((record.symbol.to_uppercase(), rate)),
+            Err(err) => {
+                warn!(
+                    "Unable to parse {} rate as an f64: {} {:?}",
+                    record.symbol, record.rate_usd, err
+                );
+                None
+            }
         })
+        .collect();
+    Ok(all_rates)
 }
 
-fn query_coincap_endpoint(
-    client: &Client,
-    url: Url,
-) -> impl Future<Item = RateResponse, Error = ()> {
-    client
+async fn query_coincap_endpoint(client: &Client, url: Url) -> Result<RateResponse, ()> {
+    let res = client
         .get(url)
         .send()
         .map_err(|err| {
             error!("Error fetching exchange rates from CoinCap: {:?}", err);
         })
-        .and_then(|res| {
-            res.error_for_status().map_err(|err| {
-                error!("HTTP error getting exchange rates from CoinCap: {:?}", err);
-            })
+        .await?;
+
+    let res = res.error_for_status().map_err(|err| {
+        error!("HTTP error getting exchange rates from CoinCap: {:?}", err);
+    })?;
+
+    res.json()
+        .map_err(|err| {
+            error!(
+                "Error getting exchange rate response body from CoinCap, incorrect type: {:?}",
+                err
+            );
         })
-        .and_then(|mut res| {
-            res.json().map_err(|err| {
-                error!(
-                    "Error getting exchange rate response body from CoinCap, incorrect type: {:?}",
-                    err
-                );
-            })
-        })
+        .await
 }

--- a/crates/interledger-service-util/src/exchange_rate_providers/coincap.rs
+++ b/crates/interledger-service-util/src/exchange_rate_providers/coincap.rs
@@ -26,11 +26,13 @@ struct RateResponse {
 }
 
 pub async fn query_coincap(client: &Client) -> Result<HashMap<String, f64>, ()> {
+    println!("querying coincap");
     let (assets, rates) = futures::future::join(
         query_coincap_endpoint(client, COINCAP_ASSETS_URL.clone()),
         query_coincap_endpoint(client, COINCAP_RATES_URL.clone()),
     )
     .await;
+    println!("queryied coincap {:?} {:?}", assets, rates);
 
     let all_rates: HashMap<String, f64> = assets?
         .data

--- a/crates/interledger-service-util/src/exchange_rate_providers/cryptocompare.rs
+++ b/crates/interledger-service-util/src/exchange_rate_providers/cryptocompare.rs
@@ -51,13 +51,12 @@ pub async fn query_cryptocompare(
     client: &Client,
     api_key: &SecretString,
 ) -> Result<HashMap<String, f64>, ()> {
+    // ref: https://github.com/rust-lang/rust/pull/64856
+    let header = format!("Apikey {}", api_key.expose_secret()).to_string();
     let res = client
         .get(CRYPTOCOMPARE_URL.clone())
         // TODO don't copy the api key on every request
-        .header(
-            "Authorization",
-            format!("Apikey {}", api_key.expose_secret()).as_str(),
-        )
+        .header("Authorization", header)
         .send()
         .map_err(|err| {
             error!(

--- a/crates/interledger-service-util/src/exchange_rate_providers/cryptocompare.rs
+++ b/crates/interledger-service-util/src/exchange_rate_providers/cryptocompare.rs
@@ -1,7 +1,7 @@
-use futures::Future;
+use futures::TryFutureExt;
 use lazy_static::lazy_static;
 use log::error;
-use reqwest::{r#async::Client, Url};
+use reqwest::{Client, Url};
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use std::{
@@ -47,11 +47,11 @@ struct Response {
     data: Vec<Record>,
 }
 
-pub fn query_cryptocompare(
+pub async fn query_cryptocompare(
     client: &Client,
     api_key: &SecretString,
-) -> impl Future<Item = HashMap<String, f64>, Error = ()> {
-    client
+) -> Result<HashMap<String, f64>, ()> {
+    let res = client
         .get(CRYPTOCOMPARE_URL.clone())
         // TODO don't copy the api key on every request
         .header(
@@ -60,31 +60,40 @@ pub fn query_cryptocompare(
         )
         .send()
         .map_err(|err| {
-            error!("Error fetching exchange rates from CryptoCompare: {:?}", err);
+            error!(
+                "Error fetching exchange rates from CryptoCompare: {:?}",
+                err
+            );
         })
-        .and_then(|res| {
-            res.error_for_status().map_err(|err| {
-                error!("HTTP error getting exchange rates from CryptoCompare: {:?}", err);
-            })
+        .await?;
+
+    let res = res.error_for_status().map_err(|err| {
+        error!(
+            "HTTP error getting exchange rates from CryptoCompare: {:?}",
+            err
+        );
+    })?;
+
+    let res: Response = res
+        .json()
+        .map_err(|err| {
+            error!(
+            "Error getting exchange rate response body from CryptoCompare, incorrect type: {:?}",
+            err
+        );
         })
-        .and_then(|mut res| {
-            res.json().map_err(|err| {
-                error!(
-                    "Error getting exchange rate response body from CryptoCompare, incorrect type: {:?}",
-                    err
-                );
-            })
+        .await?;
+
+    let rates = res
+        .data
+        .into_iter()
+        .filter_map(|asset| {
+            if let Some(raw) = asset.raw {
+                Some((asset.coin_info.name.to_uppercase(), raw.usd.price))
+            } else {
+                None
+            }
         })
-        .and_then(|res: Response| {
-            let rates = res
-                .data
-                .into_iter()
-                .filter_map(|asset| if let Some(raw) = asset.raw {
-                    Some((asset.coin_info.name.to_uppercase(), raw.usd.price))
-                  } else {
-                    None
-                  })
-                .chain(once(("USD".to_string(), 1.0)));
-            Ok(HashMap::from_iter(rates))
-        })
+        .chain(once(("USD".to_string(), 1.0)));
+    Ok(HashMap::from_iter(rates))
 }

--- a/crates/interledger-service-util/src/exchange_rates_service.rs
+++ b/crates/interledger-service-util/src/exchange_rates_service.rs
@@ -1,13 +1,11 @@
 use super::exchange_rate_providers::*;
-use futures::{
-    future::{err, Either},
-    Future, Stream,
-};
-use interledger_packet::{ErrorCode, Fulfill, Reject, RejectBuilder};
+use async_trait::async_trait;
+use futures::TryFutureExt;
+use interledger_packet::{ErrorCode, RejectBuilder};
 use interledger_service::*;
 use interledger_settlement::core::types::{Convert, ConvertDetails};
 use log::{debug, error, trace, warn};
-use reqwest::r#async::Client;
+use reqwest::Client;
 use secrecy::SecretString;
 use serde::Deserialize;
 use std::{
@@ -17,9 +15,8 @@ use std::{
         atomic::{AtomicU32, Ordering},
         Arc,
     },
-    time::{Duration, Instant},
+    time::Duration,
 };
-use tokio::{executor::spawn, timer::Interval};
 
 // TODO should this whole file be moved to its own crate?
 
@@ -67,25 +64,21 @@ where
     }
 }
 
+#[async_trait]
 impl<S, O, A> OutgoingService<A> for ExchangeRateService<S, O, A>
 where
     // TODO can we make these non-'static?
     S: AddressStore + ExchangeRateStore + Clone + Send + Sync + 'static,
-    O: OutgoingService<A> + Send + Clone + 'static,
-    A: Account + Sync + 'static,
+    O: OutgoingService<A> + Send + Sync + Clone + 'static,
+    A: Account + Send + Sync + 'static,
 {
-    type Future = BoxedIlpFuture;
-
     /// On send request:
     /// 1. If the prepare packet's amount is 0, it just forwards
     /// 1. Retrieves the exchange rate from the store (the store independently is responsible for polling the rates)
     ///     - return reject if the call to the store fails
     /// 1. Calculates the exchange rate AND scales it up/down depending on how many decimals each asset requires
     /// 1. Updates the amount in the prepare packet and forwards it
-    fn send_request(
-        &mut self,
-        mut request: OutgoingRequest<A>,
-    ) -> Box<dyn Future<Item = Fulfill, Error = Reject> + Send> {
+    async fn send_request(&mut self, mut request: OutgoingRequest<A>) -> IlpResult {
         let ilp_address = self.store.get_ilp_address();
         if request.prepare.amount() > 0 {
             let rate: f64 = if request.from.asset_code() == request.to.asset_code() {
@@ -105,7 +98,7 @@ where
                     request.from.asset_code(),
                     request.to.asset_code()
                 );
-                return Box::new(err(RejectBuilder {
+                return Err(RejectBuilder {
                     code: ErrorCode::T00_INTERNAL_ERROR,
                     message: format!(
                         "No exchange rate available from asset: {} to: {}",
@@ -116,7 +109,7 @@ where
                     triggered_by: Some(&ilp_address),
                     data: &[],
                 }
-                .build()));
+                .build());
             };
 
             // Apply spread
@@ -165,13 +158,13 @@ where
                             )
                         };
 
-                        return Box::new(err(RejectBuilder {
+                        return Err(RejectBuilder {
                             code,
                             message: message.as_bytes(),
                             triggered_by: Some(&ilp_address),
                             data: &[],
                         }
-                        .build()));
+                        .build());
                     }
                     request.prepare.set_amount(outgoing_amount as u64);
                     trace!("Converted incoming amount of: {} {} (scale {}) from account {} to outgoing amount of: {} {} (scale {}) for account {}",
@@ -183,7 +176,7 @@ where
                     // returns an error. Happens due to float
                     // multiplication overflow .
                     // (float overflow in Rust produces +inf)
-                    return Box::new(err(RejectBuilder {
+                    return Err(RejectBuilder {
                         code: ErrorCode::F08_AMOUNT_TOO_LARGE,
                         message: format!(
                             "Could not convert exchange rate from {}:{} to: {}:{}. Got incoming amount: {}",
@@ -197,12 +190,12 @@ where
                         triggered_by: Some(&ilp_address),
                         data: &[],
                     }
-                    .build()));
+                    .build());
                 }
             }
         }
 
-        Box::new(self.next.send_request(request))
+        self.next.send_request(request).await
     }
 }
 
@@ -230,6 +223,7 @@ pub enum ExchangeRateProvider {
 }
 
 /// Poll exchange rate providers for the current exchange rates
+#[derive(Clone)]
 pub struct ExchangeRateFetcher<S> {
     provider: ExchangeRateProvider,
     consecutive_failed_polls: Arc<AtomicU32>,
@@ -256,47 +250,45 @@ where
         }
     }
 
-    pub fn fetch_on_interval(self, interval: Duration) -> impl Future<Item = (), Error = ()> {
+    pub async fn fetch_on_interval(self, interval: Duration) -> Result<(), ()> {
         debug!(
             "Starting interval to poll exchange rate provider: {:?} for rates",
             self.provider
         );
-        Interval::new(Instant::now(), interval)
-            .map_err(|err| {
-                error!(
-                    "Interval error, no longer fetching exchange rates: {:?}",
-                    err
-                );
-            })
-            .for_each(move |_| {
-                self.update_rates().then(|_| {
-                    // Ignore errors so that they don't cause the Interval to stop
-                    Ok(())
-                })
-            })
+        let mut interval = tokio::time::interval(interval);
+        while let _ = interval.tick().await {
+            // Ignore errors so that they don't cause the Interval to stop
+            let _ = self.update_rates().await;
+        }
+
+        Ok(())
     }
 
-    pub fn spawn_interval(self, interval: Duration) {
-        spawn(self.fetch_on_interval(interval));
-    }
+    // TODO: This compiles on nightly but fails on 1.39?
+    // pub fn spawn_interval(self, interval: Duration) {
+    //     tokio::spawn({
+    //         let self_clone = self.clone();
+    //         async move { self_clone.fetch_on_interval(interval).await }
+    //     });
+    // }
 
-    fn fetch_rates(&self) -> impl Future<Item = HashMap<String, f64>, Error = ()> {
+    async fn fetch_rates(&self) -> Result<HashMap<String, f64>, ()> {
         match self.provider {
             ExchangeRateProvider::CryptoCompare(ref api_key) => {
-                Either::A(query_cryptocompare(&self.client, api_key))
+                query_cryptocompare(&self.client, api_key).await
             }
-            ExchangeRateProvider::CoinCap => Either::B(query_coincap(&self.client)),
+            ExchangeRateProvider::CoinCap => query_coincap(&self.client).await,
         }
     }
 
-    fn update_rates(&self) -> impl Future<Item = (), Error = ()> {
+    async fn update_rates(&self) -> Result<(), ()> {
         let consecutive_failed_polls = self.consecutive_failed_polls.clone();
         let consecutive_failed_polls_zeroer = consecutive_failed_polls.clone();
         let failed_polls_before_invalidation = self.failed_polls_before_invalidation;
         let store = self.store.clone();
         let store_clone = self.store.clone();
         let provider = self.provider.clone();
-        self.fetch_rates()
+        let mut rates = self.fetch_rates()
             .map_err(move |_| {
                 // Note that a race between the read on this line and the check on the line after
                 // is quite unlikely as long as the interval between polls is reasonable.
@@ -311,29 +303,27 @@ where
                         panic!("Failed to clear exchange rates cache after exchange rates server became unresponsive");
                     }
                 }
-            })
-            .and_then(move |mut rates| {
-                trace!("Fetched exchange rates: {:?}", rates);
-                let num_rates = rates.len();
-                rates.insert("USD".to_string(), 1.0);
-                if store_clone.set_exchange_rates(rates).is_ok() {
-                    // Reset our invalidation counter
-                    consecutive_failed_polls_zeroer.store(0, Ordering::Relaxed);
-                    debug!("Updated {} exchange rates from {:?}", num_rates, provider);
-                    Ok(())
-                } else {
-                    error!("Error setting exchange rates in store");
-                    Err(())
-                }
-            })
+            }).await?;
+
+        trace!("Fetched exchange rates: {:?}", rates);
+        let num_rates = rates.len();
+        rates.insert("USD".to_string(), 1.0);
+        if store_clone.set_exchange_rates(rates).is_ok() {
+            // Reset our invalidation counter
+            consecutive_failed_polls_zeroer.store(0, Ordering::Relaxed);
+            debug!("Updated {} exchange rates from {:?}", num_rates, provider);
+            Ok(())
+        } else {
+            error!("Error setting exchange rates in store");
+            Err(())
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::{future::ok, Future};
-    use interledger_packet::{Address, FulfillBuilder, PrepareBuilder};
+    use interledger_packet::{Address, Fulfill, FulfillBuilder, PrepareBuilder, Reject};
     use interledger_service::{outgoing_service_fn, Account};
     use lazy_static::lazy_static;
     use std::collections::HashMap;
@@ -348,21 +338,21 @@ mod tests {
         pub static ref ALICE: Username = Username::from_str("alice").unwrap();
     }
 
-    #[test]
-    fn exchange_rate_ok() {
+    #[tokio::test]
+    async fn exchange_rate_ok() {
         // if `to` is worth $2, and `from` is worth 1, then they receive half
         // the amount of units
-        let ret = exchange_rate(200, 1, 1.0, 1, 2.0, 0.0);
+        let ret = exchange_rate(200, 1, 1.0, 1, 2.0, 0.0).await;
         assert_eq!(ret.1[0].prepare.amount(), 100);
 
-        let ret = exchange_rate(1_000_000, 1, 3.0, 1, 2.0, 0.0);
+        let ret = exchange_rate(1_000_000, 1, 3.0, 1, 2.0, 0.0).await;
         assert_eq!(ret.1[0].prepare.amount(), 1_500_000);
     }
 
-    #[test]
-    fn exchange_conversion_error() {
+    #[tokio::test]
+    async fn exchange_conversion_error() {
         // rejects f64 that does not fit in u64
-        let ret = exchange_rate(std::u64::MAX, 1, 2.0, 1, 1.0, 0.0);
+        let ret = exchange_rate(std::u64::MAX, 1, 2.0, 1, 1.0, 0.0).await;
         let reject = ret.0.unwrap_err();
         assert_eq!(reject.code(), ErrorCode::F08_AMOUNT_TOO_LARGE);
         assert!(reject
@@ -370,7 +360,7 @@ mod tests {
             .starts_with(b"Could not cast to f64, amount too large"));
 
         // rejects f64 which gets rounded down to 0
-        let ret = exchange_rate(1, 2, 1.0, 1, 1.0, 0.0);
+        let ret = exchange_rate(1, 2, 1.0, 1, 1.0, 0.0).await;
         let reject = ret.0.unwrap_err();
         assert_eq!(reject.code(), ErrorCode::R01_INSUFFICIENT_SOURCE_AMOUNT);
         assert!(reject
@@ -378,38 +368,38 @@ mod tests {
             .starts_with(b"Could not cast to f64, amount too small"));
 
         // `Convert` errored
-        let ret = exchange_rate(std::u64::MAX, 1, std::f64::MAX, 255, 1.0, 0.0);
+        let ret = exchange_rate(std::u64::MAX, 1, std::f64::MAX, 255, 1.0, 0.0).await;
         let reject = ret.0.unwrap_err();
         assert_eq!(reject.code(), ErrorCode::F08_AMOUNT_TOO_LARGE);
         assert!(reject.message().starts_with(b"Could not convert"));
     }
 
-    #[test]
-    fn applies_spread() {
-        let ret = exchange_rate(100, 1, 1.0, 1, 2.0, 0.01);
+    #[tokio::test]
+    async fn applies_spread() {
+        let ret = exchange_rate(100, 1, 1.0, 1, 2.0, 0.01).await;
         assert_eq!(ret.1[0].prepare.amount(), 49);
 
         // Negative spread is unusual but possible
-        let ret = exchange_rate(200, 1, 1.0, 1, 2.0, -0.01);
+        let ret = exchange_rate(200, 1, 1.0, 1, 2.0, -0.01).await;
         assert_eq!(ret.1[0].prepare.amount(), 101);
 
         // Rounds down
-        let ret = exchange_rate(4, 1, 1.0, 1, 2.0, 0.01);
+        let ret = exchange_rate(4, 1, 1.0, 1, 2.0, 0.01).await;
         // this would've been 2, but it becomes 1.99 and gets rounded down to 1
         assert_eq!(ret.1[0].prepare.amount(), 1);
 
         // Spread >= 1 means the node takes everything
-        let ret = exchange_rate(10_000_000_000, 1, 1.0, 1, 2.0, 1.0);
+        let ret = exchange_rate(10_000_000_000, 1, 1.0, 1, 2.0, 1.0).await;
         assert_eq!(ret.1[0].prepare.amount(), 0);
 
         // Need to catch when spread > 1
-        let ret = exchange_rate(10_000_000_000, 1, 1.0, 1, 2.0, 2.0);
+        let ret = exchange_rate(10_000_000_000, 1, 1.0, 1, 2.0, 2.0).await;
         assert_eq!(ret.1[0].prepare.amount(), 0);
     }
 
     // Instantiates an exchange rate service and returns the fulfill/reject
     // packet and the outgoing request after performing an asset conversion
-    fn exchange_rate(
+    async fn exchange_rate(
         amount: u64,
         scale1: u8,
         rate1: f64,
@@ -421,11 +411,11 @@ mod tests {
         let requests_clone = requests.clone();
         let outgoing = outgoing_service_fn(move |request| {
             requests_clone.lock().unwrap().push(request);
-            Box::new(ok(FulfillBuilder {
+            Ok(FulfillBuilder {
                 fulfillment: &[0; 32],
                 data: b"hello!",
             }
-            .build()))
+            .build())
         });
         let mut service = test_service(rate1, rate2, spread, outgoing);
         let result = service
@@ -442,7 +432,7 @@ mod tests {
                 }
                 .build(),
             })
-            .wait();
+            .await;
 
         let reqs = requests.lock().unwrap();
         (result, reqs.clone())
@@ -464,16 +454,14 @@ mod tests {
         }
     }
 
+    #[async_trait]
     impl AddressStore for TestStore {
         /// Saves the ILP Address in the store's memory and database
-        fn set_ilp_address(
-            &self,
-            _ilp_address: Address,
-        ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        async fn set_ilp_address(&self, _ilp_address: Address) -> Result<(), ()> {
             unimplemented!()
         }
 
-        fn clear_ilp_address(&self) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        async fn clear_ilp_address(&self) -> Result<(), ()> {
             unimplemented!()
         }
 

--- a/crates/interledger-service-util/src/exchange_rates_service.rs
+++ b/crates/interledger-service-util/src/exchange_rates_service.rs
@@ -251,18 +251,21 @@ where
     }
 
     // TODO: This compiles on nightly but fails on 1.39?
-    pub fn spawn_interval(self, interval: Duration) {
-        debug!("Starting interval to poll exchange rate provider: {:?} for rates", self.provider);
-        let interval = async move {
-            let mut interval = tokio::time::interval(interval);
-            while let _ = interval.tick().await {
-                // Ignore errors so that they don't cause the Interval to stop
-                let _ = self.update_rates().await;
-            }
-            Ok::<(), ()>(())
-        };
-        tokio::spawn(interval);
-    }
+    // pub fn spawn_interval(self, interval: Duration) {
+    //     debug!(
+    //         "Starting interval to poll exchange rate provider: {:?} for rates",
+    //         self.provider
+    //     );
+    //     let interval = async move {
+    //         let mut interval = tokio::time::interval(interval);
+    //         while let _ = interval.tick().await {
+    //             // Ignore errors so that they don't cause the Interval to stop
+    //             let _ = self.update_rates().await;
+    //         }
+    //         Ok::<(), ()>(())
+    //     };
+    //     tokio::spawn(interval);
+    // }
 
     async fn fetch_rates(&self) -> Result<HashMap<String, f64>, ()> {
         match self.provider {

--- a/crates/interledger-service-util/src/exchange_rates_service.rs
+++ b/crates/interledger-service-util/src/exchange_rates_service.rs
@@ -258,11 +258,11 @@ where
         );
         let interval = async move {
             let mut interval = tokio::time::interval(interval);
-            while let _ = interval.tick().await {
+            loop {
+                interval.tick().await;
                 // Ignore errors so that they don't cause the Interval to stop
                 let _ = self.update_rates().await;
             }
-            Ok::<(), ()>(())
         };
         tokio::spawn(interval);
     }

--- a/crates/interledger-service-util/src/exchange_rates_service.rs
+++ b/crates/interledger-service-util/src/exchange_rates_service.rs
@@ -251,21 +251,21 @@ where
     }
 
     // TODO: This compiles on nightly but fails on 1.39?
-    // pub fn spawn_interval(self, interval: Duration) {
-    //     debug!(
-    //         "Starting interval to poll exchange rate provider: {:?} for rates",
-    //         self.provider
-    //     );
-    //     let interval = async move {
-    //         let mut interval = tokio::time::interval(interval);
-    //         while let _ = interval.tick().await {
-    //             // Ignore errors so that they don't cause the Interval to stop
-    //             let _ = self.update_rates().await;
-    //         }
-    //         Ok::<(), ()>(())
-    //     };
-    //     tokio::spawn(interval);
-    // }
+    pub fn spawn_interval(self, interval: Duration) {
+        debug!(
+            "Starting interval to poll exchange rate provider: {:?} for rates",
+            self.provider
+        );
+        let interval = async move {
+            let mut interval = tokio::time::interval(interval);
+            while let _ = interval.tick().await {
+                // Ignore errors so that they don't cause the Interval to stop
+                let _ = self.update_rates().await;
+            }
+            Ok::<(), ()>(())
+        };
+        tokio::spawn(interval);
+    }
 
     async fn fetch_rates(&self) -> Result<HashMap<String, f64>, ()> {
         match self.provider {

--- a/crates/interledger-service-util/src/expiry_shortener_service.rs
+++ b/crates/interledger-service-util/src/expiry_shortener_service.rs
@@ -1,5 +1,6 @@
+use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
-use interledger_service::{Account, OutgoingRequest, OutgoingService};
+use interledger_service::{Account, IlpResult, OutgoingRequest, OutgoingService};
 use log::trace;
 
 pub const DEFAULT_ROUND_TRIP_TIME: u32 = 500;
@@ -39,19 +40,18 @@ impl<O> ExpiryShortenerService<O> {
     }
 }
 
+#[async_trait]
 impl<O, A> OutgoingService<A> for ExpiryShortenerService<O>
 where
-    O: OutgoingService<A>,
-    A: RoundTripTimeAccount,
+    O: OutgoingService<A> + Send + Sync + 'static,
+    A: RoundTripTimeAccount + Send + Sync + 'static,
 {
-    type Future = O::Future;
-
     /// On send request:
     /// 1. Get the sender and receiver's roundtrip time (default 1000ms)
     /// 2. Reduce the packet's expiry by that amount
     /// 3. Ensure that the packet expiry does not exceed the maximum expiry duration
     /// 4. Forward the request
-    fn send_request(&mut self, mut request: OutgoingRequest<A>) -> Self::Future {
+    async fn send_request(&mut self, mut request: OutgoingRequest<A>) -> IlpResult {
         let time_to_subtract =
             i64::from(request.from.round_trip_time() + request.to.round_trip_time());
         let new_expiry = DateTime::<Utc>::from(request.prepare.expires_at())
@@ -70,14 +70,13 @@ where
         };
 
         request.prepare.set_expires_at(new_expiry.into());
-        self.next.send_request(request)
+        self.next.send_request(request).await
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::Future;
     use interledger_packet::{Address, ErrorCode, FulfillBuilder, PrepareBuilder, RejectBuilder};
     use interledger_service::{outgoing_service_fn, Username};
     use std::str::FromStr;
@@ -121,8 +120,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn shortens_expiry_by_round_trip_time() {
+    #[tokio::test]
+    async fn shortens_expiry_by_round_trip_time() {
         let original_expiry = Utc::now() + Duration::milliseconds(30000);
         let mut service = ExpiryShortenerService::new(outgoing_service_fn(move |request| {
             if DateTime::<Utc>::from(request.prepare.expires_at())
@@ -157,12 +156,12 @@ mod tests {
                 .build(),
                 original_amount: 10,
             })
-            .wait()
+            .await
             .expect("Should have shortened expiry");
     }
 
-    #[test]
-    fn reduces_expiry_to_max_duration() {
+    #[tokio::test]
+    async fn reduces_expiry_to_max_duration() {
         let mut service = ExpiryShortenerService::new(outgoing_service_fn(move |request| {
             if DateTime::<Utc>::from(request.prepare.expires_at()) - Utc::now()
                 <= Duration::milliseconds(30000)
@@ -196,7 +195,7 @@ mod tests {
                 .build(),
                 original_amount: 10,
             })
-            .wait()
+            .await
             .expect("Should have shortened expiry");
     }
 }

--- a/crates/interledger-service-util/src/max_packet_amount_service.rs
+++ b/crates/interledger-service-util/src/max_packet_amount_service.rs
@@ -1,4 +1,4 @@
-use futures::future::err;
+use async_trait::async_trait;
 use interledger_packet::{ErrorCode, MaxPacketAmountDetails, RejectBuilder};
 use interledger_service::*;
 use log::debug;
@@ -27,21 +27,20 @@ impl<I, S> MaxPacketAmountService<I, S> {
     }
 }
 
+#[async_trait]
 impl<I, S, A> IncomingService<A> for MaxPacketAmountService<I, S>
 where
-    I: IncomingService<A>,
-    S: AddressStore,
-    A: MaxPacketAmountAccount,
+    I: IncomingService<A> + Send + Sync + 'static,
+    S: AddressStore + Send + Sync + 'static,
+    A: MaxPacketAmountAccount + Send + Sync + 'static,
 {
-    type Future = BoxedIlpFuture;
-
     /// On receive request:
     /// 1. if request.prepare.amount <= request.from.max_packet_amount forward the request, else error
-    fn handle_request(&mut self, request: IncomingRequest<A>) -> Self::Future {
+    async fn handle_request(&mut self, request: IncomingRequest<A>) -> IlpResult {
         let ilp_address = self.store.get_ilp_address();
         let max_packet_amount = request.from.max_packet_amount();
         if request.prepare.amount() <= max_packet_amount {
-            Box::new(self.next.handle_request(request))
+            self.next.handle_request(request).await
         } else {
             debug!(
                 "Prepare amount:{} exceeds max_packet_amount: {}",
@@ -50,13 +49,13 @@ where
             );
             let details =
                 MaxPacketAmountDetails::new(request.prepare.amount(), max_packet_amount).to_bytes();
-            Box::new(err(RejectBuilder {
+            Err(RejectBuilder {
                 code: ErrorCode::F08_AMOUNT_TOO_LARGE,
                 message: &[],
                 triggered_by: Some(&ilp_address),
                 data: &details[..],
             }
-            .build()))
+            .build())
         }
     }
 }

--- a/crates/interledger-service-util/src/rate_limit_service.rs
+++ b/crates/interledger-service-util/src/rate_limit_service.rs
@@ -1,11 +1,6 @@
-use futures::{
-    future::{err, Either},
-    Future,
-};
+use async_trait::async_trait;
 use interledger_packet::{ErrorCode, RejectBuilder};
-use interledger_service::{
-    Account, AddressStore, BoxedIlpFuture, IncomingRequest, IncomingService,
-};
+use interledger_service::{Account, AddressStore, IlpResult, IncomingRequest, IncomingService};
 use log::{error, warn};
 use std::marker::PhantomData;
 
@@ -26,19 +21,21 @@ pub enum RateLimitError {
     StoreError,
 }
 
+#[async_trait]
 pub trait RateLimitStore {
     type Account: RateLimitAccount;
 
-    fn apply_rate_limits(
+    async fn apply_rate_limits(
         &self,
         account: Self::Account,
         prepare_amount: u64,
-    ) -> Box<dyn Future<Item = (), Error = RateLimitError> + Send>;
-    fn refund_throughput_limit(
+    ) -> Result<(), RateLimitError>;
+
+    async fn refund_throughput_limit(
         &self,
         account: Self::Account,
         prepare_amount: u64,
-    ) -> Box<dyn Future<Item = (), Error = ()> + Send>;
+    ) -> Result<(), ()>;
 }
 
 /// # Rate Limit Service
@@ -74,21 +71,20 @@ where
     }
 }
 
+#[async_trait]
 impl<S, I, A> IncomingService<A> for RateLimitService<S, I, A>
 where
     S: AddressStore + RateLimitStore<Account = A> + Clone + Send + Sync + 'static,
     I: IncomingService<A> + Clone + Send + Sync + 'static,
     A: RateLimitAccount + Sync + 'static,
 {
-    type Future = BoxedIlpFuture;
-
     /// On receiving a request:
     /// 1. Apply rate limit based on the sender of the request and the amount in the prepare packet in the request
     /// 1. If no limits were hit forward the request
     ///     - If it succeeds, OK
     ///     - If the request forwarding failed, the client should not be charged towards their throughput limit, so they are refunded, and return a reject
     /// 1. If the limit was hit, return a reject with the appropriate ErrorCode.
-    fn handle_request(&mut self, request: IncomingRequest<A>) -> Self::Future {
+    async fn handle_request(&mut self, request: IncomingRequest<A>) -> IlpResult {
         let ilp_address = self.store.get_ilp_address();
         let mut next = self.next.clone();
         let store = self.store.clone();
@@ -98,43 +94,47 @@ where
         let has_throughput_limit = account.amount_per_minute_limit().is_some();
         // request.from and request.amount are used for apply_rate_limits, can't the previous service
         // always set the account to have None for both?
-        Box::new(self.store.apply_rate_limits(request.from.clone(), request.prepare.amount())
-            .map_err(move |err| {
+        match self
+            .store
+            .apply_rate_limits(request.from.clone(), request.prepare.amount())
+            .await
+        {
+            Ok(_) => next.handle_request(request).await,
+            Err(err) => {
                 let code = match err {
                     RateLimitError::PacketLimitExceeded => {
                         if let Some(limit) = account.packets_per_minute_limit() {
                             warn!("Account {} was rate limited for sending too many packets. Limit is: {} per minute", account.id(), limit);
                         }
                         ErrorCode::T05_RATE_LIMITED
-                    },
+                    }
                     RateLimitError::ThroughputLimitExceeded => {
                         if let Some(limit) = account.amount_per_minute_limit() {
                             warn!("Account {} was throughput limited for trying to send too much money. Limit is: {} per minute", account.id(), limit);
                         }
                         ErrorCode::T04_INSUFFICIENT_LIQUIDITY
-                    },
+                    }
                     RateLimitError::StoreError => ErrorCode::T00_INTERNAL_ERROR,
                 };
-                RejectBuilder {
+
+                let reject = RejectBuilder {
                     code,
                     triggered_by: Some(&ilp_address),
                     message: &[],
                     data: &[],
-                }.build()
-            })
-            .and_then(move |_| next.handle_request(request))
-            .or_else(move |reject| {
-                if has_throughput_limit {
-                    Either::A(store.refund_throughput_limit(account_clone, prepare_amount)
-                        .then(|result| {
-                            if let Err(err) = result {
-                                error!("Error refunding throughput limit: {:?}", err);
-                            }
-                            Err(reject)
-                        }))
-                } else {
-                    Either::B(err(reject))
                 }
-            }))
+                .build();
+
+                if has_throughput_limit {
+                    if let Err(err) = store
+                        .refund_throughput_limit(account_clone, prepare_amount)
+                        .await
+                    {
+                        error!("Error refunding throughput limit: {:?}", err);
+                    }
+                }
+                Err(reject)
+            }
+        }
     }
 }

--- a/crates/interledger-service/Cargo.toml
+++ b/crates/interledger-service/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0.101", default-features = false, features = ["derive"] }
 base64 = { version = "0.10.1", default-features = false }
 regex = { version = "1.3.1", default-features = false, features = ["std", "unicode-perl"] }
 lazy_static = { version = "1.4.0", default-features = false }
-tracing-futures = { version = "0.1.1", default-features = true, features = ["tokio", "futures-01"], optional = true }
+tracing-futures = { version = "0.2", default-features = true, features = ["tokio", "futures-03"], optional = true }
 unicase = { version = "2.5.1", default-features = false }
 unicode-normalization = { version = "0.1.8", default-features = false }
 uuid = { version = "0.8.1", default-features = false}

--- a/crates/interledger-service/Cargo.toml
+++ b/crates/interledger-service/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 trace = ["tracing-futures"]
 
 [dependencies]
-futures = { version = "0.1.29", default-features = true }
+futures = { version = "0.3", default-features = true }
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
 serde = { version = "1.0.101", default-features = false, features = ["derive"] }
 base64 = { version = "0.10.1", default-features = false }

--- a/crates/interledger-service/Cargo.toml
+++ b/crates/interledger-service/Cargo.toml
@@ -22,6 +22,7 @@ tracing-futures = { version = "0.1.1", default-features = true, features = ["tok
 unicase = { version = "2.5.1", default-features = false }
 unicode-normalization = { version = "0.1.8", default-features = false }
 uuid = { version = "0.8.1", default-features = false}
+async-trait = "0.1.22"
 
 [dev-dependencies]
 serde_json = { version = "1.0.41", default-features = false }

--- a/crates/interledger-service/src/lib.rs
+++ b/crates/interledger-service/src/lib.rs
@@ -38,8 +38,8 @@ use uuid::Uuid;
 mod username;
 pub use username::Username;
 // TODO: Temporarily disable until we figure out what's going on with tracing and async_trait
-// #[cfg(feature = "trace")]
-// mod trace;
+#[cfg(feature = "trace")]
+mod trace;
 
 pub type IlpResult = Result<Fulfill, Reject>;
 

--- a/crates/interledger-service/src/lib.rs
+++ b/crates/interledger-service/src/lib.rs
@@ -190,10 +190,10 @@ pub trait AccountStore {
 }
 
 /// Create an IncomingService that calls the given handler for each request.
-pub fn incoming_service_fn<A, B, F>(handler: F) -> ServiceFn<F, A>
+pub fn incoming_service_fn<A, F>(handler: F) -> ServiceFn<F, A>
 where
     A: Account,
-    F: FnMut(IncomingRequest<A>) -> B,
+    F: FnMut(IncomingRequest<A>) -> IlpResult,
 {
     ServiceFn {
         handler,
@@ -202,10 +202,10 @@ where
 }
 
 /// Create an OutgoingService that calls the given handler for each request.
-pub fn outgoing_service_fn<A, B, F>(handler: F) -> ServiceFn<F, A>
+pub fn outgoing_service_fn<A, F>(handler: F) -> ServiceFn<F, A>
 where
     A: Account,
-    F: FnMut(OutgoingRequest<A>) -> B,
+    F: FnMut(OutgoingRequest<A>) -> IlpResult,
 {
     ServiceFn {
         handler,

--- a/crates/interledger-service/src/lib.rs
+++ b/crates/interledger-service/src/lib.rs
@@ -27,7 +27,6 @@
 //! HttpServerService --> ValidatorService --> StreamReceiverService
 
 use async_trait::async_trait;
-use futures::Future;
 use interledger_packet::{Address, Fulfill, Prepare, Reject};
 use std::{
     fmt::{self, Debug},
@@ -322,17 +321,18 @@ where
 /// perform an ILDCP request to it. The parent will then return the ILP Address
 /// which has been assigned to the node. The node will then proceed to set its
 /// ILP Address to that value.
+#[async_trait]
 pub trait AddressStore: Clone {
     /// Saves the ILP Address in the database AND in the store's memory so that it can
     /// be read without read overhead
-    fn set_ilp_address(
+    async fn set_ilp_address(
         &self,
         // The new ILP Address of the node
         ilp_address: Address,
-    ) -> Box<dyn Future<Output = Result<(), ()>> + Send>;
+    ) -> Result<(), ()>;
 
     /// Resets the node's ILP Address to local.host
-    fn clear_ilp_address(&self) -> Box<dyn Future<Output = Result<(), ()>> + Send>;
+    async fn clear_ilp_address(&self) -> Result<(), ()>;
 
     /// Gets the node's ILP Address *synchronously*
     /// (the value is stored in memory because it is read often by all services)

--- a/crates/interledger-service/src/lib.rs
+++ b/crates/interledger-service/src/lib.rs
@@ -37,8 +37,9 @@ use uuid::Uuid;
 
 mod username;
 pub use username::Username;
-#[cfg(feature = "trace")]
-mod trace;
+// TODO: Temporarily disable until we figure out what's going on with tracing and async_trait
+// #[cfg(feature = "trace")]
+// mod trace;
 
 pub type IlpResult = Result<Fulfill, Reject>;
 

--- a/crates/interledger-service/src/trace.rs
+++ b/crates/interledger-service/src/trace.rs
@@ -1,18 +1,21 @@
 use crate::*;
-use tracing_futures::{Instrument, Instrumented};
 use async_trait::async_trait;
+use tracing_futures::{Instrument, Instrumented};
 
 // TODO see if we can replace this with the tower tracing later
 #[async_trait]
 impl<IO, A> IncomingService<A> for Instrumented<IO>
 where
     IO: IncomingService<A> + Clone + Send,
-    A: Account + 'static, 
+    A: Account + 'static,
 {
     async fn handle_request(&mut self, request: IncomingRequest<A>) -> IlpResult {
         let span = self.span().clone();
         let _enter = span.enter();
-        self.inner_mut().handle_request(request).in_current_span().await
+        self.inner_mut()
+            .handle_request(request)
+            .in_current_span()
+            .await
     }
 }
 
@@ -20,11 +23,14 @@ where
 impl<IO, A> OutgoingService<A> for Instrumented<IO>
 where
     IO: OutgoingService<A> + Clone + Send,
-    A: Account + 'static, 
+    A: Account + 'static,
 {
     async fn send_request(&mut self, request: OutgoingRequest<A>) -> IlpResult {
         let span = self.span().clone();
         let _enter = span.enter();
-        self.inner_mut().send_request(request).in_current_span().await
+        self.inner_mut()
+            .send_request(request)
+            .in_current_span()
+            .await
     }
 }

--- a/crates/interledger-service/src/trace.rs
+++ b/crates/interledger-service/src/trace.rs
@@ -1,31 +1,30 @@
 use crate::*;
 use tracing_futures::{Instrument, Instrumented};
+use async_trait::async_trait;
 
 // TODO see if we can replace this with the tower tracing later
+#[async_trait]
 impl<IO, A> IncomingService<A> for Instrumented<IO>
 where
-    IO: IncomingService<A> + Clone,
-    A: Account,
+    IO: IncomingService<A> + Clone + Send,
+    A: Account + 'async_trait,
 {
-    type Future = Instrumented<IO::Future>;
-
-    fn handle_request(&mut self, request: IncomingRequest<A>) -> Self::Future {
+    async fn handle_request(&mut self, request: IncomingRequest<A>) -> IlpResult {
         let span = self.span().clone();
         let _enter = span.enter();
-        self.inner_mut().handle_request(request).in_current_span()
+        self.inner_mut().handle_request(request).in_current_span().await
     }
 }
 
+#[async_trait]
 impl<IO, A> OutgoingService<A> for Instrumented<IO>
 where
-    IO: OutgoingService<A> + Clone,
+    IO: OutgoingService<A> + Clone + Send,
     A: Account,
 {
-    type Future = Instrumented<IO::Future>;
-
-    fn send_request(&mut self, request: OutgoingRequest<A>) -> Self::Future {
+    async fn send_request(&mut self, request: OutgoingRequest<A>) -> IlpResult {
         let span = self.span().clone();
         let _enter = span.enter();
-        self.inner_mut().send_request(request).in_current_span()
+        self.inner_mut().send_request(request).in_current_span().await
     }
 }

--- a/crates/interledger-service/src/trace.rs
+++ b/crates/interledger-service/src/trace.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 impl<IO, A> IncomingService<A> for Instrumented<IO>
 where
     IO: IncomingService<A> + Clone + Send,
-    A: Account + 'async_trait,
+    A: Account + 'static, 
 {
     async fn handle_request(&mut self, request: IncomingRequest<A>) -> IlpResult {
         let span = self.span().clone();
@@ -20,7 +20,7 @@ where
 impl<IO, A> OutgoingService<A> for Instrumented<IO>
 where
     IO: OutgoingService<A> + Clone + Send,
-    A: Account,
+    A: Account + 'static, 
 {
     async fn send_request(&mut self, request: OutgoingRequest<A>) -> IlpResult {
         let span = self.span().clone();

--- a/crates/interledger-settlement/Cargo.toml
+++ b/crates/interledger-settlement/Cargo.toml
@@ -9,13 +9,14 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 
 [dependencies]
 bytes = { version = "0.4.12", default-features = false }
-futures = { version = "0.1.29", default-features = false }
-hyper = { version = "0.12.35", default-features = false }
+bytes05 = { package = "bytes", version = "0.5", default-features = false }
+futures = { version = "0.3.1", default-features = false, features = ["compat"] }
+hyper = { version = "0.13.1", default-features = false }
 interledger-http = { path = "../interledger-http", version = "^0.4.0", default-features = false }
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 log = { version = "0.4.8", default-features = false }
-reqwest = { version = "0.9.22", default-features = false, features = ["default-tls"] }
+reqwest = { version = "0.10", default-features = false, features = ["default-tls", "json"] }
 serde = { version = "1.0.101", default-features = false }
 serde_json = { version = "1.0.41", default-features = false }
 url = { version = "2.1.0", default-features = false }
@@ -23,12 +24,15 @@ lazy_static = { version = "1.4.0", default-features = false }
 uuid = { version = "0.8.1", default-features = false, features = ["v4"] }
 ring = { version = "0.16.9", default-features = false }
 tokio-retry = { version = "0.2.0", default-features = false }
-tokio = { version = "0.1.22", default-features = false }
+tokio = { version = "0.2.6", default-features = false, features = ["macros", "rt-core"] }
 num-bigint = { version = "0.2.3", default-features = false, features = ["std"] }
 num-traits = { version = "0.2.8", default-features = false }
-warp = { version = "0.1.20", default-features = false }
-http = "0.1.19"
-redis_crate = { package = "redis", version = "0.13.0", optional = true }
+# warp = { version = "0.1.20", default-features = false }
+warp = { git = "https://github.com/seanmonstar/warp", default-features = false }
+http = "0.2.0"
+# redis_crate = { package = "redis", version = "0.13.0", optional = true }
+redis_crate = { package = "redis", git = "https://github.com/mitsuhiko/redis-rs", optional = true, features = ["tokio-rt-core"] }
+async-trait = "0.1.22"
 
 [dev-dependencies]
 parking_lot = { version = "0.9.0", default-features = false }

--- a/crates/interledger-settlement/src/api/client.rs
+++ b/crates/interledger-settlement/src/api/client.rs
@@ -1,11 +1,8 @@
 use crate::core::types::{Quantity, SettlementAccount};
-use futures::{
-    future::{err, Either},
-    Future,
-};
+use futures::TryFutureExt;
 use interledger_service::Account;
 use log::{debug, error, trace};
-use reqwest::r#async::Client;
+use reqwest::Client;
 use serde_json::json;
 use uuid::Uuid;
 
@@ -21,11 +18,11 @@ impl SettlementClient {
         }
     }
 
-    pub fn send_settlement<A: SettlementAccount + Account>(
+    pub async fn send_settlement<A: SettlementAccount + Account>(
         &self,
         account: A,
         amount: u64,
-    ) -> impl Future<Item = (), Error = ()> {
+    ) -> Result<(), ()> {
         if let Some(settlement_engine) = account.settlement_engine_details() {
             let mut settlement_engine_url = settlement_engine.url;
             settlement_engine_url
@@ -40,23 +37,37 @@ impl SettlementClient {
             );
             let settlement_engine_url_clone = settlement_engine_url.clone();
             let idempotency_uuid = Uuid::new_v4().to_hyphenated().to_string();
-            return Either::A(self.http_client.post(settlement_engine_url.as_ref())
+            let response = self
+                .http_client
+                .post(settlement_engine_url.as_ref())
                 .header("Idempotency-Key", idempotency_uuid)
                 .json(&json!(Quantity::new(amount, account.asset_scale())))
                 .send()
-                .map_err(move |err| error!("Error sending settlement command to settlement engine {}: {:?}", settlement_engine_url, err))
-                .and_then(move |response| {
-                    if response.status().is_success() {
-                        trace!("Sent settlement of {} to settlement engine: {}", amount, settlement_engine_url_clone);
-                        Ok(())
-                    } else {
-                        error!("Error sending settlement. Settlement engine responded with HTTP code: {}", response.status());
-                        Err(())
-                    }
-                }));
+                .map_err(move |err| {
+                    error!(
+                        "Error sending settlement command to settlement engine {}: {:?}",
+                        settlement_engine_url, err
+                    )
+                })
+                .await?;
+
+            if response.status().is_success() {
+                trace!(
+                    "Sent settlement of {} to settlement engine: {}",
+                    amount,
+                    settlement_engine_url_clone
+                );
+                return Ok(());
+            } else {
+                error!(
+                    "Error sending settlement. Settlement engine responded with HTTP code: {}",
+                    response.status()
+                );
+                return Err(());
+            }
         }
         error!("Cannot send settlement for account {} because it does not have the settlement_engine_url and scale configured", account.id());
-        Either::B(err(()))
+        Err(())
     }
 }
 
@@ -70,37 +81,37 @@ impl Default for SettlementClient {
 mod tests {
     use super::*;
     use crate::api::fixtures::TEST_ACCOUNT_0;
-    use crate::api::test_helpers::{block_on, mock_settlement};
+    use crate::api::test_helpers::mock_settlement;
     use mockito::Matcher;
 
-    #[test]
-    fn settlement_ok() {
+    #[tokio::test]
+    async fn settlement_ok() {
         let m = mock_settlement(200)
             .match_header("Idempotency-Key", Matcher::Any)
             .create();
         let client = SettlementClient::new();
 
-        let ret = block_on(client.send_settlement(TEST_ACCOUNT_0.clone(), 100));
+        let ret = client.send_settlement(TEST_ACCOUNT_0.clone(), 100).await;
 
         m.assert();
         assert!(ret.is_ok());
     }
 
-    #[test]
-    fn engine_rejects() {
+    #[tokio::test]
+    async fn engine_rejects() {
         let m = mock_settlement(500)
             .match_header("Idempotency-Key", Matcher::Any)
             .create();
         let client = SettlementClient::new();
 
-        let ret = block_on(client.send_settlement(TEST_ACCOUNT_0.clone(), 100));
+        let ret = client.send_settlement(TEST_ACCOUNT_0.clone(), 100).await;
 
         m.assert();
         assert!(ret.is_err());
     }
 
-    #[test]
-    fn account_does_not_have_settlement_engine() {
+    #[tokio::test]
+    async fn account_does_not_have_settlement_engine() {
         let m = mock_settlement(200)
             .expect(0)
             .match_header("Idempotency-Key", Matcher::Any)
@@ -109,7 +120,7 @@ mod tests {
 
         let mut acc = TEST_ACCOUNT_0.clone();
         acc.no_details = true; // Hide the settlement engine data from the account
-        let ret = block_on(client.send_settlement(acc, 100));
+        let ret = client.send_settlement(acc, 100).await;
 
         m.assert();
         assert!(ret.is_err());

--- a/crates/interledger-settlement/src/api/message_service.rs
+++ b/crates/interledger-settlement/src/api/message_service.rs
@@ -1,12 +1,10 @@
 use crate::core::types::{SettlementAccount, SE_ILP_ADDRESS};
-use futures::{
-    future::{err, Either},
-    Future, Stream,
-};
+use async_trait::async_trait;
+use futures::{compat::Future01CompatExt, TryFutureExt};
 use interledger_packet::{ErrorCode, FulfillBuilder, RejectBuilder};
-use interledger_service::{Account, BoxedIlpFuture, IncomingRequest, IncomingService};
+use interledger_service::{Account, IlpResult, IncomingRequest, IncomingService};
 use log::error;
-use reqwest::r#async::Client;
+use reqwest::Client;
 use std::marker::PhantomData;
 use tokio_retry::{strategy::ExponentialBackoff, Retry};
 
@@ -33,14 +31,13 @@ where
     }
 }
 
+#[async_trait]
 impl<I, A> IncomingService<A> for SettlementMessageService<I, A>
 where
     I: IncomingService<A> + Send,
-    A: SettlementAccount + Account,
+    A: SettlementAccount + Account + Send + Sync,
 {
-    type Future = BoxedIlpFuture;
-
-    fn handle_request(&mut self, request: IncomingRequest<A>) -> Self::Future {
+    async fn handle_request(&mut self, request: IncomingRequest<A>) -> IlpResult {
         // Only handle the request if the destination address matches the ILP address
         // of the settlement engine being used for this account
         if let Some(settlement_engine_details) = request.from.settlement_engine_details() {
@@ -67,54 +64,75 @@ where
                         .header("Idempotency-Key", idempotency_uuid.clone())
                         .body(message.clone())
                         .send()
+                        .compat() // Wrap to a 0.1 future
                 };
+                // TODO: futures-retry is still not on futures 0.3. As a result, we wrap our action in a
+                // 0.1 future, and then wrap the Retry future in a 0.3 future to use async/await.
 
-                return Box::new(Retry::spawn(ExponentialBackoff::from_millis(10).take(10), action)
-                .map_err(move |error| {
-                    error!("Error sending message to settlement engine: {:?}", error);
-                    RejectBuilder {
-                        code: ErrorCode::T00_INTERNAL_ERROR,
-                        message: b"Error sending message to settlement engine",
-                        data: &[],
-                        triggered_by: Some(&SE_ILP_ADDRESS),
-                    }.build()
-                })
-                .and_then(move |response| {
-                    let status = response.status();
-                    if status.is_success() {
-                        Either::A(response.into_body().concat2().map_err(move |err| {
-                            error!("Error concatenating settlement engine response body: {:?}", err);
+                let response = Retry::spawn(ExponentialBackoff::from_millis(10).take(10), action)
+                    .compat()
+                    .map_err(move |error| {
+                        error!("Error sending message to settlement engine: {:?}", error);
+                        RejectBuilder {
+                            code: ErrorCode::T00_INTERNAL_ERROR,
+                            message: b"Error sending message to settlement engine",
+                            data: &[],
+                            triggered_by: Some(&SE_ILP_ADDRESS),
+                        }
+                        .build()
+                    })
+                    .await?;
+                let status = response.status();
+                if status.is_success() {
+                    let body = response
+                        .bytes()
+                        .map_err(|err| {
+                            error!(
+                                "Error concatenating settlement engine response body: {:?}",
+                                err
+                            );
                             RejectBuilder {
                                 code: ErrorCode::T00_INTERNAL_ERROR,
                                 message: b"Error getting settlement engine response",
                                 data: &[],
                                 triggered_by: Some(&SE_ILP_ADDRESS),
-                            }.build()
+                            }
+                            .build()
                         })
-                        .and_then(|body| {
-                            Ok(FulfillBuilder {
-                                fulfillment: &PEER_FULFILLMENT,
-                                data: body.as_ref(),
-                            }.build())
-                        }))
-                    } else {
-                        error!("Settlement engine rejected message with HTTP error code: {}", response.status());
-                        let code = if status.is_client_error() {
-                            ErrorCode::F00_BAD_REQUEST
-                        } else {
-                            ErrorCode::T00_INTERNAL_ERROR
-                        };
-                        Either::B(err(RejectBuilder {
-                            code,
-                            message: format!("Settlement engine rejected request with error code: {}", response.status()).as_str().as_ref(),
-                            data: &[],
-                            triggered_by: Some(&SE_ILP_ADDRESS),
-                        }.build()))
+                        .await?;
+
+                    return Ok(FulfillBuilder {
+                        fulfillment: &PEER_FULFILLMENT,
+                        data: body.as_ref(),
                     }
-                }));
+                    .build());
+                } else {
+                    error!(
+                        "Settlement engine rejected message with HTTP error code: {}",
+                        response.status()
+                    );
+                    let code = if status.is_client_error() {
+                        ErrorCode::F00_BAD_REQUEST
+                    } else {
+                        ErrorCode::T00_INTERNAL_ERROR
+                    };
+
+                    return Err(RejectBuilder {
+                        code,
+                        message: format!(
+                            "Settlement engine rejected request with error code: {}",
+                            response.status()
+                        )
+                        .as_str()
+                        .as_ref(),
+                        data: &[],
+                        triggered_by: Some(&SE_ILP_ADDRESS),
+                    }
+                    .build());
+                }
             }
         }
-        Box::new(self.next.handle_request(request))
+        self.next.handle_request(request).await
     }
 }
 
@@ -122,18 +140,18 @@ where
 mod tests {
     use super::*;
     use crate::api::fixtures::{BODY, DATA, SERVICE_ADDRESS, TEST_ACCOUNT_0};
-    use crate::api::test_helpers::{block_on, mock_message, test_service};
+    use crate::api::test_helpers::{mock_message, test_service};
     use interledger_packet::{Address, Fulfill, PrepareBuilder, Reject};
     use std::str::FromStr;
     use std::time::SystemTime;
 
-    #[test]
-    fn settlement_ok() {
+    #[tokio::test]
+    async fn settlement_ok() {
         // happy case
         let m = mock_message(200).create();
         let mut settlement = test_service();
-        let fulfill: Fulfill = block_on(
-            settlement.handle_request(IncomingRequest {
+        let fulfill: Fulfill = settlement
+            .handle_request(IncomingRequest {
                 from: TEST_ACCOUNT_0.clone(),
                 prepare: PrepareBuilder {
                     amount: 0,
@@ -143,22 +161,22 @@ mod tests {
                     execution_condition: &[0; 32],
                 }
                 .build(),
-            }),
-        )
-        .unwrap();
+            })
+            .await
+            .unwrap();
 
         m.assert();
         assert_eq!(fulfill.data(), BODY.as_bytes());
         assert_eq!(fulfill.fulfillment(), &[0; 32]);
     }
 
-    #[test]
-    fn gets_forwarded_if_destination_not_engine_() {
+    #[tokio::test]
+    async fn gets_forwarded_if_destination_not_engine_() {
         let m = mock_message(200).create().expect(0);
         let mut settlement = test_service();
         let destination = Address::from_str("example.some.address").unwrap();
-        let reject: Reject = block_on(
-            settlement.handle_request(IncomingRequest {
+        let reject: Reject = settlement
+            .handle_request(IncomingRequest {
                 from: TEST_ACCOUNT_0.clone(),
                 prepare: PrepareBuilder {
                     amount: 0,
@@ -168,9 +186,9 @@ mod tests {
                     execution_condition: &[0; 32],
                 }
                 .build(),
-            }),
-        )
-        .unwrap_err();
+            })
+            .await
+            .unwrap_err();
 
         m.assert();
         assert_eq!(reject.code(), ErrorCode::F02_UNREACHABLE);
@@ -178,14 +196,14 @@ mod tests {
         assert_eq!(reject.message(), b"No other incoming handler!" as &[u8],);
     }
 
-    #[test]
-    fn account_does_not_have_settlement_engine() {
+    #[tokio::test]
+    async fn account_does_not_have_settlement_engine() {
         let m = mock_message(200).create().expect(0);
         let mut settlement = test_service();
         let mut acc = TEST_ACCOUNT_0.clone();
         acc.no_details = true; // Hide the settlement engine data from the account
-        let reject: Reject = block_on(
-            settlement.handle_request(IncomingRequest {
+        let reject: Reject = settlement
+            .handle_request(IncomingRequest {
                 from: acc.clone(),
                 prepare: PrepareBuilder {
                     amount: 0,
@@ -195,9 +213,9 @@ mod tests {
                     execution_condition: &[0; 32],
                 }
                 .build(),
-            }),
-        )
-        .unwrap_err();
+            })
+            .await
+            .unwrap_err();
 
         m.assert();
         assert_eq!(reject.code(), ErrorCode::F02_UNREACHABLE);
@@ -205,15 +223,15 @@ mod tests {
         assert_eq!(reject.message(), b"No other incoming handler!");
     }
 
-    #[test]
-    fn settlement_engine_rejects() {
+    #[tokio::test]
+    async fn settlement_engine_rejects() {
         // for whatever reason the engine rejects our request with a 500 code
         let error_code = 500;
         let error_str = "Internal Server Error";
         let m = mock_message(error_code).create();
         let mut settlement = test_service();
-        let reject: Reject = block_on(
-            settlement.handle_request(IncomingRequest {
+        let reject: Reject = settlement
+            .handle_request(IncomingRequest {
                 from: TEST_ACCOUNT_0.clone(),
                 prepare: PrepareBuilder {
                     amount: 0,
@@ -223,9 +241,9 @@ mod tests {
                     execution_condition: &[0; 32],
                 }
                 .build(),
-            }),
-        )
-        .unwrap_err();
+            })
+            .await
+            .unwrap_err();
 
         m.assert();
         assert_eq!(reject.code(), ErrorCode::T00_INTERNAL_ERROR);

--- a/crates/interledger-settlement/src/api/node_api.rs
+++ b/crates/interledger-settlement/src/api/node_api.rs
@@ -3,16 +3,12 @@ use crate::core::{
     idempotency::*,
     scale_with_precision_loss,
     types::{
-        ApiResponse, LeftoversStore, Quantity, SettlementAccount, SettlementStore,
-        CONVERSION_ERROR_TYPE, NO_ENGINE_CONFIGURED_ERROR_TYPE, SE_ILP_ADDRESS,
+        ApiResponse, ApiResult, LeftoversStore, Quantity, SettlementAccount, SettlementStore,
+        CONVERSION_ERROR_TYPE, SE_ILP_ADDRESS,
     },
 };
-use bytes::buf::FromBuf;
 use bytes::Bytes;
-use futures::{
-    future::{err, result},
-    Future,
-};
+use futures::TryFutureExt;
 use hyper::{Response, StatusCode};
 use interledger_http::error::*;
 use interledger_packet::PrepareBuilder;
@@ -32,6 +28,84 @@ static PEER_PROTOCOL_CONDITION: [u8; 32] = [
     110, 226, 51, 179, 144, 42, 89, 29, 13, 95, 41, 37,
 ];
 
+async fn receive_settlement<S, A>(
+    account_id: String,
+    idempotency_key: Option<String>,
+    quantity: Quantity,
+    store: S,
+) -> Result<impl warp::Reply, Rejection>
+where
+    S: LeftoversStore<AccountId = Uuid, AssetType = BigUint>
+        + SettlementStore<Account = A>
+        + IdempotentStore
+        + AccountStore<Account = A>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    A: SettlementAccount + Account + Send + Sync + 'static,
+{
+    let input = format!("{}{:?}", account_id, quantity);
+    let input_hash = get_hash_of(input.as_ref());
+
+    let idempotency_key_clone = idempotency_key.clone();
+    println!("got settlement idem pey {:?}", idempotency_key.clone());
+    let store_clone = store.clone();
+    let (status_code, message) = make_idempotent_call(
+        store,
+        || do_receive_settlement(store_clone, account_id, quantity, idempotency_key_clone),
+        input_hash,
+        idempotency_key,
+        StatusCode::CREATED,
+        "RECEIVED".into(),
+    )
+    .await?;
+    Ok(Response::builder()
+        .status(status_code)
+        // bytes 04 to 05 compatibility
+        .body(bytes05::Bytes::from(message.to_vec()))
+        .unwrap())
+}
+
+async fn send_message<S, A, O>(
+    account_id: String,
+    idempotency_key: Option<String>,
+    message: bytes05::Bytes,
+    store: S,
+    outgoing_handler: O,
+) -> Result<impl warp::Reply, Rejection>
+where
+    S: LeftoversStore<AccountId = Uuid, AssetType = BigUint>
+        + SettlementStore<Account = A>
+        + IdempotentStore
+        + AccountStore<Account = A>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    O: OutgoingService<A> + Clone + Send + Sync + 'static,
+    A: SettlementAccount + Account + Send + Sync + 'static,
+{
+    let input = format!("{}{:?}", account_id, message);
+    let input_hash = get_hash_of(input.as_ref());
+
+    let store_clone = store.clone();
+    let (status_code, message) = make_idempotent_call(
+        store,
+        || do_send_outgoing_message(store_clone, outgoing_handler, account_id, message.to_vec()),
+        input_hash,
+        idempotency_key,
+        StatusCode::CREATED,
+        "SENT".into(),
+    )
+    .await?;
+    Ok(Response::builder()
+        .status(status_code)
+        // bytes 04 to 05 compatibility
+        .body(bytes05::Bytes::from(message.to_vec()))
+        .unwrap())
+}
+
 pub fn create_settlements_filter<S, O, A>(
     store: S,
     outgoing_handler: O,
@@ -50,94 +124,31 @@ where
 {
     let with_store = warp::any().map(move || store.clone()).boxed();
     let idempotency = warp::header::optional::<String>("idempotency-key");
-    let account_id_filter = warp::path("accounts").and(warp::path::param2::<String>()); // account_id
+    let account_id_filter = warp::path("accounts").and(warp::path::param::<String>()); // account_id
 
     // POST /accounts/:account_id/settlements (optional idempotency-key header)
     // Body is a Quantity object
     let settlement_endpoint = account_id_filter.and(warp::path("settlements"));
-    let settlements = warp::post2()
+    let settlements = warp::post()
         .and(settlement_endpoint)
         .and(warp::path::end())
         .and(idempotency)
         .and(warp::body::json())
         .and(with_store.clone())
-        .and_then(
-            move |account_id: String,
-                  idempotency_key: Option<String>,
-                  quantity: Quantity,
-                  store: S| {
-                let input = format!("{}{:?}", account_id, quantity);
-                let input_hash = get_hash_of(input.as_ref());
-
-                let idempotency_key_clone = idempotency_key.clone();
-                let store_clone = store.clone();
-                let receive_settlement_fn = move || {
-                    do_receive_settlement(store_clone, account_id, quantity, idempotency_key_clone)
-                };
-                make_idempotent_call(
-                    store,
-                    receive_settlement_fn,
-                    input_hash,
-                    idempotency_key,
-                    StatusCode::CREATED,
-                    "RECEIVED".into(),
-                )
-                .map_err::<_, Rejection>(move |err| err.into())
-                .and_then(move |(status_code, message)| {
-                    Ok(Response::builder()
-                        .status(status_code)
-                        .body(message)
-                        .unwrap())
-                })
-            },
-        );
+        .and_then(receive_settlement);
 
     // POST /accounts/:account_id/messages (optional idempotency-key header)
     // Body is a Vec<u8> object
     let with_outgoing_handler = warp::any().map(move || outgoing_handler.clone()).boxed();
     let messages_endpoint = account_id_filter.and(warp::path("messages"));
-    let messages = warp::post2()
+    let messages = warp::post()
         .and(messages_endpoint)
         .and(warp::path::end())
         .and(idempotency)
-        .and(warp::body::concat())
-        .and(with_store.clone())
-        .and(with_outgoing_handler.clone())
-        .and_then(
-            move |account_id: String,
-                  idempotency_key: Option<String>,
-                  body: warp::body::FullBody,
-                  store: S,
-                  outgoing_handler: O| {
-                // Gets called by our settlement engine, forwards the request outwards
-                // until it reaches the peer's settlement engine.
-                let message = Vec::from_buf(body);
-                let input = format!("{}{:?}", account_id, message);
-                let input_hash = get_hash_of(input.as_ref());
-
-                let store_clone = store.clone();
-                // Wrap do_send_outgoing_message in a closure to be invoked by
-                // the idempotency wrapper
-                let send_outgoing_message_fn = move || {
-                    do_send_outgoing_message(store_clone, outgoing_handler, account_id, message)
-                };
-                make_idempotent_call(
-                    store,
-                    send_outgoing_message_fn,
-                    input_hash,
-                    idempotency_key,
-                    StatusCode::CREATED,
-                    "SENT".into(),
-                )
-                .map_err::<_, Rejection>(move |err| err.into())
-                .and_then(move |(status_code, message)| {
-                    Ok(Response::builder()
-                        .status(status_code)
-                        .body(message)
-                        .unwrap())
-                })
-            },
-        );
+        .and(warp::body::bytes())
+        .and(with_store)
+        .and(with_outgoing_handler)
+        .and_then(send_message);
 
     settlements
         .or(messages)
@@ -145,12 +156,12 @@ where
         .boxed()
 }
 
-fn do_receive_settlement<S, A>(
+async fn do_receive_settlement<S, A>(
     store: S,
     account_id: String,
     body: Quantity,
     idempotency_key: Option<String>,
-) -> Box<dyn Future<Item = ApiResponse, Error = ApiError> + Send>
+) -> ApiResult
 where
     S: LeftoversStore<AccountId = Uuid, AssetType = BigUint>
         + SettlementStore<Account = A>
@@ -167,103 +178,107 @@ where
     let engine_scale = body.scale;
 
     // Convert to the desired data types
-    let account_id = match Uuid::from_str(&account_id) {
-        Ok(a) => a,
-        Err(_) => {
-            let error_msg = format!("Unable to parse account id: {}", account_id);
+    let account_id = Uuid::from_str(&account_id).map_err(move |_| {
+        let err = ApiError::invalid_account_id(Some(&account_id));
+        error!("{}", err);
+        err
+    })?;
+
+    let engine_amount = BigUint::from_str(&engine_amount).map_err(|_| {
+        let error_msg = format!("Could not convert amount: {:?}", engine_amount);
+        error!("{}", error_msg);
+        ApiError::from_api_error_type(&CONVERSION_ERROR_TYPE).detail(error_msg)
+    })?;
+
+    let accounts = store
+        .get_accounts(vec![account_id])
+        .map_err(move |_| {
+            let err = ApiError::account_not_found()
+                .detail(format!("Account {} was not found", account_id));
+            error!("{}", err);
+            err
+        })
+        .await?;
+
+    let account = &accounts[0];
+    if account.settlement_engine_details().is_none() {
+        let err = ApiError::account_not_found().detail(format!("Account {} has no settlement engine details configured, cannot send a settlement engine message to that account", accounts[0].id()));
+        error!("{}", err);
+        return Err(err);
+    }
+
+    let account_id = account.id();
+    let asset_scale = account.asset_scale();
+    // Scale to account's scale from the engine's scale
+    // If we're downscaling we might have some precision error which
+    // we must save as leftovers. Upscaling is OK since we're using
+    // biguint's.
+    let (scaled_engine_amount, precision_loss) =
+        scale_with_precision_loss(engine_amount, asset_scale, engine_scale);
+
+    // This will load any leftovers (which are saved in the highest
+    // so far received scale by the engine), will scale them to
+    // the account's asset scale and return them. If there was any
+    // precision loss due to downscaling, it will also update the
+    // leftovers to the new leftovers value
+    let scaled_leftover_amount = store_clone
+        .load_uncredited_settlement_amount(account_id, asset_scale)
+        .map_err(move |_err| {
+            let error_msg = format!(
+                "Error getting uncredited settlement amount for: {}",
+                account.id()
+            );
             error!("{}", error_msg);
-            return Box::new(err(ApiError::invalid_account_id(Some(&account_id))));
-        }
-    };
+            let error_type = ApiErrorType {
+                r#type: &ProblemType::Default,
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                title: "Load uncredited settlement amount error",
+            };
+            ApiError::from_api_error_type(&error_type).detail(error_msg)
+        })
+        .await?;
 
-    let engine_amount = match BigUint::from_str(&engine_amount) {
-        Ok(a) => a,
-        Err(_) => {
-            let error_msg = format!("Could not convert amount: {:?}", engine_amount);
-            error!("{}", error_msg);
-            return Box::new(err(
-                ApiError::from_api_error_type(&CONVERSION_ERROR_TYPE).detail(error_msg)
-            ));
-        }
-    };
+    // add the leftovers to the scaled engine amount
+    let total_amount = scaled_engine_amount.clone() + scaled_leftover_amount;
+    let engine_amount_u64 = total_amount.to_u64().unwrap_or(std::u64::MAX);
 
-    Box::new(
-            store.get_accounts(vec![account_id])
-            .map_err(move |_err| {
-                let err = ApiError::account_not_found().detail(format!("Account {} was not found", account_id));
-                error!("{}", err);
-                err
-            })
-            .and_then(move |accounts| {
-                let account = &accounts[0];
-                if account.settlement_engine_details().is_some() {
-                    Ok(account.clone())
-                } else {
-                    let error_msg = format!("Account {} does not have settlement engine details configured. Cannot handle incoming settlement", account.id());
-                    error!("{}", error_msg);
-                    Err(ApiError::from_api_error_type(&NO_ENGINE_CONFIGURED_ERROR_TYPE).detail(error_msg))
-                }
-            })
-            .and_then(move |account| {
-                let account_id = account.id();
-                let asset_scale = account.asset_scale();
-                // Scale to account's scale from the engine's scale
-                // If we're downscaling we might have some precision error which
-                // we must save as leftovers. Upscaling is OK since we're using
-                // biguint's.
-                let (scaled_engine_amount, precision_loss) = scale_with_precision_loss(engine_amount, asset_scale, engine_scale);
+    let ret = futures::future::join_all(vec![
+        // update the account's balance in the store
+        store.update_balance_for_incoming_settlement(
+            account_id,
+            engine_amount_u64,
+            idempotency_key,
+        ),
+        // save any precision loss that occurred during the
+        // scaling of the engine's amount to the account's scale
+        store.save_uncredited_settlement_amount(account_id, (precision_loss, engine_scale)),
+    ])
+    .await;
 
-                // This will load any leftovers (which are saved in the highest
-                // so far received scale by the engine), will scale them to
-                // the account's asset scale and return them. If there was any
-                // precision loss due to downscaling, it will also update the
-                // leftovers to the new leftovers value
-                store_clone.load_uncredited_settlement_amount(account_id, asset_scale)
-                .map_err(move |_err| {
-                    let error_msg = format!("Error getting uncredited settlement amount for: {}", account.id());
-                    error!("{}", error_msg);
-                    let error_type = ApiErrorType {
-                        r#type: &ProblemType::Default,
-                        status: StatusCode::INTERNAL_SERVER_ERROR,
-                        title: "Load uncredited settlement amount error", 
-                    };
-                    ApiError::from_api_error_type(&error_type).detail(error_msg)
-                })
-                .and_then(move |scaled_leftover_amount| {
-                    // add the leftovers to the scaled engine amount
-                    let total_amount = scaled_engine_amount.clone() + scaled_leftover_amount;
-                    let engine_amount_u64 = total_amount.to_u64().unwrap_or(std::u64::MAX);
+    // if any of the futures errored, then we should propagate that
+    if ret.iter().any(|r| r.is_err()) {
+        let error_msg = format!(
+            "Error updating the balance and leftovers of account: {}",
+            account_id
+        );
+        error!("{}", error_msg);
+        let error_type = ApiErrorType {
+            r#type: &ProblemType::Default,
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            title: "Balance update error",
+        };
+        return Err(ApiError::from_api_error_type(&error_type).detail(error_msg));
+    }
 
-                    futures::future::join_all(vec![
-                        // update the account's balance in the store
-                        store.update_balance_for_incoming_settlement(account_id, engine_amount_u64, idempotency_key),
-                        // save any precision loss that occurred during the
-                        // scaling of the engine's amount to the account's scale
-                        store.save_uncredited_settlement_amount(account_id, (precision_loss, engine_scale))
-                    ])
-                    .map_err(move |_| {
-                        let error_msg = format!("Error updating the balance and leftovers of account: {}", account_id);
-                        error!("{}", error_msg);
-                        let error_type = ApiErrorType {
-                            r#type: &ProblemType::Default,
-                            status: StatusCode::INTERNAL_SERVER_ERROR,
-                            title: "Balance update error"
-                        };
-                        ApiError::from_api_error_type(&error_type).detail(error_msg)
-                    })
-                    .and_then(move |_| {
-                        Ok(ApiResponse::Default)
-                    })
-                })
-            }))
+    Ok(ApiResponse::Default)
 }
 
-fn do_send_outgoing_message<S, O, A>(
+async fn do_send_outgoing_message<S, O, A>(
     store: S,
     mut outgoing_handler: O,
     account_id: String,
     body: Vec<u8>,
-) -> Box<dyn Future<Item = ApiResponse, Error = ApiError> + Send>
+) -> ApiResult
 where
     S: LeftoversStore<AssetType = BigUint>
         + SettlementStore<Account = A>
@@ -276,64 +291,65 @@ where
     O: OutgoingService<A> + Clone + Send + Sync + 'static,
     A: SettlementAccount + Account + Send + Sync + 'static,
 {
-    Box::new(result(Uuid::from_str(&account_id)
-            .map_err(move |_| {
-                let err = ApiError::invalid_account_id(Some(&account_id));
-                error!("{}", err);
-                err
-            }))
-            .and_then(move |account_id| {
-                store.get_accounts(vec![account_id])
-                .map_err(move |_| {
-                    let err = ApiError::account_not_found().detail(format!("Account {} was not found", account_id));
-                    error!("{}", err);
-                    err
-                })
-            })
-            .and_then(|accounts| {
-                let account = &accounts[0];
-                if account.settlement_engine_details().is_some() {
-                    Ok(account.clone())
-                } else {
-                    let err = ApiError::account_not_found().detail(format!("Account {} has no settlement engine details configured, cannot send a settlement engine message to that account", accounts[0].id()));
-                    error!("{}", err);
-                    Err(err)
-                }
-            })
-            .and_then(move |account| {
-                // Send the message to the peer's settlement engine.
-                // Note that we use dummy values for the `from` and `original_amount`
-                // because this `OutgoingRequest` will bypass the router and thus will not
-                // use either of these values. Including dummy values in the rare case where
-                // we do not need them seems easier than using
-                // `Option`s all over the place.
-                outgoing_handler.send_request(OutgoingRequest {
-                    from: account.clone(),
-                    to: account.clone(),
-                    original_amount: 0,
-                    prepare: PrepareBuilder {
-                        destination: SE_ILP_ADDRESS.clone(),
-                        amount: 0,
-                        expires_at: SystemTime::now() + Duration::from_secs(30),
-                        data: &body,
-                        execution_condition: &PEER_PROTOCOL_CONDITION,
-                    }.build()
-                })
-                .map_err(move |reject| {
-                    let error_msg = format!("Error sending message to peer settlement engine. Packet rejected with code: {}, message: {}", reject.code(), str::from_utf8(reject.message()).unwrap_or_default());
-                    let error_type = ApiErrorType {
-                        r#type: &ProblemType::Default,
-                        status: StatusCode::BAD_GATEWAY,
-                        title: "Error sending message to peer engine",
-                    };
-                    error!("{}", error_msg);
-                    ApiError::from_api_error_type(&error_type).detail(error_msg)
-                })
-            })
-            .and_then(move |fulfill| {
-                let data = Bytes::from(fulfill.data());
-                Ok(ApiResponse::Data(data))
-            }))
+    let account_id = Uuid::from_str(&account_id).map_err(move |_| {
+        let err = ApiError::invalid_account_id(Some(&account_id));
+        error!("{}", err);
+        err
+    })?;
+    let accounts = store
+        .get_accounts(vec![account_id])
+        .map_err(move |_| {
+            let err = ApiError::account_not_found()
+                .detail(format!("Account {} was not found", account_id));
+            error!("{}", err);
+            err
+        })
+        .await?;
+
+    let account = &accounts[0];
+    if account.settlement_engine_details().is_none() {
+        let err = ApiError::account_not_found().detail(format!("Account {} has no settlement engine details configured, cannot send a settlement engine message to that account", accounts[0].id()));
+        error!("{}", err);
+        return Err(err);
+    }
+
+    // Send the message to the peer's settlement engine.
+    // Note that we use dummy values for the `from` and `original_amount`
+    // because this `OutgoingRequest` will bypass the router and thus will not
+    // use either of these values. Including dummy values in the rare case where
+    // we do not need them seems easier than using
+    // `Option`s all over the place.
+    match outgoing_handler
+        .send_request(OutgoingRequest {
+            from: account.clone(),
+            to: account.clone(),
+            original_amount: 0,
+            prepare: PrepareBuilder {
+                destination: SE_ILP_ADDRESS.clone(),
+                amount: 0,
+                expires_at: SystemTime::now() + Duration::from_secs(30),
+                data: &body,
+                execution_condition: &PEER_PROTOCOL_CONDITION,
+            }
+            .build(),
+        })
+        .await
+    {
+        Ok(fulfill) => {
+            let data = Bytes::from(fulfill.data());
+            Ok(ApiResponse::Data(data))
+        }
+        Err(reject) => {
+            let error_msg = format!("Error sending message to peer settlement engine. Packet rejected with code: {}, message: {}", reject.code(), str::from_utf8(reject.message()).unwrap_or_default());
+            let error_type = ApiErrorType {
+                r#type: &ProblemType::Default,
+                status: StatusCode::BAD_GATEWAY,
+                title: "Error sending message to peer engine",
+            };
+            error!("{}", error_msg);
+            Err(ApiError::from_api_error_type(&error_type).detail(error_msg))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -343,7 +359,11 @@ mod tests {
     use crate::api::test_helpers::*;
     use serde_json::Value;
 
-    fn check_error_status_and_message(response: Response<Bytes>, status_code: u16, message: &str) {
+    fn check_error_status_and_message(
+        response: Response<bytes05::Bytes>,
+        status_code: u16,
+        message: &str,
+    ) {
         let err: Value = serde_json::from_slice(response.body()).unwrap();
         assert_eq!(response.status().as_u16(), status_code);
         assert_eq!(err.get("status").unwrap(), status_code);
@@ -371,17 +391,18 @@ mod tests {
     // Settlement Tests
     mod settlement_tests {
         use super::*;
+        use bytes05::Bytes;
         use serde_json::json;
 
         const OUR_SCALE: u8 = 11;
 
-        fn settlement_call<F>(
+        async fn settlement_call<F>(
             api: &F,
             id: &str,
             amount: u64,
             scale: u8,
             idempotency_key: Option<&str>,
-        ) -> Response<Bytes>
+        ) -> Response<bytes05::Bytes>
         where
             F: warp::Filter + 'static,
             F::Extract: warp::Reply,
@@ -394,11 +415,11 @@ mod tests {
             if let Some(idempotency_key) = idempotency_key {
                 response = response.header("Idempotency-Key", idempotency_key);
             }
-            response.reply(api)
+            response.reply(api).await
         }
 
-        #[test]
-        fn settlement_ok() {
+        #[tokio::test]
+        async fn settlement_ok() {
             let id = TEST_ACCOUNT_0.clone().id.to_string();
             let store = test_store(false, true);
             let api = test_api(store.clone(), false);
@@ -407,17 +428,17 @@ mod tests {
             // = 9. When
             // we send a settlement with scale OUR_SCALE, the connector should respond
             // with 2 less 0's.
-            let response = settlement_call(&api, &id, 200, OUR_SCALE, Some(IDEMPOTENCY));
+            let response = settlement_call(&api, &id, 200, OUR_SCALE, Some(IDEMPOTENCY)).await;
             assert_eq!(response.body(), &Bytes::from("RECEIVED"));
             assert_eq!(response.status(), StatusCode::CREATED);
 
             // check that it's idempotent
-            let response = settlement_call(&api, &id, 200, OUR_SCALE, Some(IDEMPOTENCY));
+            let response = settlement_call(&api, &id, 200, OUR_SCALE, Some(IDEMPOTENCY)).await;
             assert_eq!(response.body(), &Bytes::from("RECEIVED"));
             assert_eq!(response.status(), StatusCode::CREATED);
 
             // fails with different account id
-            let response = settlement_call(&api, "2", 200, OUR_SCALE, Some(IDEMPOTENCY));
+            let response = settlement_call(&api, "2", 200, OUR_SCALE, Some(IDEMPOTENCY)).await;
             check_error_status_and_message(
                 response,
                 409,
@@ -425,7 +446,7 @@ mod tests {
             );
 
             // fails with different settlement data and account id
-            let response = settlement_call(&api, "2", 42, OUR_SCALE, Some(IDEMPOTENCY));
+            let response = settlement_call(&api, "2", 42, OUR_SCALE, Some(IDEMPOTENCY)).await;
             check_error_status_and_message(
                 response,
                 409,
@@ -433,7 +454,7 @@ mod tests {
             );
 
             // fails with different settlement data and same account id
-            let response = settlement_call(&api, &id, 42, OUR_SCALE, Some(IDEMPOTENCY));
+            let response = settlement_call(&api, &id, 42, OUR_SCALE, Some(IDEMPOTENCY)).await;
             check_error_status_and_message(
                 response,
                 409,
@@ -441,7 +462,7 @@ mod tests {
             );
 
             // works without idempotency key
-            let response = settlement_call(&api, &id, 400, OUR_SCALE, None);
+            let response = settlement_call(&api, &id, 400, OUR_SCALE, None).await;
             assert_eq!(response.body(), &Bytes::from("RECEIVED"));
             assert_eq!(response.status(), StatusCode::CREATED);
 
@@ -452,19 +473,19 @@ mod tests {
             let cache_hits = s.cache_hits.read();
             assert_eq!(*cache_hits, 4);
             assert_eq!(cached_data.status, StatusCode::CREATED);
-            assert_eq!(cached_data.body, &Bytes::from("RECEIVED"));
+            assert_eq!(cached_data.body, &bytes::Bytes::from("RECEIVED"));
         }
 
-        #[test]
+        #[tokio::test]
         // The connector must save the difference each time there's precision
         // loss and try to add it the amount it's being notified to settle for the next time.
-        fn settlement_leftovers() {
+        async fn settlement_leftovers() {
             let id = TEST_ACCOUNT_0.clone().id.to_string();
             let store = test_store(false, true);
             let api = test_api(store.clone(), false);
 
             // Send 205 with scale 11, 2 decimals lost -> 0.05 leftovers
-            let response = settlement_call(&api, &id, 205, 11, None);
+            let response = settlement_call(&api, &id, 205, 11, None).await;
             assert_eq!(response.body(), &Bytes::from("RECEIVED"));
 
             // balance should be 2
@@ -472,75 +493,75 @@ mod tests {
             assert_eq!(
                 store
                     .get_uncredited_settlement_amount(TEST_ACCOUNT_0.id)
-                    .wait()
+                    .await
                     .unwrap(),
                 (BigUint::from(5u32), 11)
             );
 
             // Send 855 with scale 12, 3 decimals lost -> 0.855 leftovers,
-            let response = settlement_call(&api, &id, 855, 12, None);
+            let response = settlement_call(&api, &id, 855, 12, None).await;
             assert_eq!(response.body(), &Bytes::from("RECEIVED"));
             assert_eq!(store.get_balance(TEST_ACCOUNT_0.id), 2);
             // total leftover: 0.905 = 0.05 + 0.855
             assert_eq!(
                 store
                     .get_uncredited_settlement_amount(TEST_ACCOUNT_0.id)
-                    .wait()
+                    .await
                     .unwrap(),
                 (BigUint::from(905u32), 12)
             );
 
             // send 110 with scale 11, 2 decimals lost -> 0.1 leftover
-            let response = settlement_call(&api, &id, 110, 11, None);
+            let response = settlement_call(&api, &id, 110, 11, None).await;
             assert_eq!(response.body(), &Bytes::from("RECEIVED"));
             assert_eq!(store.get_balance(TEST_ACCOUNT_0.id), 3);
             assert_eq!(
                 store
                     .get_uncredited_settlement_amount(TEST_ACCOUNT_0.id)
-                    .wait()
+                    .await
                     .unwrap(),
                 (BigUint::from(1005u32), 12)
             );
 
             // send 5 with scale 9, will consume the leftovers and increase
             // total balance by 6 while updating the rest of the leftovers
-            let response = settlement_call(&api, &id, 5, 9, None);
+            let response = settlement_call(&api, &id, 5, 9, None).await;
             assert_eq!(response.body(), &Bytes::from("RECEIVED"));
             assert_eq!(store.get_balance(TEST_ACCOUNT_0.id), 9);
             assert_eq!(
                 store
                     .get_uncredited_settlement_amount(TEST_ACCOUNT_0.id)
-                    .wait()
+                    .await
                     .unwrap(),
                 (BigUint::from(5u32), 12)
             );
 
             // we send a payment with a smaller scale than the account now
-            let response = settlement_call(&api, &id, 2, 7, None);
+            let response = settlement_call(&api, &id, 2, 7, None).await;
             assert_eq!(response.body(), &Bytes::from("RECEIVED"));
             assert_eq!(store.get_balance(TEST_ACCOUNT_0.id), 209);
             // leftovers are still the same
             assert_eq!(
                 store
                     .get_uncredited_settlement_amount(TEST_ACCOUNT_0.id)
-                    .wait()
+                    .await
                     .unwrap(),
                 (BigUint::from(5u32), 12)
             );
         }
 
-        #[test]
-        fn account_has_no_engine_configured() {
+        #[tokio::test]
+        async fn account_has_no_engine_configured() {
             let id = TEST_ACCOUNT_0.clone().id.to_string();
             let store = test_store(false, false);
             let api = test_api(store.clone(), false);
 
-            let response = settlement_call(&api, &id, 100, 18, Some(IDEMPOTENCY));
-            check_error_status_and_message(response, 404, "Account 00000000-0000-0000-0000-000000000000 does not have settlement engine details configured. Cannot handle incoming settlement");
+            let response = settlement_call(&api, &id, 100, 18, Some(IDEMPOTENCY)).await;
+            check_error_status_and_message(response, 404, "Account 00000000-0000-0000-0000-000000000000 has no settlement engine details configured, cannot send a settlement engine message to that account");
 
             // check that it's idempotent
-            let response = settlement_call(&api, &id, 100, 18, Some(IDEMPOTENCY));
-            check_error_status_and_message(response, 404, "Account 00000000-0000-0000-0000-000000000000 does not have settlement engine details configured. Cannot handle incoming settlement");
+            let response = settlement_call(&api, &id, 100, 18, Some(IDEMPOTENCY)).await;
+            check_error_status_and_message(response, 404, "Account 00000000-0000-0000-0000-000000000000 has no settlement engine details configured, cannot send a settlement engine message to that account");
 
             let s = store.clone();
             let cache = s.cache.read();
@@ -549,34 +570,34 @@ mod tests {
             let cache_hits = s.cache_hits.read();
             assert_eq!(*cache_hits, 1);
             assert_eq!(cached_data.status, 404);
-            assert_eq!(cached_data.body, &Bytes::from("Account 00000000-0000-0000-0000-000000000000 does not have settlement engine details configured. Cannot handle incoming settlement"));
+            assert_eq!(cached_data.body, &bytes::Bytes::from("Account 00000000-0000-0000-0000-000000000000 has no settlement engine details configured, cannot send a settlement engine message to that account"));
         }
 
-        #[test]
-        fn update_balance_for_incoming_settlement_fails() {
+        #[tokio::test]
+        async fn update_balance_for_incoming_settlement_fails() {
             let id = TEST_ACCOUNT_0.clone().id.to_string();
             let store = test_store(true, true);
             let api = test_api(store, false);
-            let response = settlement_call(&api, &id, 100, 18, None);
+            let response = settlement_call(&api, &id, 100, 18, None).await;
             assert_eq!(response.status().as_u16(), 500);
         }
 
-        #[test]
-        fn invalid_account_id() {
+        #[tokio::test]
+        async fn invalid_account_id() {
             // the api is configured to take an accountId type
             // supplying an id that cannot be parsed to that type must fail
             let id = "a".to_string();
             let store = test_store(false, true);
             let api = test_api(store.clone(), false);
 
-            let ret = settlement_call(&api, &id, 100, 18, Some(IDEMPOTENCY));
+            let ret = settlement_call(&api, &id, 100, 18, Some(IDEMPOTENCY)).await;
             check_error_status_and_message(ret, 400, "a is an invalid account ID");
 
             // check that it's idempotent
-            let ret = settlement_call(&api, &id, 100, 18, Some(IDEMPOTENCY));
+            let ret = settlement_call(&api, &id, 100, 18, Some(IDEMPOTENCY)).await;
             check_error_status_and_message(ret, 400, "a is an invalid account ID");
 
-            let _ret = settlement_call(&api, &id, 100, 18, Some(IDEMPOTENCY));
+            let _ret = settlement_call(&api, &id, 100, 18, Some(IDEMPOTENCY)).await;
 
             let s = store.clone();
             let cache = s.cache.read();
@@ -585,23 +606,26 @@ mod tests {
             let cache_hits = s.cache_hits.read();
             assert_eq!(*cache_hits, 2);
             assert_eq!(cached_data.status, 400);
-            assert_eq!(cached_data.body, &Bytes::from("a is an invalid account ID"));
+            assert_eq!(
+                cached_data.body,
+                &bytes::Bytes::from("a is an invalid account ID")
+            );
         }
 
-        #[test]
-        fn account_not_in_store() {
+        #[tokio::test]
+        async fn account_not_in_store() {
             let id = TEST_ACCOUNT_0.clone().id.to_string();
             let store = TestStore::new(vec![], false);
             let api = test_api(store.clone(), false);
 
-            let ret = settlement_call(&api, &id, 100, 18, Some(IDEMPOTENCY));
+            let ret = settlement_call(&api, &id, 100, 18, Some(IDEMPOTENCY)).await;
             check_error_status_and_message(
                 ret,
                 404,
                 "Account 00000000-0000-0000-0000-000000000000 was not found",
             );
 
-            let ret = settlement_call(&api, &id, 100, 18, Some(IDEMPOTENCY));
+            let ret = settlement_call(&api, &id, 100, 18, Some(IDEMPOTENCY)).await;
             check_error_status_and_message(
                 ret,
                 404,
@@ -616,20 +640,21 @@ mod tests {
             assert_eq!(cached_data.status, 404);
             assert_eq!(
                 cached_data.body,
-                &Bytes::from("Account 00000000-0000-0000-0000-000000000000 was not found")
+                &bytes::Bytes::from("Account 00000000-0000-0000-0000-000000000000 was not found")
             );
         }
     }
 
     mod message_tests {
         use super::*;
+        use bytes05::Bytes;
 
-        fn messages_call<F>(
+        async fn messages_call<F>(
             api: &F,
             id: &str,
             message: &[u8],
             idempotency_key: Option<&str>,
-        ) -> Response<Bytes>
+        ) -> Response<bytes05::Bytes>
         where
             F: warp::Filter + 'static,
             F::Extract: warp::Reply,
@@ -642,26 +667,26 @@ mod tests {
             if let Some(idempotency_key) = idempotency_key {
                 response = response.header("Idempotency-Key", idempotency_key);
             }
-            response.reply(api)
+            response.reply(api).await
         }
 
-        #[test]
-        fn message_ok() {
+        #[tokio::test]
+        async fn message_ok() {
             let id = TEST_ACCOUNT_0.clone().id.to_string();
             let store = test_store(false, true);
             let api = test_api(store.clone(), true);
 
-            let ret = messages_call(&api, &id, &[], Some(IDEMPOTENCY));
+            let ret = messages_call(&api, &id, &[], Some(IDEMPOTENCY)).await;
             assert_eq!(ret.status(), StatusCode::CREATED);
             assert_eq!(ret.body(), &Bytes::from("hello!"));
 
-            let ret = messages_call(&api, &id, &[], Some(IDEMPOTENCY));
+            let ret = messages_call(&api, &id, &[], Some(IDEMPOTENCY)).await;
             assert_eq!(ret.status(), StatusCode::CREATED);
             assert_eq!(ret.body(), &Bytes::from("hello!"));
 
             // Using the same idempotency key with different arguments MUST
             // fail.
-            let ret = messages_call(&api, "1", &[], Some(IDEMPOTENCY));
+            let ret = messages_call(&api, "1", &[], Some(IDEMPOTENCY)).await;
             check_error_status_and_message(
                 ret,
                 409,
@@ -670,7 +695,7 @@ mod tests {
 
             let data = [0, 1, 2];
             // fails with different account id and data
-            let ret = messages_call(&api, "1", &data[..], Some(IDEMPOTENCY));
+            let ret = messages_call(&api, "1", &data[..], Some(IDEMPOTENCY)).await;
             check_error_status_and_message(
                 ret,
                 409,
@@ -678,7 +703,7 @@ mod tests {
             );
 
             // fails for same account id but different data
-            let ret = messages_call(&api, &id, &data[..], Some(IDEMPOTENCY));
+            let ret = messages_call(&api, &id, &data[..], Some(IDEMPOTENCY)).await;
             check_error_status_and_message(
                 ret,
                 409,
@@ -691,19 +716,19 @@ mod tests {
             let cache_hits = s.cache_hits.read();
             assert_eq!(*cache_hits, 4);
             assert_eq!(cached_data.status, StatusCode::CREATED);
-            assert_eq!(cached_data.body, &Bytes::from("hello!"));
+            assert_eq!(cached_data.body, &bytes::Bytes::from("hello!"));
         }
 
-        #[test]
-        fn message_gets_rejected() {
+        #[tokio::test]
+        async fn message_gets_rejected() {
             let id = TEST_ACCOUNT_0.clone().id.to_string();
             let store = test_store(false, true);
             let api = test_api(store.clone(), false);
 
-            let ret = messages_call(&api, &id, &[], Some(IDEMPOTENCY));
+            let ret = messages_call(&api, &id, &[], Some(IDEMPOTENCY)).await;
             check_error_status_and_message(ret, 502, "Error sending message to peer settlement engine. Packet rejected with code: F02, message: No other outgoing handler!");
 
-            let ret = messages_call(&api, &id, &[], Some(IDEMPOTENCY));
+            let ret = messages_call(&api, &id, &[], Some(IDEMPOTENCY)).await;
             check_error_status_and_message(ret, 502, "Error sending message to peer settlement engine. Packet rejected with code: F02, message: No other outgoing handler!");
 
             let s = store.clone();
@@ -712,24 +737,24 @@ mod tests {
             let cache_hits = s.cache_hits.read();
             assert_eq!(*cache_hits, 1);
             assert_eq!(cached_data.status, 502);
-            assert_eq!(cached_data.body, &Bytes::from("Error sending message to peer settlement engine. Packet rejected with code: F02, message: No other outgoing handler!"));
+            assert_eq!(cached_data.body, &bytes::Bytes::from("Error sending message to peer settlement engine. Packet rejected with code: F02, message: No other outgoing handler!"));
         }
 
-        #[test]
-        fn invalid_account_id() {
+        #[tokio::test]
+        async fn invalid_account_id() {
             // the api is configured to take an accountId type
             // supplying an id that cannot be parsed to that type must fail
             let id = "a".to_string();
             let store = test_store(false, true);
             let api = test_api(store.clone(), true);
 
-            let ret = messages_call(&api, &id, &[], Some(IDEMPOTENCY));
+            let ret = messages_call(&api, &id, &[], Some(IDEMPOTENCY)).await;
             check_error_status_and_message(ret, 400, "a is an invalid account ID");
 
-            let ret = messages_call(&api, &id, &[], Some(IDEMPOTENCY));
+            let ret = messages_call(&api, &id, &[], Some(IDEMPOTENCY)).await;
             check_error_status_and_message(ret, 400, "a is an invalid account ID");
 
-            let ret = messages_call(&api, &id, &[], Some(IDEMPOTENCY));
+            let ret = messages_call(&api, &id, &[], Some(IDEMPOTENCY)).await;
             check_error_status_and_message(ret, 400, "a is an invalid account ID");
 
             let s = store.clone();
@@ -739,23 +764,26 @@ mod tests {
             let cache_hits = s.cache_hits.read();
             assert_eq!(*cache_hits, 2);
             assert_eq!(cached_data.status, 400);
-            assert_eq!(cached_data.body, &Bytes::from("a is an invalid account ID"));
+            assert_eq!(
+                cached_data.body,
+                &bytes::Bytes::from("a is an invalid account ID")
+            );
         }
 
-        #[test]
-        fn account_not_in_store() {
+        #[tokio::test]
+        async fn account_not_in_store() {
             let id = TEST_ACCOUNT_0.clone().id.to_string();
             let store = TestStore::new(vec![], false);
             let api = test_api(store.clone(), true);
 
-            let ret = messages_call(&api, &id, &[], Some(IDEMPOTENCY));
+            let ret = messages_call(&api, &id, &[], Some(IDEMPOTENCY)).await;
             check_error_status_and_message(
                 ret,
                 404,
                 "Account 00000000-0000-0000-0000-000000000000 was not found",
             );
 
-            let ret = messages_call(&api, &id, &[], Some(IDEMPOTENCY));
+            let ret = messages_call(&api, &id, &[], Some(IDEMPOTENCY)).await;
             check_error_status_and_message(
                 ret,
                 404,
@@ -771,7 +799,7 @@ mod tests {
             assert_eq!(cached_data.status, 404);
             assert_eq!(
                 cached_data.body,
-                &Bytes::from("Account 00000000-0000-0000-0000-000000000000 was not found")
+                &bytes::Bytes::from("Account 00000000-0000-0000-0000-000000000000 was not found")
             );
         }
     }

--- a/crates/interledger-settlement/src/api/node_api.rs
+++ b/crates/interledger-settlement/src/api/node_api.rs
@@ -49,7 +49,6 @@ where
     let input_hash = get_hash_of(input.as_ref());
 
     let idempotency_key_clone = idempotency_key.clone();
-    println!("got settlement idem pey {:?}", idempotency_key.clone());
     let store_clone = store.clone();
     let (status_code, message) = make_idempotent_call(
         store,

--- a/crates/interledger-settlement/src/core/backends_common/redis/mod.rs
+++ b/crates/interledger-settlement/src/core/backends_common/redis/mod.rs
@@ -4,17 +4,19 @@ use crate::core::{
     types::{Convert, ConvertDetails, LeftoversStore},
 };
 use bytes::Bytes;
-use futures::{future::result, Future};
+use futures::TryFutureExt;
 use http::StatusCode;
 use num_bigint::BigUint;
 use redis_crate::{
-    self, aio::SharedConnection, cmd, Client, ConnectionInfo, ErrorKind, FromRedisValue,
-    PipelineCommands, RedisError, RedisWrite, ToRedisArgs, Value,
+    self, aio::MultiplexedConnection, AsyncCommands, Client, ConnectionInfo, ErrorKind,
+    FromRedisValue, RedisError, RedisWrite, ToRedisArgs, Value,
 };
-use std::collections::HashMap as SlowHashMap;
+use std::collections::HashMap;
 use std::str::FromStr;
 
 use log::{debug, error, trace};
+
+use async_trait::async_trait;
 
 #[cfg(test)]
 mod test_helpers;
@@ -33,16 +35,22 @@ impl EngineRedisStoreBuilder {
         EngineRedisStoreBuilder { redis_url }
     }
 
-    pub fn connect(&self) -> impl Future<Item = EngineRedisStore, Error = ()> {
-        result(Client::open(self.redis_url.clone()))
-            .map_err(|err| error!("Error creating Redis client: {:?}", err))
-            .and_then(|client| {
-                debug!("Connected to redis: {:?}", client);
-                client
-                    .get_shared_async_connection()
-                    .map_err(|err| error!("Error connecting to Redis: {:?}", err))
-            })
-            .and_then(move |connection| Ok(EngineRedisStore { connection }))
+    pub async fn connect(&self) -> Result<EngineRedisStore, ()> {
+        let client = match Client::open(self.redis_url.clone()) {
+            Ok(c) => c,
+            Err(err) => {
+                error!("Error creating Redis client: {:?}", err);
+                return Err(());
+            }
+        };
+
+        let connection = client
+            .get_multiplexed_tokio_connection()
+            .map_err(|err| error!("Error connecting to Redis: {:?}", err))
+            .await?;
+        debug!("Connected to redis: {:?}", client);
+
+        Ok(EngineRedisStore { connection })
     }
 }
 
@@ -52,56 +60,54 @@ impl EngineRedisStoreBuilder {
 /// composed in the stores of other Settlement Engines.
 #[derive(Clone)]
 pub struct EngineRedisStore {
-    pub connection: SharedConnection,
+    pub connection: MultiplexedConnection,
 }
 
+#[async_trait]
 impl IdempotentStore for EngineRedisStore {
-    fn load_idempotent_data(
+    async fn load_idempotent_data(
         &self,
         idempotency_key: String,
-    ) -> Box<dyn Future<Item = Option<IdempotentData>, Error = ()> + Send> {
+    ) -> Result<Option<IdempotentData>, ()> {
         let idempotency_key_clone = idempotency_key.clone();
-        Box::new(
-            cmd("HGETALL")
-                .arg(idempotency_key.clone())
-                .query_async(self.connection.clone())
-                .map_err(move |err| {
-                    error!(
-                        "Error loading idempotency key {}: {:?}",
-                        idempotency_key_clone, err
-                    )
-                })
-                .and_then(
-                    move |(_connection, ret): (_, SlowHashMap<String, String>)| {
-                        if let (Some(status_code), Some(data), Some(input_hash_slice)) = (
-                            ret.get("status_code"),
-                            ret.get("data"),
-                            ret.get("input_hash"),
-                        ) {
-                            trace!("Loaded idempotency key {:?} - {:?}", idempotency_key, ret);
-                            let mut input_hash: [u8; 32] = Default::default();
-                            input_hash.copy_from_slice(input_hash_slice.as_ref());
-                            Ok(Some(IdempotentData::new(
-                                StatusCode::from_str(status_code).unwrap(),
-                                Bytes::from(data.clone()),
-                                input_hash,
-                            )))
-                        } else {
-                            Ok(None)
-                        }
-                    },
-                ),
-        )
+        let mut connection = self.connection.clone();
+        let ret: HashMap<String, String> = connection
+            .hgetall(idempotency_key.clone())
+            .map_err(move |err| {
+                error!(
+                    "Error loading idempotency key {}: {:?}",
+                    idempotency_key_clone, err
+                )
+            })
+            .await?;
+
+        if let (Some(status_code), Some(data), Some(input_hash_slice)) = (
+            ret.get("status_code"),
+            ret.get("data"),
+            ret.get("input_hash"),
+        ) {
+            trace!("Loaded idempotency key {:?} - {:?}", idempotency_key, ret);
+            let mut input_hash: [u8; 32] = Default::default();
+            input_hash.copy_from_slice(input_hash_slice.as_ref());
+            Ok(Some(IdempotentData::new(
+                StatusCode::from_str(status_code).unwrap(),
+                Bytes::from(data.clone()),
+                input_hash,
+            )))
+        } else {
+            Ok(None)
+        }
     }
 
-    fn save_idempotent_data(
+    async fn save_idempotent_data(
         &self,
         idempotency_key: String,
         input_hash: [u8; 32],
         status_code: StatusCode,
         data: Bytes,
-    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+    ) -> Result<(), ()> {
         let mut pipe = redis_crate::pipe();
+        let mut connection = self.connection.clone();
         pipe.atomic()
             .cmd("HMSET") // cannot use hset_multiple since data and status_code have different types
             .arg(&idempotency_key)
@@ -114,19 +120,16 @@ impl IdempotentStore for EngineRedisStore {
             .ignore()
             .expire(&idempotency_key, 86400)
             .ignore();
-        Box::new(
-            pipe.query_async(self.connection.clone())
-                .map_err(|err| error!("Error caching: {:?}", err))
-                .and_then(move |(_connection, _): (_, Vec<String>)| {
-                    trace!(
-                        "Cached {:?}: {:?}, {:?}",
-                        idempotency_key,
-                        status_code,
-                        data,
-                    );
-                    Ok(())
-                }),
-        )
+        pipe.query_async(&mut connection)
+            .map_err(|err| error!("Error caching: {:?}", err))
+            .await?;
+        trace!(
+            "Cached {:?}: {:?}, {:?}",
+            idempotency_key,
+            status_code,
+            data,
+        );
+        Ok(())
     }
 }
 
@@ -216,151 +219,138 @@ impl FromRedisValue for AmountWithScale {
     }
 }
 
+#[async_trait]
 impl LeftoversStore for EngineRedisStore {
     type AccountId = String;
     type AssetType = BigUint;
 
-    fn get_uncredited_settlement_amount(
+    async fn get_uncredited_settlement_amount(
         &self,
         account_id: Self::AccountId,
-    ) -> Box<dyn Future<Item = (Self::AssetType, u8), Error = ()> + Send> {
-        Box::new(
-            cmd("LRANGE")
-                .arg(uncredited_amount_key(&account_id))
-                .arg(0)
-                .arg(-1)
-                .query_async(self.connection.clone())
-                .map_err(move |err| error!("Error getting uncredited_settlement_amount {:?}", err))
-                .and_then(move |(_, amount): (_, AmountWithScale)| Ok((amount.num, amount.scale))),
-        )
+    ) -> Result<(Self::AssetType, u8), ()> {
+        let mut connection = self.connection.clone();
+        let amount: AmountWithScale = connection
+            .lrange(uncredited_amount_key(&account_id), 0, -1)
+            .map_err(move |err| error!("Error getting uncredited_settlement_amount {:?}", err))
+            .await?;
+        Ok((amount.num, amount.scale))
     }
 
-    fn save_uncredited_settlement_amount(
+    async fn save_uncredited_settlement_amount(
         &self,
         account_id: Self::AccountId,
         uncredited_settlement_amount: (Self::AssetType, u8),
-    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+    ) -> Result<(), ()> {
         trace!(
             "Saving uncredited_settlement_amount {:?} {:?}",
             account_id,
             uncredited_settlement_amount
         );
-        Box::new(
-            // We store these amounts as lists of strings
-            // because we cannot do BigNumber arithmetic in the store
-            // When loading the amounts, we convert them to the appropriate data
-            // type and sum them up.
-            cmd("RPUSH")
-                .arg(uncredited_amount_key(&account_id))
-                .arg(AmountWithScale {
+        // We store these amounts as lists of strings
+        // because we cannot do BigNumber arithmetic in the store
+        // When loading the amounts, we convert them to the appropriate data
+        // type and sum them up.
+        let mut connection = self.connection.clone();
+        connection
+            .rpush(
+                uncredited_amount_key(&account_id),
+                AmountWithScale {
                     num: uncredited_settlement_amount.0,
                     scale: uncredited_settlement_amount.1,
-                })
-                .query_async(self.connection.clone())
-                .map_err(move |err| error!("Error saving uncredited_settlement_amount: {:?}", err))
-                .and_then(move |(_conn, _ret): (_, Value)| Ok(())),
-        )
+                },
+            )
+            .map_err(move |err| error!("Error saving uncredited_settlement_amount: {:?}", err))
+            .await?;
+
+        Ok(())
     }
 
-    fn load_uncredited_settlement_amount(
+    async fn load_uncredited_settlement_amount(
         &self,
         account_id: Self::AccountId,
         local_scale: u8,
-    ) -> Box<dyn Future<Item = Self::AssetType, Error = ()> + Send> {
+    ) -> Result<Self::AssetType, ()> {
         let connection = self.connection.clone();
         trace!("Loading uncredited_settlement_amount {:?}", account_id);
-        Box::new(
-            self.get_uncredited_settlement_amount(account_id.clone())
-                .and_then(move |amount| {
-                    // scale the amount from the max scale to the local scale, and then
-                    // save any potential leftovers to the store
-                    let (scaled_amount, precision_loss) =
-                        scale_with_precision_loss(amount.0, local_scale, amount.1);
-                    let mut pipe = redis_crate::pipe();
-                    pipe.atomic();
-                    pipe.del(uncredited_amount_key(&account_id)).ignore();
-                    pipe.rpush(
-                        uncredited_amount_key(&account_id),
-                        AmountWithScale {
-                            num: precision_loss,
-                            scale: std::cmp::max(local_scale, amount.1),
-                        },
-                    )
-                    .ignore();
+        let amount = self
+            .get_uncredited_settlement_amount(account_id.clone())
+            .await?;
+        // scale the amount from the max scale to the local scale, and then
+        // save any potential leftovers to the store
+        let (scaled_amount, precision_loss) =
+            scale_with_precision_loss(amount.0, local_scale, amount.1);
 
-                    pipe.query_async(connection.clone())
-                        .map_err(move |err| {
-                            error!("Error saving uncredited_settlement_amount: {:?}", err)
-                        })
-                        .and_then(move |(_conn, _ret): (_, Value)| Ok(scaled_amount))
-                }),
+        let mut pipe = redis_crate::pipe();
+        pipe.atomic();
+        pipe.del(uncredited_amount_key(&account_id)).ignore();
+        pipe.rpush(
+            uncredited_amount_key(&account_id),
+            AmountWithScale {
+                num: precision_loss,
+                scale: std::cmp::max(local_scale, amount.1),
+            },
         )
+        .ignore();
+
+        pipe.query_async(&mut connection.clone())
+            .map_err(move |err| error!("Error saving uncredited_settlement_amount: {:?}", err))
+            .await?;
+
+        Ok(scaled_amount)
     }
 
-    fn clear_uncredited_settlement_amount(
+    async fn clear_uncredited_settlement_amount(
         &self,
         account_id: Self::AccountId,
-    ) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+    ) -> Result<(), ()> {
         trace!("Clearing uncredited_settlement_amount {:?}", account_id,);
-        Box::new(
-            cmd("DEL")
-                .arg(uncredited_amount_key(&account_id))
-                .query_async(self.connection.clone())
-                .map_err(move |err| {
-                    error!("Error clearing uncredited_settlement_amount: {:?}", err)
-                })
-                .and_then(move |(_conn, _ret): (_, Value)| Ok(())),
-        )
+        let mut connection = self.connection.clone();
+        connection
+            .del(uncredited_amount_key(&account_id))
+            .map_err(move |err| error!("Error clearing uncredited_settlement_amount: {:?}", err))
+            .await?;
+
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use test_helpers::{block_on, test_store, IDEMPOTENCY_KEY};
+    use test_helpers::{test_store, IDEMPOTENCY_KEY};
 
     mod idempotency {
         use super::*;
 
-        #[test]
-        fn saves_and_loads_idempotency_key_data_properly() {
-            block_on(test_store().and_then(|(store, context)| {
-                let input_hash: [u8; 32] = Default::default();
-                store
-                    .save_idempotent_data(
-                        IDEMPOTENCY_KEY.clone(),
-                        input_hash,
-                        StatusCode::OK,
-                        Bytes::from("TEST"),
-                    )
-                    .map_err(|err| eprintln!("Redis error: {:?}", err))
-                    .and_then(move |_| {
-                        store
-                            .load_idempotent_data(IDEMPOTENCY_KEY.clone())
-                            .map_err(|err| eprintln!("Redis error: {:?}", err))
-                            .and_then(move |data1| {
-                                assert_eq!(
-                                    data1.unwrap(),
-                                    IdempotentData::new(
-                                        StatusCode::OK,
-                                        Bytes::from("TEST"),
-                                        input_hash
-                                    )
-                                );
-                                let _ = context;
+        #[tokio::test]
+        async fn saves_and_loads_idempotency_key_data_properly() {
+            // The context must be loaded into scope
+            let (store, _context) = test_store().await.unwrap();
+            let input_hash: [u8; 32] = Default::default();
+            store
+                .save_idempotent_data(
+                    IDEMPOTENCY_KEY.clone(),
+                    input_hash,
+                    StatusCode::OK,
+                    Bytes::from("TEST"),
+                )
+                .await
+                .unwrap();
 
-                                store
-                                    .load_idempotent_data("asdf".to_string())
-                                    .map_err(|err| eprintln!("Redis error: {:?}", err))
-                                    .and_then(move |data2| {
-                                        assert!(data2.is_none());
-                                        let _ = context;
-                                        Ok(())
-                                    })
-                            })
-                    })
-            }))
-            .unwrap()
+            let data1 = store
+                .load_idempotent_data(IDEMPOTENCY_KEY.clone())
+                .await
+                .unwrap();
+            assert_eq!(
+                data1.unwrap(),
+                IdempotentData::new(StatusCode::OK, Bytes::from("TEST"), input_hash)
+            );
+
+            let data2 = store
+                .load_idempotent_data("asdf".to_string())
+                .await
+                .unwrap();
+            assert!(data2.is_none());
         }
     }
 }

--- a/crates/interledger-settlement/src/core/backends_common/redis/test_helpers/mod.rs
+++ b/crates/interledger-settlement/src/core/backends_common/redis/test_helpers/mod.rs
@@ -3,4 +3,4 @@ mod redis_helpers;
 #[cfg(test)]
 mod store_helpers;
 #[cfg(test)]
-pub use store_helpers::{block_on, test_store, IDEMPOTENCY_KEY};
+pub use store_helpers::{test_store, IDEMPOTENCY_KEY};

--- a/crates/interledger-settlement/src/core/backends_common/redis/test_helpers/store_helpers.rs
+++ b/crates/interledger-settlement/src/core/backends_common/redis/test_helpers/store_helpers.rs
@@ -1,31 +1,16 @@
 use super::redis_helpers::TestContext;
 use crate::core::backends_common::redis::{EngineRedisStore, EngineRedisStoreBuilder};
 
-use env_logger;
-use futures::Future;
-use tokio::runtime::Runtime;
-
 use lazy_static::lazy_static;
 
 lazy_static! {
     pub static ref IDEMPOTENCY_KEY: String = String::from("abcd");
 }
 
-pub fn test_store() -> impl Future<Item = (EngineRedisStore, TestContext), Error = ()> {
+pub async fn test_store() -> Result<(EngineRedisStore, TestContext), ()> {
     let context = TestContext::new();
-    EngineRedisStoreBuilder::new(context.get_client_connection_info())
+    let store = EngineRedisStoreBuilder::new(context.get_client_connection_info())
         .connect()
-        .and_then(|store| Ok((store, context)))
-}
-
-pub fn block_on<F>(f: F) -> Result<F::Item, F::Error>
-where
-    F: Future + Send + 'static,
-    F::Item: Send,
-    F::Error: Send,
-{
-    // Only run one test at a time
-    let _ = env_logger::try_init();
-    let mut runtime = Runtime::new().unwrap();
-    runtime.block_on(f)
+        .await?;
+    Ok((store, context))
 }

--- a/crates/interledger-settlement/src/core/idempotency.rs
+++ b/crates/interledger-settlement/src/core/idempotency.rs
@@ -1,10 +1,8 @@
-use super::types::ApiResponse;
+use super::types::{ApiResponse, ApiResult};
+use async_trait::async_trait;
 use bytes::Bytes;
-use futures::executor::spawn;
-use futures::{
-    future::{err, ok, Either},
-    Future,
-};
+use futures::Future;
+use futures::TryFutureExt;
 use http::StatusCode;
 use interledger_http::error::*;
 use log::error;
@@ -26,64 +24,65 @@ impl IdempotentData {
     }
 }
 
+#[async_trait]
 pub trait IdempotentStore {
     /// Returns the API response that was saved when the idempotency key was used
     /// Also returns a hash of the input data which resulted in the response
-    fn load_idempotent_data(
+    async fn load_idempotent_data(
         &self,
         idempotency_key: String,
-    ) -> Box<dyn Future<Item = Option<IdempotentData>, Error = ()> + Send>;
+    ) -> Result<Option<IdempotentData>, ()>;
 
     /// Saves the data that was passed along with the api request for later
     /// The store MUST also save a hash of the input, so that it errors out on requests
-    fn save_idempotent_data(
+    async fn save_idempotent_data(
         &self,
         idempotency_key: String,
         input_hash: [u8; 32],
         status_code: StatusCode,
         data: Bytes,
-    ) -> Box<dyn Future<Item = (), Error = ()> + Send>;
+    ) -> Result<(), ()>;
 }
 
 // Helper function that returns any idempotent data that corresponds to a
 // provided idempotency key. It fails if the hash of the input that
 // generated the idempotent data does not match the hash of the provided input.
-fn check_idempotency<S>(
+async fn check_idempotency<S>(
     store: S,
     idempotency_key: String,
     input_hash: [u8; 32],
-) -> impl Future<Item = Option<(StatusCode, Bytes)>, Error = ApiError>
+) -> Result<Option<(StatusCode, Bytes)>, ApiError>
 where
     S: IdempotentStore + Clone + Send + Sync + 'static,
 {
-    store
+    let ret: Option<IdempotentData> = store
         .load_idempotent_data(idempotency_key.clone())
         .map_err(move |_| IDEMPOTENT_STORE_CALL_ERROR.clone())
-        .and_then(move |ret: Option<IdempotentData>| {
-            if let Some(ret) = ret {
-                // Check if the hash (ret.2) of the loaded idempotent data matches the hash
-                // of the provided input data. If not, we should error out since
-                // the caller provided an idempotency key that was used for a
-                // different input.
-                if ret.input_hash == input_hash {
-                    Ok(Some((ret.status, ret.body)))
-                } else {
-                    Ok(Some((
-                        StatusCode::from_u16(409).unwrap(),
-                        Bytes::from(IDEMPOTENCY_CONFLICT_ERR),
-                    )))
-                }
-            } else {
-                Ok(None)
-            }
-        })
+        .await?;
+
+    if let Some(ret) = ret {
+        // Check if the hash (ret.2) of the loaded idempotent data matches the hash
+        // of the provided input data. If not, we should error out since
+        // the caller provided an idempotency key that was used for a
+        // different input.
+        if ret.input_hash == input_hash {
+            Ok(Some((ret.status, ret.body)))
+        } else {
+            Ok(Some((
+                StatusCode::from_u16(409).unwrap(),
+                Bytes::from(IDEMPOTENCY_CONFLICT_ERR),
+            )))
+        }
+    } else {
+        Ok(None)
+    }
 }
 
 // make_idempotent_call takes a function instead of direct arguments so that we
 // can reuse it for both the messages and the settlements calls
-pub fn make_idempotent_call<S, F>(
+pub async fn make_idempotent_call<S, F>(
     store: S,
-    non_idempotent_function: F,
+    non_idempotent_function: impl FnOnce() -> F,
     input_hash: [u8; 32],
     idempotency_key: Option<String>,
     // As per the spec, the success status code is independent of the
@@ -91,88 +90,78 @@ pub fn make_idempotent_call<S, F>(
     status_code: StatusCode,
     // The default value is used when the engine returns a default return type
     default_return_value: Bytes,
-) -> impl Future<Item = (StatusCode, Bytes), Error = ApiError>
+) -> Result<(StatusCode, Bytes), ApiError>
 where
-    F: FnOnce() -> Box<dyn Future<Item = ApiResponse, Error = ApiError> + Send>,
+    F: Future<Output = ApiResult>,
     S: IdempotentStore + Clone + Send + Sync + 'static,
 {
     if let Some(idempotency_key) = idempotency_key {
         // If there an idempotency key was provided, check idempotency
-        // and the key was not present or conflicting with an existing
-        // key, perform the call and save the idempotent return data
-        Either::A(
-            check_idempotency(store.clone(), idempotency_key.clone(), input_hash).and_then(
-                move |ret: Option<(StatusCode, Bytes)>| {
-                    if let Some(ret) = ret {
-                        if ret.0.is_success() {
-                            Either::A(Either::A(ok((ret.0, ret.1))))
-                        } else {
-                            let err_msg = ApiErrorType {
-                                r#type: &ProblemType::Default,
-                                status: ret.0,
-                                title: "Idempotency Error",
-                            };
-                            // if check_idempotency returns an error, then it
-                            // has to be an idempotency error
-                            let ret_error = ApiError::from_api_error_type(&err_msg)
-                                .detail(String::from_utf8_lossy(&ret.1).to_string());
-                            Either::A(Either::B(err(ret_error)))
+        match check_idempotency(store.clone(), idempotency_key.clone(), input_hash).await? {
+            Some(ret) => {
+                if ret.0.is_success() {
+                    // Return an OK response if the idempotent call was successful
+                    Ok((ret.0, ret.1))
+                } else {
+                    // Return an HTTP Error otherwise
+                    let err_msg = ApiErrorType {
+                        r#type: &ProblemType::Default,
+                        status: ret.0,
+                        title: "Idempotency Error",
+                    };
+                    // if check_idempotency returns an error, then it
+                    // has to be an idempotency error
+                    let ret_error = ApiError::from_api_error_type(&err_msg)
+                        .detail(String::from_utf8_lossy(&ret.1).to_string());
+                    Err(ret_error)
+                }
+            }
+            None => {
+                // If there was no previous entry, make the idempotent call and save it
+                // Note: The error is also saved idempotently
+                let ret = match non_idempotent_function().await {
+                    Ok(r) => r,
+                    Err(ret) => {
+                        let status_code = ret.status;
+                        let data = Bytes::from(ret.detail.clone().unwrap_or_default());
+                        if store
+                            .save_idempotent_data(idempotency_key, input_hash, status_code, data)
+                            .await
+                            .is_err()
+                        {
+                            // Should we be panicking here instead?
+                            error!("Failed to connect to the store! The request will not be idempotent if retried.")
                         }
-                    } else {
-                        Either::B(
-                            non_idempotent_function().map_err({
-                                let store = store.clone();
-                                let idempotency_key = idempotency_key.clone();
-                                move |ret: ApiError| {
-                                    let status_code = ret.status;
-                                    let data = Bytes::from(ret.detail.clone().unwrap_or_default());
-                                    spawn(store.save_idempotent_data(
-                                        idempotency_key,
-                                        input_hash,
-                                        status_code,
-                                        data,
-                                    ).map_err(move |_| error!("Failed to connect to the store! The request will not be idempotent if retried.")));
-                                    ret
-                                }})
-                            .map(move |ret| {
-                                let data = match ret {
-                                    ApiResponse::Default => default_return_value,
-                                    ApiResponse::Data(d) => d,
-                                };
-                                (status_code, data)
-                            }).and_then(
-                                move |ret: (StatusCode, Bytes)| {
-                                    store
-                                        .save_idempotent_data(
-                                            idempotency_key,
-                                            input_hash,
-                                            ret.0,
-                                            ret.1.clone(),
-                                        )
-                                        .map_err(move |_| {
-                                            error!("Failed to connect to the store! The request will not be idempotent if retried.");
-                                             IDEMPOTENT_STORE_CALL_ERROR.clone()
-                                        })
-                                        .and_then(move |_| Ok((ret.0, ret.1)))
-                                },
-                            ),
-                        )
+                        return Err(ret);
                     }
-                },
-            ),
-        )
+                };
+
+                // NOTE: This is bytes 0.4.12. API Response is defined over it.
+                let data = match ret {
+                    ApiResponse::Default => default_return_value,
+                    ApiResponse::Data(d) => d,
+                };
+                store
+                    .save_idempotent_data(
+                        idempotency_key,
+                        input_hash,
+                        status_code,
+                        data.clone(),
+                    )
+                    .map_err(move |_| {
+                        error!("Failed to connect to the store! The request will not be idempotent if retried.");
+                            IDEMPOTENT_STORE_CALL_ERROR.clone()
+                    }).await?;
+
+                Ok((status_code, data))
+            }
+        }
     } else {
         // otherwise just make the call w/o any idempotency saves
-        Either::B(
-            non_idempotent_function()
-                .map(move |ret| {
-                    let data = match ret {
-                        ApiResponse::Default => default_return_value,
-                        ApiResponse::Data(d) => d,
-                    };
-                    (status_code, data)
-                })
-                .and_then(move |ret: (StatusCode, Bytes)| Ok((ret.0, ret.1))),
-        )
+        let data = match non_idempotent_function().await? {
+            ApiResponse::Default => default_return_value,
+            ApiResponse::Data(d) => d,
+        };
+        Ok((status_code, data))
     }
 }

--- a/crates/interledger-spsp/Cargo.toml
+++ b/crates/interledger-spsp/Cargo.toml
@@ -11,12 +11,15 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 base64 = { version = "0.10.1", default-features = false }
 bytes = { version = "0.4.12", default-features = false }
 failure = { version = "0.1.5", default-features = false }
-futures = { version = "0.1.29", default-features = false }
-hyper = { version = "0.12.35", default-features = false }
+futures = { version = "0.3.1", default-features = false }
+hyper = { version = "0.13.1", default-features = false }
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", features = ["serde"], default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 interledger-stream = { path = "../interledger-stream", version = "^0.4.0", default-features = false }
 log = { version = "0.4.8", default-features = false }
-reqwest = { version = "0.9.22", default-features = false, features = ["default-tls"] }
+reqwest = { version = "0.10", default-features = false, features = ["default-tls", "json"] }
 serde = { version = "1.0.101", default-features = false }
 serde_json = { version = "1.0.41", default-features = false }
+
+[dev-dependencies]
+tokio = { version = "0.2.8", features = ["macros"] }

--- a/crates/interledger-spsp/src/client.rs
+++ b/crates/interledger-spsp/src/client.rs
@@ -1,66 +1,65 @@
 use super::{Error, SpspResponse};
-use futures::{future::result, Future};
+use futures::TryFutureExt;
 use interledger_packet::Address;
 use interledger_service::{Account, IncomingService};
 use interledger_stream::{send_money, StreamDelivery};
 use log::{debug, error, trace};
-use reqwest::r#async::Client;
+use reqwest::Client;
 use std::convert::TryFrom;
 
-pub fn query(server: &str) -> impl Future<Item = SpspResponse, Error = Error> {
+pub async fn query(server: &str) -> Result<SpspResponse, Error> {
     let server = payment_pointer_to_url(server);
     trace!("Querying receiver: {}", server);
 
     let client = Client::new();
-    client
+    let res = client
         .get(&server)
         .header("Accept", "application/spsp4+json")
         .send()
         .map_err(|err| Error::HttpError(format!("Error querying SPSP receiver: {:?}", err)))
-        .and_then(|res| {
-            res.error_for_status()
-                .map_err(|err| Error::HttpError(format!("Error querying SPSP receiver: {:?}", err)))
-        })
-        .and_then(|mut res| {
-            res.json::<SpspResponse>()
-                .map_err(|err| Error::InvalidSpspServerResponseError(format!("{:?}", err)))
-        })
+        .await?;
+
+    let res = res
+        .error_for_status()
+        .map_err(|err| Error::HttpError(format!("Error querying SPSP receiver: {:?}", err)))?;
+
+    res.json::<SpspResponse>()
+        .map_err(|err| Error::InvalidSpspServerResponseError(format!("{:?}", err)))
+        .await
 }
 
 /// Query the details of the given Payment Pointer and send a payment using the STREAM protocol.
 ///
 /// This returns the amount delivered, as reported by the receiver and in the receiver's asset's units.
-pub fn pay<S, A>(
+pub async fn pay<S, A>(
     service: S,
     from_account: A,
     receiver: &str,
     source_amount: u64,
-) -> impl Future<Item = StreamDelivery, Error = Error>
+) -> Result<StreamDelivery, Error>
 where
     S: IncomingService<A> + Clone,
     A: Account,
 {
-    query(receiver).and_then(move |spsp| {
-        let shared_secret = spsp.shared_secret;
-        let dest = spsp.destination_account;
-        result(Address::try_from(dest).map_err(move |err| {
-            error!("Error parsing address");
-            Error::InvalidSpspServerResponseError(err.to_string())
-        }))
-        .and_then(move |addr| {
-            debug!("Sending SPSP payment to address: {}", addr);
+    let spsp = query(receiver).await?;
+    let shared_secret = spsp.shared_secret;
+    let dest = spsp.destination_account;
+    let addr = Address::try_from(dest).map_err(move |err| {
+        error!("Error parsing address");
+        Error::InvalidSpspServerResponseError(err.to_string())
+    })?;
+    debug!("Sending SPSP payment to address: {}", addr);
 
-            send_money(service, &from_account, addr, &shared_secret, source_amount)
-                .map(move |(receipt, _plugin)| {
-                    debug!("Sent SPSP payment. StreamDelivery: {:?}", receipt);
-                    receipt
-                })
-                .map_err(move |err| {
-                    error!("Error sending payment: {:?}", err);
-                    Error::SendMoneyError(source_amount)
-                })
-        })
-    })
+    let (receipt, _plugin) =
+        send_money(service, &from_account, addr, &shared_secret, source_amount)
+            .map_err(move |err| {
+                error!("Error sending payment: {:?}", err);
+                Error::SendMoneyError(source_amount)
+            })
+            .await?;
+
+    debug!("Sent SPSP payment. StreamDelivery: {:?}", receipt);
+    Ok(receipt)
 }
 
 fn payment_pointer_to_url(payment_pointer: &str) -> String {

--- a/crates/interledger-store/Cargo.toml
+++ b/crates/interledger-store/Cargo.toml
@@ -22,7 +22,8 @@ required-features = ["redis"]
 
 [dependencies]
 bytes = { version = "0.4.12", default-features = false }
-futures = { version = "0.1.29", default-features = false }
+futures01 = { version = "0.1.29", default-features = false }
+futures = { version = "0.3", default-features = false, features = ["compat"] }
 interledger-api = { path = "../interledger-api", version = "^0.3.0", default-features = false }
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
 interledger-btp = { path = "../interledger-btp", version = "^0.4.0", default-features = false }
@@ -39,21 +40,22 @@ parking_lot = { version = "0.9.0", default-features = false }
 ring = { version = "0.16.9", default-features = false }
 serde = { version = "1.0.101", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.41", default-features = false }
-tokio-executor = { version = "0.1.8", default-features = false }
-tokio-timer = { version = "0.2.11", default-features = false }
+tokio = { version = "0.2.6", default-features = false, features = ["macros", "rt-core"] }
 url = { version = "2.1.0", default-features = false, features = ["serde"] }
-http = { version = "0.1.18", default-features = false }
+http = { version = "0.2", default-features = false }
 secrecy = { version = "0.5.1", default-features = false, features = ["serde", "bytes"] }
 zeroize = { version = "1.0.0", default-features = false, features = ["bytes"] }
 num-bigint = { version = "0.2.3", default-features = false, features = ["std"]}
 uuid = { version = "0.8.1", default-features = false, features = ["serde"] }
 
 # redis feature
-redis_crate = { package = "redis", version = "0.13.0", default-features = false, features = ["executor"], optional = true }
+# redis_crate = { package = "redis", version = "0.13.0", default-features = false, features = ["executor"], optional = true }
+redis_crate = { package = "redis", git = "https://github.com/mitsuhiko/redis-rs", branch = "master", default-features = false, features = ["tokio-rt-core"], optional = true }
+runtime = "0.0.0"
+async-trait = "0.1.22"
 
 [dev-dependencies]
 env_logger = { version = "0.7.0", default-features = false }
 net2 = { version = "0.2.33", default-features = false }
 rand = { version = "0.7.2", default-features = false }
-tokio = { version = "0.1.22", default-features = false }
 os_type = { version = "2.2", default-features = false }

--- a/crates/interledger-store/src/redis/mod.rs
+++ b/crates/interledger-store/src/redis/mod.rs
@@ -1835,7 +1835,6 @@ async fn update_routes(
     mut connection: RedisReconnect,
     routing_table: Arc<RwLock<Arc<HashMap<String, Uuid>>>>,
 ) -> Result<(), ()> {
-    println!("updating routes");
     let mut pipe = redis_crate::pipe();
     pipe.hgetall(ROUTES_KEY)
         .hgetall(STATIC_ROUTES_KEY)

--- a/crates/interledger-store/src/redis/reconnect.rs
+++ b/crates/interledger-store/src/redis/reconnect.rs
@@ -1,43 +1,55 @@
-use futures::{
-    future::{err, result, Either},
-    Future,
-};
+use futures::future::{FutureExt, TryFutureExt};
+use futures01::future::{err, Either, Future as Future01};
 use log::{debug, error};
 use parking_lot::RwLock;
 use redis_crate::{
-    aio::{ConnectionLike, SharedConnection},
-    Client, ConnectionInfo, RedisError, Value,
+    aio::{ConnectionLike, MultiplexedConnection},
+    AsyncCommands, Client, Cmd, ConnectionInfo, Pipeline, RedisError, RedisFuture, Value,
 };
+use std::future::Future;
 use std::sync::Arc;
 
-/// Wrapper around a Redis SharedConnection that automatically
+type Result<T> = std::result::Result<T, RedisError>;
+
+/// Wrapper around a Redis MultiplexedConnection that automatically
 /// attempts to reconnect to the DB if the connection is dropped
 #[derive(Clone)]
 pub struct RedisReconnect {
     pub(crate) redis_info: Arc<ConnectionInfo>,
-    pub(crate) conn: Arc<RwLock<SharedConnection>>,
+    pub(crate) conn: Arc<RwLock<MultiplexedConnection>>,
 }
 
+async fn get_shared_connection(redis_info: Arc<ConnectionInfo>) -> Result<MultiplexedConnection> {
+    let client = Client::open((*redis_info).clone())?;
+    client
+        .get_multiplexed_tokio_connection()
+        .map_err(|e| {
+            error!("Error connecting to Redis: {:?}", e);
+            e
+        })
+        .await
+}
+
+use futures::compat::Compat01As03;
+
 impl RedisReconnect {
-    pub fn connect(
-        redis_info: ConnectionInfo,
-    ) -> impl Future<Item = RedisReconnect, Error = RedisError> {
+    pub async fn connect(redis_info: ConnectionInfo) -> Result<RedisReconnect> {
         let redis_info = Arc::new(redis_info);
-        get_shared_connection(redis_info.clone()).map(move |conn| RedisReconnect {
+        let conn = get_shared_connection(redis_info.clone()).await?;
+        Ok(RedisReconnect {
             conn: Arc::new(RwLock::new(conn)),
             redis_info,
         })
     }
 
-    pub fn reconnect(self) -> impl Future<Item = Self, Error = RedisError> {
-        get_shared_connection(self.redis_info.clone()).and_then(move |shared_connection| {
-            (*self.conn.write()) = shared_connection;
-            debug!("Reconnected to Redis");
-            Ok(self)
-        })
+    pub async fn reconnect(self) -> Result<Self> {
+        let shared_connection = get_shared_connection(self.redis_info.clone()).await?;
+        (*self.conn.write()) = shared_connection;
+        debug!("Reconnected to Redis");
+        Ok(self)
     }
 
-    fn get_shared_connection(&self) -> SharedConnection {
+    fn get_shared_connection(&self) -> MultiplexedConnection {
         self.conn.read().clone()
     }
 }
@@ -47,56 +59,46 @@ impl ConnectionLike for RedisReconnect {
         self.conn.read().get_db()
     }
 
-    fn req_packed_command(
-        self,
-        cmd: Vec<u8>,
-    ) -> Box<dyn Future<Item = (Self, Value), Error = RedisError> + Send> {
-        let clone = self.clone();
-        Box::new(
-            self.get_shared_connection()
-                .req_packed_command(cmd)
-                .or_else(move |error| {
+    fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
+        // This is how it is implemented in the redis-rs repository
+        (async move {
+            let mut connection = self.get_shared_connection();
+            match connection.req_packed_command(cmd).await {
+                Ok(res) => Ok(res),
+                Err(error) => {
                     if error.is_connection_dropped() {
                         debug!("Redis connection was dropped, attempting to reconnect");
-                        Either::A(clone.reconnect().then(|_| Err(error)))
-                    } else {
-                        Either::B(err(error))
+                        // TODO: Is this correct syntax? Otherwise we get an unused result warning
+                        let _ = self.clone().reconnect().await;
                     }
-                })
-                .map(move |(_conn, res)| (self, res)),
-        )
+                    Err(error)
+                }
+            }
+        })
+        .boxed()
     }
 
-    fn req_packed_commands(
-        self,
-        cmd: Vec<u8>,
+    fn req_packed_commands<'a>(
+        &'a mut self,
+        cmd: &'a Pipeline,
         offset: usize,
         count: usize,
-    ) -> Box<dyn Future<Item = (Self, Vec<Value>), Error = RedisError> + Send> {
-        let clone = self.clone();
-        Box::new(
-            self.get_shared_connection()
-                .req_packed_commands(cmd, offset, count)
-                .or_else(move |error| {
+    ) -> RedisFuture<'a, Vec<Value>> {
+        // This is how it is implemented in the redis-rs repository
+        (async move {
+            let mut connection = self.get_shared_connection();
+            match connection.req_packed_commands(cmd, offset, count).await {
+                Ok(res) => Ok(res),
+                Err(error) => {
                     if error.is_connection_dropped() {
                         debug!("Redis connection was dropped, attempting to reconnect");
-                        Either::A(clone.reconnect().then(|_| Err(error)))
-                    } else {
-                        Either::B(err(error))
+                        // TODO: Is this correct syntax? Otherwise we get an unused result warning
+                        let _ = self.clone().reconnect().await;
                     }
-                })
-                .map(|(_conn, res)| (self, res)),
-        )
-    }
-}
-
-fn get_shared_connection(
-    redis_info: Arc<ConnectionInfo>,
-) -> impl Future<Item = SharedConnection, Error = RedisError> {
-    result(Client::open((*redis_info).clone())).and_then(|client| {
-        client.get_shared_async_connection().map_err(|e| {
-            error!("Error connecting to Redis: {:?}", e);
-            e
+                    Err(error)
+                }
+            }
         })
-    })
+        .boxed()
+    }
 }

--- a/crates/interledger-store/tests/redis/accounts_test.rs
+++ b/crates/interledger-store/tests/redis/accounts_test.rs
@@ -1,5 +1,6 @@
 use super::{fixtures::*, redis_helpers::*, store_helpers::*};
-use futures::future::{result, Either, Future};
+use futures::future::{Either, Future};
+use futures::TryFutureExt;
 use interledger_api::{AccountSettings, NodeStore};
 use interledger_btp::{BtpAccount, BtpStore};
 use interledger_ccp::{CcpRoutingAccount, RoutingRelation};
@@ -9,481 +10,273 @@ use interledger_service::Account as AccountTrait;
 use interledger_service::{AccountStore, AddressStore, Username};
 use interledger_service_util::BalanceStore;
 use interledger_store::redis::RedisStoreBuilder;
-use log::{debug, error};
 use redis_crate::Client;
 use secrecy::ExposeSecret;
 use secrecy::SecretString;
+use std::default::Default;
 use std::str::FromStr;
 use uuid::Uuid;
 
-#[test]
-fn picks_up_parent_during_initialization() {
+#[tokio::test]
+async fn picks_up_parent_during_initialization() {
     let context = TestContext::new();
-    block_on(
-        result(Client::open(context.get_client_connection_info()))
-            .map_err(|err| error!("Error creating Redis client: {:?}", err))
-            .and_then(|client| {
-                debug!("Connected to redis: {:?}", client);
-                client
-                    .get_shared_async_connection()
-                    .map_err(|err| error!("Error connecting to Redis: {:?}", err))
-            })
-            .and_then(move |connection| {
-                // we set a parent that was already configured via perhaps a
-                // previous account insertion. that means that when we connect
-                // to the store we will always get the configured parent (if
-                // there was one))
-                redis_crate::cmd("SET")
-                    .arg("parent_node_account_address")
-                    .arg("example.bob.node")
-                    .query_async(connection)
-                    .map_err(|err| panic!(err))
-                    .and_then(move |(_, _): (_, redis_crate::Value)| {
-                        RedisStoreBuilder::new(context.get_client_connection_info(), [0; 32])
-                            .connect()
-                            .and_then(move |store| {
-                                // the store's ilp address is the store's
-                                // username appended to the parent's address
-                                assert_eq!(
-                                    store.get_ilp_address(),
-                                    Address::from_str("example.bob.node").unwrap()
-                                );
-                                let _ = context;
-                                Ok(())
-                            })
-                    })
-            }),
-    )
-    .unwrap();
+    let client = Client::open(context.get_client_connection_info()).unwrap();
+    let mut connection = client.get_multiplexed_tokio_connection().await.unwrap();
+
+    // we set a parent that was already configured via perhaps a
+    // previous account insertion. that means that when we connect
+    // to the store we will always get the configured parent (if
+    // there was one))
+    let _: redis_crate::Value = redis_crate::cmd("SET")
+        .arg("parent_node_account_address")
+        .arg("example.bob.node")
+        .query_async(&mut connection)
+        .await
+        .unwrap();
+
+    let store = RedisStoreBuilder::new(context.get_client_connection_info(), [0; 32])
+        .connect()
+        .await
+        .unwrap();
+    // the store's ilp address is the store's
+    // username appended to the parent's address
+    assert_eq!(
+        store.get_ilp_address(),
+        Address::from_str("example.bob.node").unwrap()
+    );
 }
 
-#[test]
-fn insert_accounts() {
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        store
-            .insert_account(ACCOUNT_DETAILS_2.clone())
-            .and_then(move |account| {
-                assert_eq!(
-                    *account.ilp_address(),
-                    Address::from_str("example.alice.user1.charlie").unwrap()
-                );
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap();
+#[tokio::test]
+async fn insert_accounts() {
+    let (store, _context, _) = test_store().await.unwrap();
+    let account = store
+        .insert_account(ACCOUNT_DETAILS_2.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        *account.ilp_address(),
+        Address::from_str("example.alice.user1.charlie").unwrap()
+    );
 }
 
-#[test]
-fn update_ilp_and_children_addresses() {
-    block_on(test_store().and_then(|(store, context, accs)| {
-        store
-            // Add a NonRoutingAccount to make sure its address
-            // gets updated as well
-            .insert_account(ACCOUNT_DETAILS_2.clone())
-            .and_then(move |acc2| {
-                let mut accs = accs.clone();
-                accs.push(acc2);
-                accs.sort_by_key(|a| a.username().clone());
-                let ilp_address = Address::from_str("test.parent.our_address").unwrap();
-                store
-                    .set_ilp_address(ilp_address.clone())
-                    .and_then(move |_| {
-                        let ret = store.get_ilp_address();
-                        assert_eq!(ilp_address, ret);
-                        store.get_all_accounts().and_then(move |accounts: Vec<_>| {
-                            let mut accounts = accounts.clone();
-                            accounts.sort_by(|a, b| {
-                                a.username()
-                                    .as_bytes()
-                                    .partial_cmp(b.username().as_bytes())
-                                    .unwrap()
-                            });
-                            for (a, b) in accounts.into_iter().zip(&accs) {
-                                if a.routing_relation() == RoutingRelation::Child
-                                    || a.routing_relation() == RoutingRelation::NonRoutingAccount
-                                {
-                                    assert_eq!(
-                                        *a.ilp_address(),
-                                        ilp_address.with_suffix(a.username().as_bytes()).unwrap()
-                                    );
-                                } else {
-                                    assert_eq!(a.ilp_address(), b.ilp_address());
-                                }
-                            }
-                            let _ = context;
-                            Ok(())
-                        })
-                    })
-            })
-    }))
-    .unwrap();
+#[tokio::test]
+async fn update_ilp_and_children_addresses() {
+    let (store, _context, accs) = test_store().await.unwrap();
+    // Add a NonRoutingAccount to make sure its address
+    // gets updated as well
+    let acc2 = store
+        .insert_account(ACCOUNT_DETAILS_2.clone())
+        .await
+        .unwrap();
+    let mut accs = accs.clone();
+    accs.push(acc2);
+    accs.sort_by_key(|a| a.username().clone());
+    let ilp_address = Address::from_str("test.parent.our_address").unwrap();
+
+    store.set_ilp_address(ilp_address.clone()).await.unwrap();
+    let ret = store.get_ilp_address();
+    assert_eq!(ilp_address, ret);
+
+    let accounts = store.get_all_accounts().await.unwrap();
+    let mut accounts = accounts.clone();
+    accounts.sort_by(|a, b| {
+        a.username()
+            .as_bytes()
+            .partial_cmp(b.username().as_bytes())
+            .unwrap()
+    });
+    for (a, b) in accounts.into_iter().zip(&accs) {
+        if a.routing_relation() == RoutingRelation::Child
+            || a.routing_relation() == RoutingRelation::NonRoutingAccount
+        {
+            assert_eq!(
+                *a.ilp_address(),
+                ilp_address.with_suffix(a.username().as_bytes()).unwrap()
+            );
+        } else {
+            assert_eq!(a.ilp_address(), b.ilp_address());
+        }
+    }
 }
 
-#[test]
-fn only_one_parent_allowed() {
+#[tokio::test]
+async fn only_one_parent_allowed() {
     let mut acc = ACCOUNT_DETAILS_2.clone();
     acc.routing_relation = Some("Parent".to_owned());
     acc.username = Username::from_str("another_name").unwrap();
     acc.ilp_address = Some(Address::from_str("example.another_name").unwrap());
-    block_on(test_store().and_then(|(store, context, accs)| {
-        store.insert_account(acc.clone()).then(move |res| {
-            // This should fail
-            assert!(res.is_err());
-            futures::future::join_all(vec![
-                Either::A(store.delete_account(accs[0].id()).and_then(|_| Ok(()))),
-                // must also clear the ILP Address to indicate that we no longer
-                // have a parent account configured
-                Either::B(store.clear_ilp_address()),
-            ])
-            .and_then(move |_| {
-                store.insert_account(acc).and_then(move |_| {
-                    // the call was successful, so the parent was succesfully added
-                    let _ = context;
-                    Ok(())
-                })
-            })
-        })
-    }))
-    .unwrap();
+    let (store, _context, accs) = test_store().await.unwrap();
+    let res = store.insert_account(acc.clone()).await;
+    // This should fail
+    assert!(res.is_err());
+    futures::future::join_all(vec![
+        Either::Left(store.delete_account(accs[0].id()).map_ok(|_| ())),
+        // must also clear the ILP Address to indicate that we no longer
+        // have a parent account configured
+        Either::Right(store.clear_ilp_address()),
+    ])
+    .await;
+    let res = store.insert_account(acc).await;
+    assert!(res.is_ok());
 }
 
-#[test]
-fn delete_accounts() {
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        store.get_all_accounts().and_then(move |accounts| {
-            let id = accounts[0].id();
-            store.delete_account(id).and_then(move |_| {
-                store.get_all_accounts().and_then(move |accounts| {
-                    for a in accounts {
-                        assert_ne!(id, a.id());
-                    }
-                    let _ = context;
-                    Ok(())
-                })
-            })
-        })
-    }))
-    .unwrap();
+#[tokio::test]
+async fn delete_accounts() {
+    let (store, _context, _) = test_store().await.unwrap();
+    let accounts = store.get_all_accounts().await.unwrap();
+    let id = accounts[0].id();
+    store.delete_account(id).await.unwrap();
+    let accounts = store.get_all_accounts().await.unwrap();
+    for a in accounts {
+        assert_ne!(id, a.id());
+    }
 }
 
-#[test]
-fn update_accounts() {
-    block_on(test_store().and_then(|(store, context, accounts)| {
-        context
-            .async_connection()
-            .map_err(|err| panic!(err))
-            .and_then(move |connection| {
-                let id = accounts[0].id();
-                redis_crate::cmd("HMSET")
-                    .arg(format!("accounts:{}", id))
-                    .arg("balance")
-                    .arg(600)
-                    .arg("prepaid_amount")
-                    .arg(400)
-                    .query_async(connection)
-                    .map_err(|err| panic!(err))
-                    .and_then(move |(_, _): (_, redis_crate::Value)| {
-                        let mut new = ACCOUNT_DETAILS_0.clone();
-                        new.asset_code = String::from("TUV");
-                        store.update_account(id, new).and_then(move |account| {
-                            assert_eq!(account.asset_code(), "TUV");
-                            store.get_balance(account).and_then(move |balance| {
-                                assert_eq!(balance, 1000);
-                                let _ = context;
-                                Ok(())
-                            })
-                        })
-                    })
-            })
-    }))
-    .unwrap();
+#[tokio::test]
+async fn update_accounts() {
+    let (store, context, accounts) = test_store().await.unwrap();
+    let mut connection = context.async_connection().await.unwrap();
+    let id = accounts[0].id();
+    let _: redis_crate::Value = redis_crate::cmd("HMSET")
+        .arg(format!("accounts:{}", id))
+        .arg("balance")
+        .arg(600u64)
+        .arg("prepaid_amount")
+        .arg(400u64)
+        .query_async(&mut connection)
+        .await
+        .unwrap();
+    let mut new = ACCOUNT_DETAILS_0.clone();
+    new.asset_code = String::from("TUV");
+    let account = store.update_account(id, new).await.unwrap();
+    assert_eq!(account.asset_code(), "TUV");
+    let balance = store.get_balance(account).await.unwrap();
+    assert_eq!(balance, 1000);
 }
 
-#[test]
-fn modify_account_settings_settle_to_overflow() {
-    block_on(test_store().and_then(|(store, context, accounts)| {
-        let mut settings = AccountSettings::default();
-        // Redis.rs cannot save a value larger than i64::MAX
-        settings.settle_to = Some(std::i64::MAX as u64 + 1);
-        let account = accounts[0].clone();
-        let id = account.id();
-        store
-            .modify_account_settings(id, settings)
-            .then(move |ret| {
-                assert!(ret.is_err());
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap();
+#[tokio::test]
+async fn modify_account_settings_settle_to_overflow() {
+    let (store, _context, accounts) = test_store().await.unwrap();
+    let mut settings = AccountSettings::default();
+    // Redis.rs cannot save a value larger than i64::MAX
+    settings.settle_to = Some(std::i64::MAX as u64 + 1);
+    let account = accounts[0].clone();
+    let id = account.id();
+    let ret = store.modify_account_settings(id, settings).await;
+    assert!(ret.is_err());
 }
 
-use std::default::Default;
-#[test]
-fn modify_account_settings_unchanged() {
-    block_on(test_store().and_then(|(store, context, accounts)| {
-        let settings = AccountSettings::default();
-        let account = accounts[0].clone();
+#[tokio::test]
+async fn modify_account_settings_unchanged() {
+    let (store, _context, accounts) = test_store().await.unwrap();
+    let settings = AccountSettings::default();
+    let account = accounts[0].clone();
 
-        let id = account.id();
-        store
-            .modify_account_settings(id, settings)
-            .and_then(move |ret| {
-                assert_eq!(
-                    account.get_http_auth_token().unwrap().expose_secret(),
-                    ret.get_http_auth_token().unwrap().expose_secret(),
-                );
-                assert_eq!(
-                    account.get_ilp_over_btp_outgoing_token().unwrap(),
-                    ret.get_ilp_over_btp_outgoing_token().unwrap()
-                );
-                // Cannot check other parameters since they are only pub(crate).
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap();
+    let id = account.id();
+    let ret = store.modify_account_settings(id, settings).await.unwrap();
+
+    assert_eq!(
+        account.get_http_auth_token().unwrap().expose_secret(),
+        ret.get_http_auth_token().unwrap().expose_secret(),
+    );
+    assert_eq!(
+        account.get_ilp_over_btp_outgoing_token().unwrap(),
+        ret.get_ilp_over_btp_outgoing_token().unwrap()
+    );
 }
 
-#[test]
-fn modify_account_settings() {
-    block_on(test_store().and_then(|(store, context, accounts)| {
-        let settings = AccountSettings {
-            ilp_over_http_outgoing_token: Some(SecretString::new("test_token".to_owned())),
-            ilp_over_http_incoming_token: Some(SecretString::new("http_in_new".to_owned())),
-            ilp_over_btp_outgoing_token: Some(SecretString::new("dylan:test".to_owned())),
-            ilp_over_btp_incoming_token: Some(SecretString::new("btp_in_new".to_owned())),
-            ilp_over_http_url: Some("http://example.com/accounts/dylan/ilp".to_owned()),
-            ilp_over_btp_url: Some("http://example.com/accounts/dylan/ilp/btp".to_owned()),
-            settle_threshold: Some(-50),
-            settle_to: Some(100),
-        };
-        let account = accounts[0].clone();
+#[tokio::test]
+async fn modify_account_settings() {
+    let (store, _context, accounts) = test_store().await.unwrap();
+    let settings = AccountSettings {
+        ilp_over_http_outgoing_token: Some(SecretString::new("test_token".to_owned())),
+        ilp_over_http_incoming_token: Some(SecretString::new("http_in_new".to_owned())),
+        ilp_over_btp_outgoing_token: Some(SecretString::new("dylan:test".to_owned())),
+        ilp_over_btp_incoming_token: Some(SecretString::new("btp_in_new".to_owned())),
+        ilp_over_http_url: Some("http://example.com/accounts/dylan/ilp".to_owned()),
+        ilp_over_btp_url: Some("http://example.com/accounts/dylan/ilp/btp".to_owned()),
+        settle_threshold: Some(-50),
+        settle_to: Some(100),
+    };
+    let account = accounts[0].clone();
 
-        let id = account.id();
-        store
-            .modify_account_settings(id, settings)
-            .and_then(move |ret| {
-                assert_eq!(
-                    ret.get_http_auth_token().unwrap().expose_secret(),
-                    "test_token",
-                );
-                assert_eq!(
-                    ret.get_ilp_over_btp_outgoing_token().unwrap(),
-                    &b"dylan:test"[..],
-                );
-                // Cannot check other parameters since they are only pub(crate).
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap();
+    let id = account.id();
+    let ret = store.modify_account_settings(id, settings).await.unwrap();
+    assert_eq!(
+        ret.get_http_auth_token().unwrap().expose_secret(),
+        "test_token",
+    );
+    assert_eq!(
+        ret.get_ilp_over_btp_outgoing_token().unwrap(),
+        &b"dylan:test"[..],
+    );
 }
 
-#[test]
-fn starts_with_zero_balance() {
-    block_on(test_store().and_then(|(store, context, accs)| {
-        let account0 = accs[0].clone();
-        store.get_balance(account0).and_then(move |balance| {
-            assert_eq!(balance, 0);
-            let _ = context;
-            Ok(())
-        })
-    }))
-    .unwrap();
+#[tokio::test]
+async fn starts_with_zero_balance() {
+    let (store, _context, accs) = test_store().await.unwrap();
+    let account0 = accs[0].clone();
+    let balance = store.get_balance(account0).await.unwrap();
+    assert_eq!(balance, 0);
 }
 
-#[test]
-fn fetches_account_from_username() {
-    block_on(test_store().and_then(|(store, context, accs)| {
-        store
-            .get_account_id_from_username(&Username::from_str("alice").unwrap())
-            .and_then(move |account_id| {
-                assert_eq!(account_id, accs[0].id());
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap();
+#[tokio::test]
+async fn fetches_account_from_username() {
+    let (store, _context, accs) = test_store().await.unwrap();
+    let account_id = store
+        .get_account_id_from_username(&Username::from_str("alice").unwrap())
+        .await
+        .unwrap();
+    assert_eq!(account_id, accs[0].id());
 }
 
-#[test]
-fn duplicate_http_incoming_auth_works() {
-    let mut duplicate = ACCOUNT_DETAILS_2.clone();
-    duplicate.ilp_over_http_incoming_token =
-        Some(SecretString::new("incoming_auth_token".to_string()));
-    block_on(test_store().and_then(|(store, context, accs)| {
-        let original = accs[0].clone();
-        let original_id = original.id();
-        store.insert_account(duplicate).and_then(move |duplicate| {
-            let duplicate_id = duplicate.id();
-            assert_ne!(original_id, duplicate_id);
-            futures::future::join_all(vec![
-                store.get_account_from_http_auth(
-                    &Username::from_str("alice").unwrap(),
-                    "incoming_auth_token",
-                ),
-                store.get_account_from_http_auth(
-                    &Username::from_str("charlie").unwrap(),
-                    "incoming_auth_token",
-                ),
-            ])
-            .and_then(move |accs| {
-                // Alice and Charlie had the same auth token, but they had a
-                // different username/account id, so no problem.
-                assert_ne!(accs[0].id(), accs[1].id());
-                assert_eq!(accs[0].id(), original_id);
-                assert_eq!(accs[1].id(), duplicate_id);
-                let _ = context;
-                Ok(())
-            })
-        })
-    }))
-    .unwrap();
+#[tokio::test]
+async fn get_all_accounts() {
+    let (store, _context, _) = test_store().await.unwrap();
+    let accounts = store.get_all_accounts().await.unwrap();
+    assert_eq!(accounts.len(), 2);
 }
 
-#[test]
-fn gets_account_from_btp_auth() {
-    block_on(test_store().and_then(|(store, context, accs)| {
-        // alice's incoming btp token is the username/password to get her
-        // account's information
-        store
-            .get_account_from_btp_auth(&Username::from_str("alice").unwrap(), "btp_token")
-            .and_then(move |acc| {
-                assert_eq!(acc.id(), accs[0].id());
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap();
+#[tokio::test]
+async fn gets_single_account() {
+    let (store, _context, accs) = test_store().await.unwrap();
+    let acc = accs[0].clone();
+    let accounts = store.get_accounts(vec![acc.id()]).await.unwrap();
+    assert_eq!(accounts[0].ilp_address(), acc.ilp_address());
 }
 
-#[test]
-fn gets_account_from_http_auth() {
-    block_on(test_store().and_then(|(store, context, accs)| {
-        store
-            .get_account_from_http_auth(
-                &Username::from_str("alice").unwrap(),
-                "incoming_auth_token",
-            )
-            .and_then(move |acc| {
-                assert_eq!(acc.id(), accs[0].id());
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap();
+#[tokio::test]
+async fn gets_multiple() {
+    let (store, _context, accs) = test_store().await.unwrap();
+    // set account ids in reverse order
+    let account_ids: Vec<Uuid> = accs.iter().rev().map(|a| a.id()).collect::<_>();
+    let accounts = store.get_accounts(account_ids).await.unwrap();
+    // note reverse order is intentional
+    assert_eq!(accounts[0].ilp_address(), accs[1].ilp_address());
+    assert_eq!(accounts[1].ilp_address(), accs[0].ilp_address());
 }
 
-#[test]
-fn duplicate_btp_incoming_auth_works() {
-    let mut charlie = ACCOUNT_DETAILS_2.clone();
-    charlie.ilp_over_btp_incoming_token = Some(SecretString::new("btp_token".to_string()));
-    block_on(test_store().and_then(|(store, context, accs)| {
-        let alice = accs[0].clone();
-        let alice_id = alice.id();
-        store.insert_account(charlie).and_then(move |charlie| {
-            let charlie_id = charlie.id();
-            assert_ne!(alice_id, charlie_id);
-            futures::future::join_all(vec![
-                store.get_account_from_btp_auth(&Username::from_str("alice").unwrap(), "btp_token"),
-                store.get_account_from_btp_auth(
-                    &Username::from_str("charlie").unwrap(),
-                    "btp_token",
-                ),
-            ])
-            .and_then(move |accs| {
-                assert_ne!(accs[0].id(), accs[1].id());
-                assert_eq!(accs[0].id(), alice_id);
-                assert_eq!(accs[1].id(), charlie_id);
-                let _ = context;
-                Ok(())
-            })
-        })
-    }))
-    .unwrap();
+#[tokio::test]
+async fn decrypts_outgoing_tokens_acc() {
+    let (store, _context, accs) = test_store().await.unwrap();
+    let acc = accs[0].clone();
+    let accounts = store.get_accounts(vec![acc.id()]).await.unwrap();
+    let account = accounts[0].clone();
+    assert_eq!(
+        account.get_http_auth_token().unwrap().expose_secret(),
+        acc.get_http_auth_token().unwrap().expose_secret(),
+    );
+    assert_eq!(
+        account.get_ilp_over_btp_outgoing_token().unwrap(),
+        acc.get_ilp_over_btp_outgoing_token().unwrap(),
+    );
 }
 
-#[test]
-fn get_all_accounts() {
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        store.get_all_accounts().and_then(move |accounts| {
-            assert_eq!(accounts.len(), 2);
-            let _ = context;
-            Ok(())
-        })
-    }))
-    .unwrap();
-}
-
-#[test]
-fn gets_single_account() {
-    block_on(test_store().and_then(|(store, context, accs)| {
-        let store_clone = store.clone();
-        let acc = accs[0].clone();
-        store_clone
-            .get_accounts(vec![acc.id()])
-            .and_then(move |accounts| {
-                assert_eq!(accounts[0].ilp_address(), acc.ilp_address());
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap();
-}
-
-#[test]
-fn gets_multiple() {
-    block_on(test_store().and_then(|(store, context, accs)| {
-        let store_clone = store.clone();
-        // set account ids in reverse order
-        let account_ids: Vec<Uuid> = accs.iter().rev().map(|a| a.id()).collect::<_>();
-        store_clone
-            .get_accounts(account_ids)
-            .and_then(move |accounts| {
-                // note reverse order is intentional
-                assert_eq!(accounts[0].ilp_address(), accs[1].ilp_address());
-                assert_eq!(accounts[1].ilp_address(), accs[0].ilp_address());
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap();
-}
-
-#[test]
-fn decrypts_outgoing_tokens_acc() {
-    block_on(test_store().and_then(|(store, context, accs)| {
-        let acc = accs[0].clone();
-        store
-            .get_accounts(vec![acc.id()])
-            .and_then(move |accounts| {
-                let account = accounts[0].clone();
-                assert_eq!(
-                    account.get_http_auth_token().unwrap().expose_secret(),
-                    acc.get_http_auth_token().unwrap().expose_secret(),
-                );
-                assert_eq!(
-                    account.get_ilp_over_btp_outgoing_token().unwrap(),
-                    acc.get_ilp_over_btp_outgoing_token().unwrap(),
-                );
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap()
-}
-
-#[test]
-fn errors_for_unknown_accounts() {
-    let result = block_on(test_store().and_then(|(store, context, _accs)| {
-        store
-            .get_accounts(vec![Uuid::new_v4(), Uuid::new_v4()])
-            .then(move |result| {
-                let _ = context;
-                result
-            })
-    }));
+#[tokio::test]
+async fn errors_for_unknown_accounts() {
+    let (store, _context, _) = test_store().await.unwrap();
+    let result = store
+        .get_accounts(vec![Uuid::new_v4(), Uuid::new_v4()])
+        .await;
     assert!(result.is_err());
 }

--- a/crates/interledger-store/tests/redis/balances_test.rs
+++ b/crates/interledger-store/tests/redis/balances_test.rs
@@ -9,90 +9,64 @@ use interledger_store::account::Account;
 use std::str::FromStr;
 use uuid::Uuid;
 
-#[test]
-fn get_balance() {
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        let account_id = Uuid::new_v4();
-        context
-            .async_connection()
-            .map_err(move |err| panic!(err))
-            .and_then(move |connection| {
-                redis_crate::cmd("HMSET")
-                    .arg(format!("accounts:{}", account_id))
-                    .arg("balance")
-                    .arg(600)
-                    .arg("prepaid_amount")
-                    .arg(400)
-                    .query_async(connection)
-                    .map_err(|err| panic!(err))
-                    .and_then(move |(_, _): (_, redis_crate::Value)| {
-                        let account = Account::try_from(
-                            account_id,
-                            ACCOUNT_DETAILS_0.clone(),
-                            store.get_ilp_address(),
-                        )
-                        .unwrap();
-                        store.get_balance(account).and_then(move |balance| {
-                            assert_eq!(balance, 1000);
-                            let _ = context;
-                            Ok(())
-                        })
-                    })
-            })
-    }))
+#[tokio::test]
+async fn get_balance() {
+    let (store, context, _accs) = test_store().await.unwrap();
+    let account_id = Uuid::new_v4();
+    let mut connection = context.async_connection().await.unwrap();
+    let _: redis_crate::Value = redis_crate::cmd("HMSET")
+        .arg(format!("accounts:{}", account_id))
+        .arg("balance")
+        .arg(600u64)
+        .arg("prepaid_amount")
+        .arg(400u64)
+        .query_async(&mut connection)
+        .await
+        .unwrap();
+    let account = Account::try_from(
+        account_id,
+        ACCOUNT_DETAILS_0.clone(),
+        store.get_ilp_address(),
+    )
     .unwrap();
+    let balance = store.get_balance(account).await.unwrap();
+    assert_eq!(balance, 1000);
 }
 
-#[test]
-fn prepare_then_fulfill_with_settlement() {
-    block_on(test_store().and_then(|(store, context, accs)| {
-        let store_clone_1 = store.clone();
-        let store_clone_2 = store.clone();
-        store
-            .clone()
-            .get_accounts(vec![accs[0].id(), accs[1].id()])
-            .map_err(|_err| panic!("Unable to get accounts"))
-            .and_then(move |accounts| {
-                let account0 = accounts[0].clone();
-                let account1 = accounts[1].clone();
-                store
-                    // reduce account 0's balance by 100
-                    .update_balances_for_prepare(accounts[0].clone(), 100)
-                    .and_then(move |_| {
-                        store_clone_1
-                            .clone()
-                            .get_balance(accounts[0].clone())
-                            .join(store_clone_1.clone().get_balance(accounts[1].clone()))
-                            .and_then(|(balance0, balance1)| {
-                                assert_eq!(balance0, -100);
-                                assert_eq!(balance1, 0);
-                                Ok(())
-                            })
-                    })
-                    .and_then(move |_| {
-                        store_clone_2
-                            .clone()
-                            .update_balances_for_fulfill(account1.clone(), 100)
-                            .and_then(move |_| {
-                                store_clone_2
-                                    .clone()
-                                    .get_balance(account0.clone())
-                                    .join(store_clone_2.clone().get_balance(account1.clone()))
-                                    .and_then(move |(balance0, balance1)| {
-                                        assert_eq!(balance0, -100);
-                                        assert_eq!(balance1, -1000); // the account must be settled down to -1000
-                                        let _ = context;
-                                        Ok(())
-                                    })
-                            })
-                    })
-            })
-    }))
-    .unwrap();
+#[tokio::test]
+async fn prepare_then_fulfill_with_settlement() {
+    let (store, _context, accs) = test_store().await.unwrap();
+    let accounts = store
+        .get_accounts(vec![accs[0].id(), accs[1].id()])
+        .await
+        .unwrap();
+    let account0 = accounts[0].clone();
+    let account1 = accounts[1].clone();
+    // reduce account 0's balance by 100
+    store
+        .update_balances_for_prepare(account0.clone(), 100)
+        .await
+        .unwrap();
+    // TODO:Can we make get_balance take a reference to the account?
+    // Even better, we should make it just take the account uid/username!
+    let balance0 = store.get_balance(account0.clone()).await.unwrap();
+    let balance1 = store.get_balance(account1.clone()).await.unwrap();
+    assert_eq!(balance0, -100);
+    assert_eq!(balance1, 0);
+
+    // Account 1 hits the settlement limit (?) TODO
+    store
+        .update_balances_for_fulfill(account1.clone(), 100)
+        .await
+        .unwrap();
+    let balance0 = store.get_balance(account0).await.unwrap();
+    let balance1 = store.get_balance(account1).await.unwrap();
+    assert_eq!(balance0, -100);
+    assert_eq!(balance1, -1000);
 }
 
-#[test]
-fn process_fulfill_no_settle_to() {
+#[tokio::test]
+async fn process_fulfill_no_settle_to() {
     // account without a settle_to
     let acc = {
         let mut acc = ACCOUNT_DETAILS_1.clone();
@@ -104,31 +78,21 @@ fn process_fulfill_no_settle_to() {
         acc.settle_to = None;
         acc
     };
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        let store_clone = store.clone();
-        store.clone().insert_account(acc).and_then(move |account| {
-            let id = account.id();
-            store_clone
-                .get_accounts(vec![id])
-                .and_then(move |accounts| {
-                    let acc = accounts[0].clone();
-                    store_clone
-                        .clone()
-                        .update_balances_for_fulfill(acc.clone(), 100)
-                        .and_then(move |(balance, amount_to_settle)| {
-                            assert_eq!(balance, 100);
-                            assert_eq!(amount_to_settle, 0);
-                            let _ = context;
-                            Ok(())
-                        })
-                })
-        })
-    }))
-    .unwrap();
+    let (store, _context, _accs) = test_store().await.unwrap();
+    let account = store.insert_account(acc).await.unwrap();
+    let id = account.id();
+    let accounts = store.get_accounts(vec![id]).await.unwrap();
+    let acc = accounts[0].clone();
+    let (balance, amount_to_settle) = store
+        .update_balances_for_fulfill(acc.clone(), 100)
+        .await
+        .unwrap();
+    assert_eq!(balance, 100);
+    assert_eq!(amount_to_settle, 0);
 }
 
-#[test]
-fn process_fulfill_settle_to_over_threshold() {
+#[tokio::test]
+async fn process_fulfill_settle_to_over_threshold() {
     // account misconfigured with settle_to >= settle_threshold does not get settlements
     let acc = {
         let mut acc = ACCOUNT_DETAILS_1.clone();
@@ -141,31 +105,21 @@ fn process_fulfill_settle_to_over_threshold() {
         acc.ilp_over_btp_incoming_token = None;
         acc
     };
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        let store_clone = store.clone();
-        store.clone().insert_account(acc).and_then(move |acc| {
-            let id = acc.id();
-            store_clone
-                .get_accounts(vec![id])
-                .and_then(move |accounts| {
-                    let acc = accounts[0].clone();
-                    store_clone
-                        .clone()
-                        .update_balances_for_fulfill(acc.clone(), 1000)
-                        .and_then(move |(balance, amount_to_settle)| {
-                            assert_eq!(balance, 1000);
-                            assert_eq!(amount_to_settle, 0);
-                            let _ = context;
-                            Ok(())
-                        })
-                })
-        })
-    }))
-    .unwrap();
+    let (store, _context, _accs) = test_store().await.unwrap();
+    let acc = store.insert_account(acc).await.unwrap();
+    let id = acc.id();
+    let accounts = store.get_accounts(vec![id]).await.unwrap();
+    let acc = accounts[0].clone();
+    let (balance, amount_to_settle) = store
+        .update_balances_for_fulfill(acc.clone(), 1000)
+        .await
+        .unwrap();
+    assert_eq!(balance, 1000);
+    assert_eq!(amount_to_settle, 0);
 }
 
-#[test]
-fn process_fulfill_ok() {
+#[tokio::test]
+async fn process_fulfill_ok() {
     // account with settle to = 0 (not falsy) with settle_threshold > 0, gets settlements
     let acc = {
         let mut acc = ACCOUNT_DETAILS_1.clone();
@@ -178,160 +132,99 @@ fn process_fulfill_ok() {
         acc.ilp_over_btp_incoming_token = None;
         acc
     };
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        let store_clone = store.clone();
-        store.clone().insert_account(acc).and_then(move |account| {
-            let id = account.id();
-            store_clone
-                .get_accounts(vec![id])
-                .and_then(move |accounts| {
-                    let acc = accounts[0].clone();
-                    store_clone
-                        .clone()
-                        .update_balances_for_fulfill(acc.clone(), 101)
-                        .and_then(move |(balance, amount_to_settle)| {
-                            assert_eq!(balance, 0);
-                            assert_eq!(amount_to_settle, 101);
-                            let _ = context;
-                            Ok(())
-                        })
-                })
-        })
-    }))
-    .unwrap();
+    let (store, _context, _accs) = test_store().await.unwrap();
+    let account = store.insert_account(acc).await.unwrap();
+    let id = account.id();
+    let accounts = store.get_accounts(vec![id]).await.unwrap();
+    let acc = accounts[0].clone();
+    let (balance, amount_to_settle) = store
+        .update_balances_for_fulfill(acc.clone(), 101)
+        .await
+        .unwrap();
+    assert_eq!(balance, 0);
+    assert_eq!(amount_to_settle, 101);
 }
 
-#[test]
-fn prepare_then_reject() {
-    block_on(test_store().and_then(|(store, context, accs)| {
-        let store_clone_1 = store.clone();
-        let store_clone_2 = store.clone();
-        store
-            .clone()
-            .get_accounts(vec![accs[0].id(), accs[1].id()])
-            .map_err(|_err| panic!("Unable to get accounts"))
-            .and_then(move |accounts| {
-                let account0 = accounts[0].clone();
-                let account1 = accounts[1].clone();
-                store
-                    .update_balances_for_prepare(accounts[0].clone(), 100)
-                    .and_then(move |_| {
-                        store_clone_1
-                            .clone()
-                            .get_balance(accounts[0].clone())
-                            .join(store_clone_1.clone().get_balance(accounts[1].clone()))
-                            .and_then(|(balance0, balance1)| {
-                                assert_eq!(balance0, -100);
-                                assert_eq!(balance1, 0);
-                                Ok(())
-                            })
-                    })
-                    .and_then(move |_| {
-                        store_clone_2
-                            .clone()
-                            .update_balances_for_reject(account0.clone(), 100)
-                            .and_then(move |_| {
-                                store_clone_2
-                                    .clone()
-                                    .get_balance(account0.clone())
-                                    .join(store_clone_2.clone().get_balance(account1.clone()))
-                                    .and_then(move |(balance0, balance1)| {
-                                        assert_eq!(balance0, 0);
-                                        assert_eq!(balance1, 0);
-                                        let _ = context;
-                                        Ok(())
-                                    })
-                            })
-                    })
-            })
-    }))
-    .unwrap();
+#[tokio::test]
+async fn prepare_then_reject() {
+    let (store, _context, accs) = test_store().await.unwrap();
+    let accounts = store
+        .get_accounts(vec![accs[0].id(), accs[1].id()])
+        .await
+        .unwrap();
+    let account0 = accounts[0].clone();
+    let account1 = accounts[1].clone();
+    store
+        .update_balances_for_prepare(accounts[0].clone(), 100)
+        .await
+        .unwrap();
+    let balance0 = store.get_balance(accounts[0].clone()).await.unwrap();
+    let balance1 = store.get_balance(accounts[1].clone()).await.unwrap();
+    assert_eq!(balance0, -100);
+    assert_eq!(balance1, 0);
+    store
+        .update_balances_for_reject(account0.clone(), 100)
+        .await
+        .unwrap();
+    let balance0 = store.get_balance(accounts[0].clone()).await.unwrap();
+    let balance1 = store.get_balance(accounts[1].clone()).await.unwrap();
+    assert_eq!(balance0, 0);
+    assert_eq!(balance1, 0);
 }
 
-#[test]
-fn enforces_minimum_balance() {
-    block_on(test_store().and_then(|(store, context, accs)| {
-        store
-            .clone()
-            .get_accounts(vec![accs[0].id(), accs[1].id()])
-            .map_err(|_err| panic!("Unable to get accounts"))
-            .and_then(move |accounts| {
-                store
-                    .update_balances_for_prepare(accounts[0].clone(), 10000)
-                    .then(move |result| {
-                        assert!(result.is_err());
-                        let _ = context;
-                        Ok(())
-                    })
-            })
-    }))
-    .unwrap()
+#[tokio::test]
+async fn enforces_minimum_balance() {
+    let (store, _context, accs) = test_store().await.unwrap();
+    let accounts = store
+        .get_accounts(vec![accs[0].id(), accs[1].id()])
+        .await
+        .unwrap();
+    let result = store
+        .update_balances_for_prepare(accounts[0].clone(), 10000)
+        .await;
+    assert!(result.is_err());
 }
 
-#[test]
+#[tokio::test]
 // Prepare and Fulfill a packet for 100 units from Account 0 to Account 1
 // Then, Prepare and Fulfill a packet for 80 units from Account 1 to Account 0
-fn netting_fulfilled_balances() {
-    block_on(test_store().and_then(|(store, context, accs)| {
-        let store_clone1 = store.clone();
-        let store_clone2 = store.clone();
-        store
-            .clone()
-            .insert_account(ACCOUNT_DETAILS_2.clone())
-            .and_then(move |acc| {
-                store
-                    .clone()
-                    .get_accounts(vec![accs[0].id(), acc.id()])
-                    .map_err(|_err| panic!("Unable to get accounts"))
-                    .and_then(move |accounts| {
-                        let account0 = accounts[0].clone();
-                        let account1 = accounts[1].clone();
-                        let account0_clone = account0.clone();
-                        let account1_clone = account1.clone();
-                        future::join_all(vec![
-                            Either::A(store.clone().update_balances_for_prepare(
-                                account0.clone(),
-                                100, // decrement account 0 by 100
-                            )),
-                            Either::B(
-                                store
-                                    .clone()
-                                    .update_balances_for_fulfill(
-                                        account1.clone(), // increment account 1 by 100
-                                        100,
-                                    )
-                                    .and_then(|_| Ok(())),
-                            ),
-                        ])
-                        .and_then(move |_| {
-                            future::join_all(vec![
-                                Either::A(
-                                    store_clone1
-                                        .clone()
-                                        .update_balances_for_prepare(account1.clone(), 80),
-                                ),
-                                Either::B(
-                                    store_clone1
-                                        .clone()
-                                        .update_balances_for_fulfill(account0.clone(), 80)
-                                        .and_then(|_| Ok(())),
-                                ),
-                            ])
-                        })
-                        .and_then(move |_| {
-                            store_clone2
-                                .clone()
-                                .get_balance(account0_clone)
-                                .join(store_clone2.get_balance(account1_clone))
-                                .and_then(move |(balance0, balance1)| {
-                                    assert_eq!(balance0, -20);
-                                    assert_eq!(balance1, 20);
-                                    let _ = context;
-                                    Ok(())
-                                })
-                        })
-                    })
-            })
-    }))
-    .unwrap();
+async fn netting_fulfilled_balances() {
+    let (store, _context, accs) = test_store().await.unwrap();
+    let acc = store
+        .insert_account(ACCOUNT_DETAILS_2.clone())
+        .await
+        .unwrap();
+    let accounts = store
+        .get_accounts(vec![accs[0].id(), acc.id()])
+        .await
+        .unwrap();
+    let account0 = accounts[0].clone();
+    let account1 = accounts[1].clone();
+
+    // decrement account 0 by 100
+    store
+        .update_balances_for_prepare(account0.clone(), 100)
+        .await
+        .unwrap();
+    // increment account 1 by 100
+    store
+        .update_balances_for_fulfill(account1.clone(), 100)
+        .await
+        .unwrap();
+
+    // decrement account 1 by 80
+    store
+        .update_balances_for_prepare(account1.clone(), 80)
+        .await
+        .unwrap();
+    // increment account 0 by 80
+    store
+        .update_balances_for_fulfill(account0.clone(), 80)
+        .await
+        .unwrap();
+
+    let balance0 = store.get_balance(accounts[0].clone()).await.unwrap();
+    let balance1 = store.get_balance(accounts[1].clone()).await.unwrap();
+    assert_eq!(balance0, -20);
+    assert_eq!(balance1, 20);
 }

--- a/crates/interledger-store/tests/redis/btp_test.rs
+++ b/crates/interledger-store/tests/redis/btp_test.rs
@@ -1,63 +1,81 @@
+use super::fixtures::*;
+use super::redis_helpers::TestContext;
 use super::store_helpers::*;
+use futures::compat::Future01CompatExt;
 use futures::future::Future;
+use futures01::future::Future as Future01;
+use interledger_api::NodeStore;
 use interledger_btp::{BtpAccount, BtpStore};
 use interledger_http::HttpAccount;
 use interledger_packet::Address;
-use interledger_service::{Account, Username};
-use secrecy::ExposeSecret;
+use interledger_service::{Account as AccountTrait, Username};
+use interledger_store::{account::Account, redis::RedisStore};
+use secrecy::{ExposeSecret, SecretString};
 use std::str::FromStr;
 
-#[test]
-fn gets_account_from_btp_auth() {
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        store
-            .get_account_from_btp_auth(&Username::from_str("bob").unwrap(), "other_btp_token")
-            .and_then(move |account| {
-                assert_eq!(
-                    *account.ilp_address(),
-                    Address::from_str("example.alice.user1.bob").unwrap()
-                );
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap()
+#[tokio::test]
+async fn gets_account_from_btp_auth() {
+    let (store, _context, _) = test_store().await.unwrap();
+    let account = store
+        .get_account_from_btp_auth(&Username::from_str("bob").unwrap(), "other_btp_token")
+        .await
+        .unwrap();
+    assert_eq!(
+        *account.ilp_address(),
+        Address::from_str("example.alice.user1.bob").unwrap()
+    );
 }
 
-#[test]
-fn decrypts_outgoing_tokens_btp() {
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        store
-            .get_account_from_btp_auth(&Username::from_str("bob").unwrap(), "other_btp_token")
-            .and_then(move |account| {
-                // the account is created on Dylan's connector
-                assert_eq!(
-                    account.get_http_auth_token().unwrap().expose_secret(),
-                    "outgoing_auth_token",
-                );
-                assert_eq!(
-                    &account.get_ilp_over_btp_outgoing_token().unwrap(),
-                    b"btp_token"
-                );
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap()
+#[tokio::test]
+async fn decrypts_outgoing_tokens_btp() {
+    let (store, _context, _) = test_store().await.unwrap();
+    let account = store
+        .get_account_from_btp_auth(&Username::from_str("bob").unwrap(), "other_btp_token")
+        .await
+        .unwrap();
+
+    // the account is created on Dylan's connector
+    assert_eq!(
+        account.get_http_auth_token().unwrap().expose_secret(),
+        "outgoing_auth_token",
+    );
+    assert_eq!(
+        &account.get_ilp_over_btp_outgoing_token().unwrap(),
+        b"btp_token"
+    );
 }
 
-#[test]
-fn errors_on_unknown_btp_token() {
-    let result = block_on(test_store().and_then(|(store, context, _accs)| {
-        store
-            .get_account_from_btp_auth(
-                &Username::from_str("someuser").unwrap(),
-                "unknown_btp_token",
-            )
-            .then(move |result| {
-                let _ = context;
-                result
-            })
-    }));
+#[tokio::test]
+async fn errors_on_unknown_user_or_wrong_btp_token() {
+    let (store, _context, _) = test_store().await.unwrap();
+    let result = store
+        .get_account_from_btp_auth(&Username::from_str("asdf").unwrap(), "other_btp_token")
+        .await;
     assert!(result.is_err());
+
+    let result = store
+        .get_account_from_btp_auth(&Username::from_str("bob").unwrap(), "wrong_token")
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn duplicate_btp_incoming_auth_works() {
+    let mut charlie = ACCOUNT_DETAILS_2.clone();
+    charlie.ilp_over_btp_incoming_token = Some(SecretString::new("btp_token".to_string()));
+    let (store, _context, accs) = test_store().await.unwrap();
+    let alice = accs[0].clone();
+    let alice_id = alice.id();
+    let charlie = store.insert_account(charlie).await.unwrap();
+    let charlie_id = charlie.id();
+    assert_ne!(alice_id, charlie_id);
+    let result = futures::future::join_all(vec![
+        store.get_account_from_btp_auth(&Username::from_str("alice").unwrap(), "btp_token"),
+        store.get_account_from_btp_auth(&Username::from_str("charlie").unwrap(), "btp_token"),
+    ])
+    .await;
+    let accs: Vec<_> = result.into_iter().map(|r| r.unwrap()).collect();
+    assert_ne!(accs[0].id(), accs[1].id());
+    assert_eq!(accs[0].id(), alice_id);
+    assert_eq!(accs[1].id(), charlie_id);
 }

--- a/crates/interledger-store/tests/redis/http_test.rs
+++ b/crates/interledger-store/tests/redis/http_test.rs
@@ -1,74 +1,77 @@
+use super::fixtures::*;
 use super::store_helpers::*;
 use futures::future::Future;
+use interledger_api::NodeStore;
 use interledger_btp::BtpAccount;
 use interledger_http::{HttpAccount, HttpStore};
 use interledger_packet::Address;
 use interledger_service::{Account, Username};
-use secrecy::ExposeSecret;
+use secrecy::{ExposeSecret, SecretString};
 use std::str::FromStr;
 
-#[test]
-fn gets_account_from_http_bearer_token() {
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        store
-            .get_account_from_http_auth(
-                &Username::from_str("alice").unwrap(),
-                "incoming_auth_token",
-            )
-            .and_then(move |account| {
-                assert_eq!(
-                    *account.ilp_address(),
-                    Address::from_str("example.alice").unwrap()
-                );
-                // this account is in Dylan's connector
-                assert_eq!(
-                    account.get_http_auth_token().unwrap().expose_secret(),
-                    "outgoing_auth_token",
-                );
-                assert_eq!(
-                    &account.get_ilp_over_btp_outgoing_token().unwrap(),
-                    b"btp_token",
-                );
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap()
+#[tokio::test]
+async fn gets_account_from_http_bearer_token() {
+    let (store, _context, _) = test_store().await.unwrap();
+    let account = store
+        .get_account_from_http_auth(&Username::from_str("alice").unwrap(), "incoming_auth_token")
+        .await
+        .unwrap();
+    assert_eq!(
+        *account.ilp_address(),
+        Address::from_str("example.alice").unwrap()
+    );
+    assert_eq!(
+        account.get_http_auth_token().unwrap().expose_secret(),
+        "outgoing_auth_token",
+    );
+    assert_eq!(
+        &account.get_ilp_over_btp_outgoing_token().unwrap(),
+        b"btp_token",
+    );
 }
 
-#[test]
-fn decrypts_outgoing_tokens_http() {
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        store
-            .get_account_from_http_auth(
-                &Username::from_str("alice").unwrap(),
-                "incoming_auth_token",
-            )
-            .and_then(move |account| {
-                assert_eq!(
-                    account.get_http_auth_token().unwrap().expose_secret(),
-                    "outgoing_auth_token",
-                );
-                assert_eq!(
-                    &account.get_ilp_over_btp_outgoing_token().unwrap(),
-                    b"btp_token",
-                );
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap()
-}
-
-#[test]
-fn errors_on_unknown_http_auth() {
-    let result = block_on(test_store().and_then(|(store, context, _accs)| {
-        store
-            .get_account_from_http_auth(&Username::from_str("someuser").unwrap(), "unknown_token")
-            .then(move |result| {
-                let _ = context;
-                result
-            })
-    }));
+#[tokio::test]
+async fn errors_on_unknown_user_or_wrong_http_token() {
+    let (store, _context, _) = test_store().await.unwrap();
+    // wrong password
+    let result = store
+        .get_account_from_http_auth(&Username::from_str("alice").unwrap(), "unknown_token")
+        .await;
     assert!(result.is_err());
+
+    // wrong user
+    let result = store
+        .get_account_from_http_auth(&Username::from_str("asdf").unwrap(), "incoming_auth_token")
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn duplicate_http_incoming_auth_works() {
+    let mut duplicate = ACCOUNT_DETAILS_2.clone();
+    duplicate.ilp_over_http_incoming_token =
+        Some(SecretString::new("incoming_auth_token".to_string()));
+    let (store, _context, accs) = test_store().await.unwrap();
+    let original = accs[0].clone();
+    let original_id = original.id();
+    let duplicate = store.insert_account(duplicate).await.unwrap();
+    let duplicate_id = duplicate.id();
+    assert_ne!(original_id, duplicate_id);
+    let result = futures::future::join_all(vec![
+        store.get_account_from_http_auth(
+            &Username::from_str("alice").unwrap(),
+            "incoming_auth_token",
+        ),
+        store.get_account_from_http_auth(
+            &Username::from_str("charlie").unwrap(),
+            "incoming_auth_token",
+        ),
+    ])
+    .await;
+    let accs: Vec<_> = result.into_iter().map(|r| r.unwrap()).collect();
+    // Alice and Charlie had the same auth token, but they had a
+    // different username/account id, so no problem.
+    assert_ne!(accs[0].id(), accs[1].id());
+    assert_eq!(accs[0].id(), original_id);
+    assert_eq!(accs[1].id(), duplicate_id);
 }

--- a/crates/interledger-store/tests/redis/rate_limiting_test.rs
+++ b/crates/interledger-store/tests/redis/rate_limiting_test.rs
@@ -5,94 +5,76 @@ use interledger_service_util::{RateLimitError, RateLimitStore};
 use interledger_store::account::Account;
 use uuid::Uuid;
 
-#[test]
-fn rate_limits_number_of_packets() {
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        let account = Account::try_from(
-            Uuid::new_v4(),
-            ACCOUNT_DETAILS_0.clone(),
-            store.get_ilp_address(),
-        )
-        .unwrap();
-        join_all(vec![
-            store.clone().apply_rate_limits(account.clone(), 10),
-            store.clone().apply_rate_limits(account.clone(), 10),
-            store.clone().apply_rate_limits(account.clone(), 10),
-        ])
-        .then(move |result| {
-            assert!(result.is_err());
-            assert_eq!(result.unwrap_err(), RateLimitError::PacketLimitExceeded);
-            let _ = context;
-            Ok(())
-        })
-    }))
-    .unwrap()
+#[tokio::test]
+async fn rate_limits_number_of_packets() {
+    let (store, _context, _) = test_store().await.unwrap();
+    let account = Account::try_from(
+        Uuid::new_v4(),
+        ACCOUNT_DETAILS_0.clone(),
+        store.get_ilp_address(),
+    )
+    .unwrap();
+    let results = join_all(vec![
+        store.clone().apply_rate_limits(account.clone(), 10),
+        store.clone().apply_rate_limits(account.clone(), 10),
+        store.clone().apply_rate_limits(account.clone(), 10),
+    ])
+    .await;
+    // The first 2 calls succeed, while the 3rd one hits the rate limit error
+    // because the account is only allowed 2 packets per minute
+    assert_eq!(
+        results,
+        vec![Ok(()), Ok(()), Err(RateLimitError::PacketLimitExceeded)]
+    );
 }
 
-#[test]
-fn limits_amount_throughput() {
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        let account = Account::try_from(
-            Uuid::new_v4(),
-            ACCOUNT_DETAILS_1.clone(),
-            store.get_ilp_address(),
-        )
-        .unwrap();
-        join_all(vec![
-            store.clone().apply_rate_limits(account.clone(), 500),
-            store.clone().apply_rate_limits(account.clone(), 500),
-            store.clone().apply_rate_limits(account.clone(), 1),
-        ])
-        .then(move |result| {
-            assert!(result.is_err());
-            assert_eq!(result.unwrap_err(), RateLimitError::ThroughputLimitExceeded);
-            let _ = context;
-            Ok(())
-        })
-    }))
-    .unwrap()
+#[tokio::test]
+async fn limits_amount_throughput() {
+    let (store, _context, _) = test_store().await.unwrap();
+    let account = Account::try_from(
+        Uuid::new_v4(),
+        ACCOUNT_DETAILS_1.clone(),
+        store.get_ilp_address(),
+    )
+    .unwrap();
+    let results = join_all(vec![
+        store.clone().apply_rate_limits(account.clone(), 500),
+        store.clone().apply_rate_limits(account.clone(), 500),
+        store.clone().apply_rate_limits(account.clone(), 1),
+    ])
+    .await;
+    // The first 2 calls succeed, while the 3rd one hits the rate limit error
+    // because the account is only allowed 1000 units of currency per minute
+    assert_eq!(
+        results,
+        vec![Ok(()), Ok(()), Err(RateLimitError::ThroughputLimitExceeded)]
+    );
 }
 
-#[test]
-fn refunds_throughput_limit_for_rejected_packets() {
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        let account = Account::try_from(
-            Uuid::new_v4(),
-            ACCOUNT_DETAILS_1.clone(),
-            store.get_ilp_address(),
-        )
+#[tokio::test]
+async fn refunds_throughput_limit_for_rejected_packets() {
+    let (store, _context, _) = test_store().await.unwrap();
+    let account = Account::try_from(
+        Uuid::new_v4(),
+        ACCOUNT_DETAILS_1.clone(),
+        store.get_ilp_address(),
+    )
+    .unwrap();
+
+    join_all(vec![
+        store.clone().apply_rate_limits(account.clone(), 500),
+        store.clone().apply_rate_limits(account.clone(), 500),
+    ])
+    .await;
+
+    // We refund the throughput limit once, meaning we can do 1 more call before
+    // the error
+    store
+        .refund_throughput_limit(account.clone(), 500)
+        .await
         .unwrap();
-        join_all(vec![
-            store.clone().apply_rate_limits(account.clone(), 500),
-            store.clone().apply_rate_limits(account.clone(), 500),
-        ])
-        .map_err(|err| panic!(err))
-        .and_then(move |_| {
-            let store_clone = store.clone();
-            let account_clone = account.clone();
-            store
-                .clone()
-                .refund_throughput_limit(account.clone(), 500)
-                .and_then(move |_| {
-                    store
-                        .clone()
-                        .apply_rate_limits(account.clone(), 500)
-                        .map_err(|err| panic!(err))
-                })
-                .and_then(move |_| {
-                    store_clone
-                        .apply_rate_limits(account_clone, 1)
-                        .then(move |result| {
-                            assert!(result.is_err());
-                            assert_eq!(
-                                result.unwrap_err(),
-                                RateLimitError::ThroughputLimitExceeded
-                            );
-                            let _ = context;
-                            Ok(())
-                        })
-                })
-        })
-    }))
-    .unwrap()
+    store.apply_rate_limits(account.clone(), 500).await.unwrap();
+
+    let result = store.apply_rate_limits(account.clone(), 1).await;
+    assert_eq!(result.unwrap_err(), RateLimitError::ThroughputLimitExceeded);
 }

--- a/crates/interledger-store/tests/redis/rates_test.rs
+++ b/crates/interledger-store/tests/redis/rates_test.rs
@@ -2,26 +2,21 @@ use super::store_helpers::*;
 use futures::future::Future;
 use interledger_service_util::ExchangeRateStore;
 
-#[test]
-fn set_rates() {
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        let store_clone = store.clone();
-        let rates = store.get_exchange_rates(&["ABC", "XYZ"]);
-        assert!(rates.is_err());
-        store
-            .set_exchange_rates(
-                [("ABC".to_string(), 500.0), ("XYZ".to_string(), 0.005)]
-                    .iter()
-                    .cloned()
-                    .collect(),
-            )
-            .and_then(move |_| {
-                let rates = store_clone.get_exchange_rates(&["XYZ", "ABC"]).unwrap();
-                assert_eq!(rates[0].to_string(), "0.005");
-                assert_eq!(rates[1].to_string(), "500");
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap();
+#[tokio::test]
+async fn set_rates() {
+    let (store, _context, _) = test_store().await.unwrap();
+    let rates = store.get_exchange_rates(&["ABC", "XYZ"]);
+    assert!(rates.is_err());
+    store
+        .set_exchange_rates(
+            [("ABC".to_string(), 500.0), ("XYZ".to_string(), 0.005)]
+                .iter()
+                .cloned()
+                .collect(),
+        )
+        .unwrap();
+
+    let rates = store.get_exchange_rates(&["XYZ", "ABC"]).unwrap();
+    assert_eq!(rates[0].to_string(), "0.005");
+    assert_eq!(rates[1].to_string(), "500");
 }

--- a/crates/interledger-store/tests/redis/redis_tests.rs
+++ b/crates/interledger-store/tests/redis/redis_tests.rs
@@ -8,6 +8,7 @@ mod routing_test;
 mod settlement_test;
 
 mod fixtures {
+
     use interledger_api::AccountDetails;
     use interledger_packet::Address;
     use interledger_service::Username;
@@ -96,6 +97,8 @@ mod redis_helpers {
     use std::process;
     use std::thread::sleep;
     use std::time::Duration;
+
+    use futures::future::TryFutureExt;
 
     #[derive(PartialEq)]
     enum ServerType {
@@ -247,22 +250,21 @@ mod redis_helpers {
             self.client.get_connection().unwrap()
         }
 
-        pub fn async_connection(
-            &self,
-        ) -> impl Future<Item = redis_crate::aio::Connection, Error = ()> {
+        pub async fn async_connection(&self) -> Result<redis_crate::aio::Connection, ()> {
             self.client
                 .get_async_connection()
                 .map_err(|err| panic!(err))
+                .await
         }
 
         pub fn stop_server(&mut self) {
             self.server.stop();
         }
 
-        pub fn shared_async_connection(
+        pub async fn shared_async_connection(
             &self,
-        ) -> impl Future<Item = redis_crate::aio::SharedConnection, Error = RedisError> {
-            self.client.get_shared_async_connection()
+        ) -> Result<redis_crate::aio::MultiplexedConnection, RedisError> {
+            self.client.get_multiplexed_tokio_connection().await
         }
     }
 }
@@ -271,7 +273,9 @@ mod store_helpers {
     use super::fixtures::*;
     use super::redis_helpers::*;
     use env_logger;
+    use futures::compat::Future01CompatExt;
     use futures::Future;
+    use futures::TryFutureExt;
     use interledger_api::NodeStore;
     use interledger_packet::Address;
     use interledger_service::{Account as AccountTrait, AddressStore};
@@ -288,49 +292,32 @@ mod store_helpers {
         static ref TEST_MUTEX: Mutex<()> = Mutex::new(());
     }
 
-    pub fn test_store() -> impl Future<Item = (RedisStore, TestContext, Vec<Account>), Error = ()> {
+    pub async fn test_store() -> Result<(RedisStore, TestContext, Vec<Account>), ()> {
         let context = TestContext::new();
-        RedisStoreBuilder::new(context.get_client_connection_info(), [0; 32])
+        let store = RedisStoreBuilder::new(context.get_client_connection_info(), [0; 32])
             .node_ilp_address(Address::from_str("example.node").unwrap())
             .connect()
-            .and_then(|store| {
-                let store_clone = store.clone();
-                let mut accs = Vec::new();
-                store
-                    .clone()
-                    .insert_account(ACCOUNT_DETAILS_0.clone())
-                    .and_then(move |acc| {
-                        accs.push(acc.clone());
-                        // alice is a Parent, so the store's ilp address is updated to
-                        // the value that would be received by the ILDCP request. here,
-                        // we just assume alice appended some data to her address
-                        store
-                            .clone()
-                            .set_ilp_address(acc.ilp_address().with_suffix(b"user1").unwrap())
-                            .and_then(move |_| {
-                                store_clone
-                                    .insert_account(ACCOUNT_DETAILS_1.clone())
-                                    .and_then(move |acc| {
-                                        accs.push(acc.clone());
-                                        Ok((store, context, accs))
-                                    })
-                            })
-                    })
-            })
-    }
+            .await
+            .unwrap();
+        let mut accs = Vec::new();
+        let acc = store
+            .insert_account(ACCOUNT_DETAILS_0.clone())
+            .await
+            .unwrap();
+        accs.push(acc.clone());
+        // alice is a Parent, so the store's ilp address is updated to
+        // the value that would be received by the ILDCP request. here,
+        // we just assume alice appended some data to her address
+        store
+            .set_ilp_address(acc.ilp_address().with_suffix(b"user1").unwrap())
+            .await
+            .unwrap();
 
-    pub fn block_on<F>(f: F) -> Result<F::Item, F::Error>
-    where
-        F: Future + Send + 'static,
-        F::Item: Send,
-        F::Error: Send,
-    {
-        // Only run one test at a time
-        let _ = env_logger::try_init();
-        let lock = TEST_MUTEX.lock();
-        let mut runtime = Runtime::new().unwrap();
-        let result = runtime.block_on(f);
-        drop(lock);
-        result
+        let acc = store
+            .insert_account(ACCOUNT_DETAILS_1.clone())
+            .await
+            .unwrap();
+        accs.push(acc.clone());
+        Ok((store, context, accs))
     }
 }

--- a/crates/interledger-store/tests/redis/routing_test.rs
+++ b/crates/interledger-store/tests/redis/routing_test.rs
@@ -8,378 +8,266 @@ use interledger_service::{Account as AccountTrait, AddressStore, Username};
 use interledger_store::{account::Account, redis::RedisStoreBuilder};
 use std::str::FromStr;
 use std::{collections::HashMap, time::Duration};
-use tokio_timer::sleep;
 use uuid::Uuid;
 
-#[test]
-fn polls_for_route_updates() {
+#[tokio::test]
+async fn polls_for_route_updates() {
     let context = TestContext::new();
-    block_on(
-        RedisStoreBuilder::new(context.get_client_connection_info(), [0; 32])
-            .poll_interval(1)
-            .node_ilp_address(Address::from_str("example.node").unwrap())
-            .connect()
-            .and_then(|store| {
-                let connection = context.async_connection();
-                assert_eq!(store.routing_table().len(), 0);
-                let store_clone_1 = store.clone();
-                let store_clone_2 = store.clone();
-                store
-                    .clone()
-                    .insert_account(ACCOUNT_DETAILS_0.clone())
-                    .and_then(move |alice| {
-                        let routing_table = store_clone_1.routing_table();
-                        assert_eq!(routing_table.len(), 1);
-                        assert_eq!(*routing_table.get("example.alice").unwrap(), alice.id());
-                        store_clone_1
-                            .insert_account(AccountDetails {
-                                ilp_address: Some(Address::from_str("example.bob").unwrap()),
-                                username: Username::from_str("bob").unwrap(),
-                                asset_scale: 6,
-                                asset_code: "XYZ".to_string(),
-                                max_packet_amount: 1000,
-                                min_balance: Some(-1000),
-                                ilp_over_http_url: None,
-                                ilp_over_http_incoming_token: None,
-                                ilp_over_http_outgoing_token: None,
-                                ilp_over_btp_url: None,
-                                ilp_over_btp_outgoing_token: None,
-                                ilp_over_btp_incoming_token: None,
-                                settle_threshold: None,
-                                settle_to: None,
-                                routing_relation: Some("Peer".to_owned()),
-                                round_trip_time: None,
-                                amount_per_minute_limit: None,
-                                packets_per_minute_limit: None,
-                                settlement_engine_url: None,
-                            })
-                            .and_then(move |bob| {
-                                let routing_table = store_clone_2.routing_table();
-                                assert_eq!(routing_table.len(), 2);
-                                assert_eq!(*routing_table.get("example.bob").unwrap(), bob.id(),);
-                                let alice_id = alice.id();
-                                let bob_id = bob.id();
-                                connection
-                                    .map_err(|err| panic!(err))
-                                    .and_then(move |connection| {
-                                        redis_crate::cmd("HMSET")
-                                            .arg("routes:current")
-                                            .arg("example.alice")
-                                            .arg(bob_id.to_string())
-                                            .arg("example.charlie")
-                                            .arg(alice_id.to_string())
-                                            .query_async(connection)
-                                            .and_then(
-                                                |(_connection, _result): (
-                                                    _,
-                                                    redis_crate::Value,
-                                                )| {
-                                                    Ok(())
-                                                },
-                                            )
-                                            .map_err(|err| panic!(err))
-                                            .and_then(|_| {
-                                                sleep(Duration::from_millis(10)).then(|_| Ok(()))
-                                            })
-                                    })
-                                    .and_then(move |_| {
-                                        let routing_table = store_clone_2.routing_table();
-                                        assert_eq!(routing_table.len(), 3);
-                                        assert_eq!(
-                                            *routing_table.get("example.alice").unwrap(),
-                                            bob_id
-                                        );
-                                        assert_eq!(
-                                            *routing_table.get("example.bob").unwrap(),
-                                            bob.id(),
-                                        );
-                                        assert_eq!(
-                                            *routing_table.get("example.charlie").unwrap(),
-                                            alice_id,
-                                        );
-                                        assert!(routing_table.get("example.other").is_none());
-                                        let _ = context;
-                                        Ok(())
-                                    })
-                            })
-                    })
-            }),
+    let store = RedisStoreBuilder::new(context.get_client_connection_info(), [0; 32])
+        .poll_interval(1)
+        .node_ilp_address(Address::from_str("example.node").unwrap())
+        .connect()
+        .await
+        .unwrap();
+
+    let connection = context.async_connection();
+    assert_eq!(store.routing_table().len(), 0);
+    let store_clone_1 = store.clone();
+    let store_clone_2 = store.clone();
+    let alice = store
+        .insert_account(ACCOUNT_DETAILS_0.clone())
+        .await
+        .unwrap();
+    let routing_table = store_clone_1.routing_table();
+    assert_eq!(routing_table.len(), 1);
+    assert_eq!(*routing_table.get("example.alice").unwrap(), alice.id());
+    let bob = store_clone_1
+        .insert_account(AccountDetails {
+            ilp_address: Some(Address::from_str("example.bob").unwrap()),
+            username: Username::from_str("bob").unwrap(),
+            asset_scale: 6,
+            asset_code: "XYZ".to_string(),
+            max_packet_amount: 1000,
+            min_balance: Some(-1000),
+            ilp_over_http_url: None,
+            ilp_over_http_incoming_token: None,
+            ilp_over_http_outgoing_token: None,
+            ilp_over_btp_url: None,
+            ilp_over_btp_outgoing_token: None,
+            ilp_over_btp_incoming_token: None,
+            settle_threshold: None,
+            settle_to: None,
+            routing_relation: Some("Peer".to_owned()),
+            round_trip_time: None,
+            amount_per_minute_limit: None,
+            packets_per_minute_limit: None,
+            settlement_engine_url: None,
+        })
+        .await
+        .unwrap();
+
+    let routing_table = store_clone_2.routing_table();
+    assert_eq!(routing_table.len(), 2);
+    assert_eq!(*routing_table.get("example.bob").unwrap(), bob.id(),);
+    let alice_id = alice.id();
+    let bob_id = bob.id();
+    let mut connection = connection.await.unwrap();
+    let _: redis_crate::Value = redis_crate::cmd("HMSET")
+        .arg("routes:current")
+        .arg("example.alice")
+        .arg(bob_id.to_string())
+        .arg("example.charlie")
+        .arg(alice_id.to_string())
+        .query_async(&mut connection)
+        .await
+        .unwrap();
+
+    tokio::time::delay_for(Duration::from_millis(10)).await;
+    let routing_table = store_clone_2.routing_table();
+    assert_eq!(routing_table.len(), 3);
+    assert_eq!(*routing_table.get("example.alice").unwrap(), bob_id);
+    assert_eq!(*routing_table.get("example.bob").unwrap(), bob.id(),);
+    assert_eq!(*routing_table.get("example.charlie").unwrap(), alice_id,);
+    assert!(routing_table.get("example.other").is_none());
+}
+
+#[tokio::test]
+async fn gets_accounts_to_send_routes_to() {
+    let (store, _context, _) = test_store().await.unwrap();
+    let accounts = store
+        .get_accounts_to_send_routes_to(Vec::new())
+        .await
+        .unwrap();
+    // We send to child accounts but not parents
+    assert_eq!(accounts[0].username().as_ref(), "bob");
+    assert_eq!(accounts.len(), 1);
+}
+
+#[tokio::test]
+async fn gets_accounts_to_send_routes_to_and_skips_ignored() {
+    let (store, _context, accs) = test_store().await.unwrap();
+    let accounts = store
+        .get_accounts_to_send_routes_to(vec![accs[1].id()])
+        .await
+        .unwrap();
+    assert!(accounts.is_empty());
+}
+
+#[tokio::test]
+async fn gets_accounts_to_receive_routes_from() {
+    let (store, _context, _) = test_store().await.unwrap();
+    let accounts = store.get_accounts_to_receive_routes_from().await.unwrap();
+    assert_eq!(
+        *accounts[0].ilp_address(),
+        Address::from_str("example.alice").unwrap()
+    );
+}
+
+#[tokio::test]
+async fn gets_local_and_configured_routes() {
+    let (store, _context, _) = test_store().await.unwrap();
+    let (local, configured) = store.get_local_and_configured_routes().await.unwrap();
+    assert_eq!(local.len(), 2);
+    assert!(configured.is_empty());
+}
+
+#[tokio::test]
+async fn saves_routes_to_db() {
+    let (store, context, _) = test_store().await.unwrap();
+    let get_connection = context.async_connection();
+    let account0_id = Uuid::new_v4();
+    let account1_id = Uuid::new_v4();
+    let account0 = Account::try_from(
+        account0_id,
+        ACCOUNT_DETAILS_0.clone(),
+        store.get_ilp_address(),
     )
     .unwrap();
-}
 
-#[test]
-fn gets_accounts_to_send_routes_to() {
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        store
-            .get_accounts_to_send_routes_to(Vec::new())
-            .and_then(move |accounts| {
-                // We send to child accounts but not parents
-                assert_eq!(accounts[0].username().as_ref(), "bob");
-                assert_eq!(accounts.len(), 1);
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap()
-}
+    let account1 = Account::try_from(
+        account1_id,
+        ACCOUNT_DETAILS_1.clone(),
+        store.get_ilp_address(),
+    )
+    .unwrap();
 
-#[test]
-fn gets_accounts_to_send_routes_to_and_skips_ignored() {
-    block_on(test_store().and_then(|(store, context, accs)| {
-        store
-            .get_accounts_to_send_routes_to(vec![accs[1].id()])
-            .and_then(move |accounts| {
-                assert!(accounts.is_empty());
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap()
-}
-
-#[test]
-fn gets_accounts_to_receive_routes_from() {
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        store
-            .get_accounts_to_receive_routes_from()
-            .and_then(move |accounts| {
-                assert_eq!(
-                    *accounts[0].ilp_address(),
-                    Address::from_str("example.alice").unwrap()
-                );
-                assert_eq!(accounts.len(), 1);
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap()
-}
-
-#[test]
-fn gets_local_and_configured_routes() {
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        store
-            .get_local_and_configured_routes()
-            .and_then(move |(local, configured)| {
-                assert_eq!(local.len(), 2);
-                assert!(configured.is_empty());
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap()
-}
-
-#[test]
-fn saves_routes_to_db() {
-    block_on(test_store().and_then(|(mut store, context, _accs)| {
-        let get_connection = context.async_connection();
-        let account0_id = Uuid::new_v4();
-        let account1_id = Uuid::new_v4();
-        let account0 = Account::try_from(
-            account0_id,
-            ACCOUNT_DETAILS_0.clone(),
-            store.get_ilp_address(),
-        )
+    store
+        .clone()
+        .set_routes(vec![
+            ("example.a".to_string(), account0.clone()),
+            ("example.b".to_string(), account0.clone()),
+            ("example.c".to_string(), account1.clone()),
+        ])
+        .await
         .unwrap();
 
-        let account1 = Account::try_from(
-            account1_id,
-            ACCOUNT_DETAILS_1.clone(),
-            store.get_ilp_address(),
-        )
+    let mut connection = get_connection.await.unwrap();
+    let routes: HashMap<String, String> = redis_crate::cmd("HGETALL")
+        .arg("routes:current")
+        .query_async(&mut connection)
+        .await
+        .unwrap();
+    assert_eq!(routes["example.a"], account0_id.to_string());
+    assert_eq!(routes["example.b"], account0_id.to_string());
+    assert_eq!(routes["example.c"], account1_id.to_string());
+    assert_eq!(routes.len(), 3);
+
+    // local routing table routes are also updated
+    let routes = store.routing_table();
+    assert_eq!(routes["example.a"], account0_id);
+    assert_eq!(routes["example.b"], account0_id);
+    assert_eq!(routes["example.c"], account1_id);
+    assert_eq!(routes.len(), 3);
+}
+
+#[tokio::test]
+async fn adds_static_routes_to_redis() {
+    let (store, context, accs) = test_store().await.unwrap();
+    let get_connection = context.async_connection();
+    store
+        .set_static_routes(vec![
+            ("example.a".to_string(), accs[0].id()),
+            ("example.b".to_string(), accs[0].id()),
+            ("example.c".to_string(), accs[1].id()),
+        ])
+        .await
+        .unwrap();
+    let mut connection = get_connection.await.unwrap();
+    let routes: HashMap<String, String> = redis_crate::cmd("HGETALL")
+        .arg("routes:static")
+        .query_async(&mut connection)
+        .await
+        .unwrap();
+    assert_eq!(routes["example.a"], accs[0].id().to_string());
+    assert_eq!(routes["example.b"], accs[0].id().to_string());
+    assert_eq!(routes["example.c"], accs[1].id().to_string());
+    assert_eq!(routes.len(), 3);
+}
+
+#[tokio::test]
+async fn static_routes_override_others() {
+    let (store, _context, accs) = test_store().await.unwrap();
+    store
+        .set_static_routes(vec![
+            ("example.a".to_string(), accs[0].id()),
+            ("example.b".to_string(), accs[0].id()),
+        ])
+        .await
         .unwrap();
 
-        store
-            .set_routes(vec![
-                ("example.a".to_string(), account0.clone()),
-                ("example.b".to_string(), account0.clone()),
-                ("example.c".to_string(), account1.clone()),
-            ])
-            .and_then(move |_| {
-                get_connection.and_then(move |connection| {
-                    redis_crate::cmd("HGETALL")
-                        .arg("routes:current")
-                        .query_async(connection)
-                        .map_err(|err| panic!(err))
-                        .and_then(move |(_conn, routes): (_, HashMap<String, String>)| {
-                            assert_eq!(routes["example.a"], account0_id.to_string());
-                            assert_eq!(routes["example.b"], account0_id.to_string());
-                            assert_eq!(routes["example.c"], account1_id.to_string());
-                            assert_eq!(routes.len(), 3);
-                            Ok(())
-                        })
-                })
-            })
-            .and_then(move |_| {
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap()
-}
-
-#[test]
-fn updates_local_routes() {
-    block_on(test_store().and_then(|(store, context, _accs)| {
-        let account0_id = Uuid::new_v4();
-        let account1_id = Uuid::new_v4();
-        let account0 = Account::try_from(
-            account0_id,
-            ACCOUNT_DETAILS_0.clone(),
-            store.get_ilp_address(),
-        )
+    let account1_id = Uuid::new_v4();
+    let account1 = Account::try_from(
+        account1_id,
+        ACCOUNT_DETAILS_1.clone(),
+        store.get_ilp_address(),
+    )
+    .unwrap();
+    store
+        .clone()
+        .set_routes(vec![
+            ("example.a".to_string(), account1.clone()),
+            ("example.b".to_string(), account1.clone()),
+            ("example.c".to_string(), account1),
+        ])
+        .await
         .unwrap();
-        let account1 = Account::try_from(
-            account1_id,
-            ACCOUNT_DETAILS_1.clone(),
-            store.get_ilp_address(),
-        )
+
+    let routes = store.routing_table();
+    assert_eq!(routes["example.a"], accs[0].id());
+    assert_eq!(routes["example.b"], accs[0].id());
+    assert_eq!(routes["example.c"], account1_id);
+    assert_eq!(routes.len(), 3);
+}
+
+#[tokio::test]
+async fn default_route() {
+    let (store, _context, accs) = test_store().await.unwrap();
+    store.set_default_route(accs[0].id()).await.unwrap();
+    let account1_id = Uuid::new_v4();
+    let account1 = Account::try_from(
+        account1_id,
+        ACCOUNT_DETAILS_1.clone(),
+        store.get_ilp_address(),
+    )
+    .unwrap();
+    store
+        .clone()
+        .set_routes(vec![
+            ("example.a".to_string(), account1.clone()),
+            ("example.b".to_string(), account1.clone()),
+        ])
+        .await
         .unwrap();
-        store
-            .clone()
-            .set_routes(vec![
-                ("example.a".to_string(), account0.clone()),
-                ("example.b".to_string(), account0.clone()),
-                ("example.c".to_string(), account1.clone()),
-            ])
-            .and_then(move |_| {
-                let routes = store.routing_table();
-                assert_eq!(routes["example.a"], account0_id);
-                assert_eq!(routes["example.b"], account0_id);
-                assert_eq!(routes["example.c"], account1_id);
-                assert_eq!(routes.len(), 3);
-                Ok(())
-            })
-            .and_then(move |_| {
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap()
+
+    let routes = store.routing_table();
+    assert_eq!(routes[""], accs[0].id());
+    assert_eq!(routes["example.a"], account1_id);
+    assert_eq!(routes["example.b"], account1_id);
+    assert_eq!(routes.len(), 3);
 }
 
-#[test]
-fn adds_static_routes_to_redis() {
-    block_on(test_store().and_then(|(store, context, accs)| {
-        let get_connection = context.async_connection();
-        store
-            .clone()
-            .set_static_routes(vec![
-                ("example.a".to_string(), accs[0].id()),
-                ("example.b".to_string(), accs[0].id()),
-                ("example.c".to_string(), accs[1].id()),
-            ])
-            .and_then(move |_| {
-                get_connection.and_then(|connection| {
-                    redis_crate::cmd("HGETALL")
-                        .arg("routes:static")
-                        .query_async(connection)
-                        .map_err(|err| panic!(err))
-                        .and_then(move |(_, routes): (_, HashMap<String, String>)| {
-                            assert_eq!(routes["example.a"], accs[0].id().to_string());
-                            assert_eq!(routes["example.b"], accs[0].id().to_string());
-                            assert_eq!(routes["example.c"], accs[1].id().to_string());
-                            assert_eq!(routes.len(), 3);
-                            let _ = context;
-                            Ok(())
-                        })
-                })
-            })
-    }))
-    .unwrap()
-}
-
-#[test]
-fn static_routes_override_others() {
-    block_on(test_store().and_then(|(store, context, accs)| {
-        let mut store_clone = store.clone();
-        store
-            .clone()
-            .set_static_routes(vec![
-                ("example.a".to_string(), accs[0].id()),
-                ("example.b".to_string(), accs[0].id()),
-            ])
-            .and_then(move |_| {
-                let account1_id = Uuid::new_v4();
-                let account1 = Account::try_from(
-                    account1_id,
-                    ACCOUNT_DETAILS_1.clone(),
-                    store.get_ilp_address(),
-                )
-                .unwrap();
-                store_clone
-                    .set_routes(vec![
-                        ("example.a".to_string(), account1.clone()),
-                        ("example.b".to_string(), account1.clone()),
-                        ("example.c".to_string(), account1),
-                    ])
-                    .and_then(move |_| {
-                        let routes = store.routing_table();
-                        assert_eq!(routes["example.a"], accs[0].id());
-                        assert_eq!(routes["example.b"], accs[0].id());
-                        assert_eq!(routes["example.c"], account1_id);
-                        assert_eq!(routes.len(), 3);
-                        let _ = context;
-                        Ok(())
-                    })
-            })
-    }))
-    .unwrap()
-}
-
-#[test]
-fn default_route() {
-    block_on(test_store().and_then(|(store, context, accs)| {
-        let mut store_clone = store.clone();
-        store
-            .clone()
-            .set_default_route(accs[0].id())
-            .and_then(move |_| {
-                let account1_id = Uuid::new_v4();
-                let account1 = Account::try_from(
-                    account1_id,
-                    ACCOUNT_DETAILS_1.clone(),
-                    store.get_ilp_address(),
-                )
-                .unwrap();
-                store_clone
-                    .set_routes(vec![
-                        ("example.a".to_string(), account1.clone()),
-                        ("example.b".to_string(), account1.clone()),
-                    ])
-                    .and_then(move |_| {
-                        let routes = store.routing_table();
-                        assert_eq!(routes[""], accs[0].id());
-                        assert_eq!(routes["example.a"], account1_id);
-                        assert_eq!(routes["example.b"], account1_id);
-                        assert_eq!(routes.len(), 3);
-                        let _ = context;
-                        Ok(())
-                    })
-            })
-    }))
-    .unwrap()
-}
-
-#[test]
-fn returns_configured_routes_for_route_manager() {
-    block_on(test_store().and_then(|(store, context, accs)| {
-        store
-            .clone()
-            .set_static_routes(vec![
-                ("example.a".to_string(), accs[0].id()),
-                ("example.b".to_string(), accs[1].id()),
-            ])
-            .and_then(move |_| store.get_local_and_configured_routes())
-            .and_then(move |(_local, configured)| {
-                assert_eq!(configured.len(), 2);
-                assert_eq!(configured["example.a"].id(), accs[0].id());
-                assert_eq!(configured["example.b"].id(), accs[1].id());
-                let _ = context;
-                Ok(())
-            })
-    }))
-    .unwrap()
+#[tokio::test]
+async fn returns_configured_routes_for_route_manager() {
+    let (store, context, accs) = test_store().await.unwrap();
+    store
+        .set_static_routes(vec![
+            ("example.a".to_string(), accs[0].id()),
+            ("example.b".to_string(), accs[1].id()),
+        ])
+        .await
+        .unwrap();
+    let (_, configured) = store.get_local_and_configured_routes().await.unwrap();
+    assert_eq!(configured.len(), 2);
+    assert_eq!(configured["example.a"].id(), accs[0].id());
+    assert_eq!(configured["example.b"].id(), accs[1].id());
 }

--- a/crates/interledger-stream/Cargo.toml
+++ b/crates/interledger-stream/Cargo.toml
@@ -18,7 +18,7 @@ byteorder = { version = "1.3.2", default-features = false }
 chrono = { version = "0.4.9", default-features = false, features = ["clock"] }
 csv = { version = "1.1.1", default-features = false, optional = true }
 failure = { version = "0.1.5", default-features = false, features = ["derive"] }
-futures = { version = "0.1.29", default-features = false }
+futures = { version = "0.3.1", default-features = false }
 hex = { version = "0.4.0", default-features = false }
 interledger-ildcp = { path = "../interledger-ildcp", version = "^0.4.0", default-features = false }
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", features = ["serde"], default-features = false }
@@ -27,8 +27,9 @@ log = { version = "0.4.8", default-features = false }
 parking_lot = { version = "0.9.0", default-features = false }
 ring = { version = "0.16.9", default-features = false }
 serde = { version = "1.0.101", default-features = false }
-tokio = { version = "0.1.22", default-features = false, features = ["rt-full"] }
+tokio = { version = "^0.2.6", default-features = false, features = ["rt-core", "macros"] }
 uuid = { version = "0.8.1", default-features = false, features = ["v4"] }
+async-trait = "0.1.22"
 
 [dev-dependencies]
 interledger-router = { path = "../interledger-router", version = "^0.4.0", default-features = false }


### PR DESCRIPTION
As title. Still WIP. Opening for initial feedback. This will be split in smaller PRs and squashed/split into more verbose commits.

- We can get rid of the `BoxedIlpFuture` and replace it everywhere with `IlpResult` (which is really a `Result<Fulfill, Reject>`.
- We can utilize async-trait to allow our traits to have async functions. So far so good, haven't hit any edge cases yet. Had to manually add `'async_trait` as a lifetime.
- Note that the reduction in generics, as well as the eventual removal of the huge closure-chains will improve our compilation times significantly. 
- Bytes-05 is now needed for all HTTP related crates, so we temporarily maintain both versions in the required crates. Before the migration is over, Bytes 0.5 should be the only version in the repository. This could be more complex than expected due to breaking changes: 
   - https://github.com/tokio-rs/bytes/issues/350
    - https://github.com/tokio-rs/bytes/pull/288
   I am considering getting this PR to a merge-able state, and then open a separate issue to port the whole crate to Bytes 0.5.
- Warp needs to be added from master for now
- Tokio-tungstenite got futures 0.3 support recently so we can expect it to be released soon

Will fix #85.

- [x] service
- [x] ildcp
- [x] http
- [x] router
- [x] btp: blocked on https://github.com/snapview/tokio-tungstenite/pull/68
- [x] ccp
- [x] service-util: how do timeouts with 0.3 futures work?
- [x] api: blocked on some Warp changes (need to document)
- [x] settlement: requires compat methods for tokio-retry
- [x] store
- [x] stream
- [x] spsp
- [x] ilp-node: blocked on BTP and Prometheus
- [x] ilp-cli