### PR TITLE
Revive all features and investigate type length limit error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,14 +26,14 @@ jobs:
           command: printf "[profile.dev]\ncodegen-units = 1\n" >> Cargo.toml
       - run:
           name: Build
-          command: cargo build # --all-features --all-targets
+          command: cargo build --all-features --all-targets
       - run:
           name: Test
           # Note the timeout is included to make sure that they
           # do not run for more than 10 minutes under any circumstances
           # (We have had issues with bugs causing the tests to "run"
           # for 5 hours, wasting a ton of compute credits)
-          command: timeout 10m cargo test # --all --all-features
+          command: timeout 10m cargo test --all --all-features
           environment:
             - RUST_LOG: "interledger=trace"
             - RUST_BACKTRACE: "full"

--- a/crates/ilp-node/src/instrumentation/metrics.rs
+++ b/crates/ilp-node/src/instrumentation/metrics.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 
 pub async fn incoming_metrics<A: Account + CcpRoutingAccount>(
     request: IncomingRequest<A>,
-    mut next: impl IncomingService<A>,
+    mut next: Box<dyn IncomingService<A> + Send>,
 ) -> IlpResult {
     let labels = labels!(
         "from_asset_code" => request.from.asset_code().to_string(),
@@ -43,7 +43,7 @@ pub async fn incoming_metrics<A: Account + CcpRoutingAccount>(
 
 pub async fn outgoing_metrics<A: Account + CcpRoutingAccount>(
     request: OutgoingRequest<A>,
-    mut next: impl OutgoingService<A>,
+    mut next: Box<dyn OutgoingService<A> + Send>,
 ) -> IlpResult {
     let labels = labels!(
         "from_asset_code" => request.from.asset_code().to_string(),

--- a/crates/ilp-node/src/instrumentation/prometheus.rs
+++ b/crates/ilp-node/src/instrumentation/prometheus.rs
@@ -79,7 +79,7 @@ pub async fn serve_prometheus(node: InterledgerNode) -> Result<(), ()> {
                 prometheus.bind_address
             );
 
-            warp::serve(filter).bind(prometheus.bind_address).await;
+            tokio::spawn(warp::serve(filter).bind(prometheus.bind_address));
             Ok(())
         }
         Err(e) => {

--- a/crates/ilp-node/src/instrumentation/trace.rs
+++ b/crates/ilp-node/src/instrumentation/trace.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 /// level and more information for the DEBUG level.
 pub async fn trace_incoming<A: Account>(
     request: IncomingRequest<A>,
-    mut next: impl IncomingService<A>,
+    mut next: Box<dyn IncomingService<A> + Send>,
 ) -> IlpResult {
     let request_span = error_span!(target: "interledger-node",
         "incoming",
@@ -47,7 +47,7 @@ pub async fn trace_incoming<A: Account>(
 /// level and more information for the DEBUG level.
 pub async fn trace_forwarding<A: Account>(
     request: OutgoingRequest<A>,
-    mut next: impl OutgoingService<A>,
+    mut next: Box<dyn OutgoingService<A> + Send>,
 ) -> IlpResult {
     // Here we only include the outgoing details because this will be
     // inside the "incoming" span that includes the other details
@@ -73,7 +73,7 @@ pub async fn trace_forwarding<A: Account>(
 /// level and more information for the DEBUG level.
 pub async fn trace_outgoing<A: Account + CcpRoutingAccount>(
     request: OutgoingRequest<A>,
-    mut next: impl OutgoingService<A>,
+    mut next: Box<dyn OutgoingService<A> + Send>,
 ) -> IlpResult {
     let request_span = error_span!(target: "interledger-node",
         "outgoing",

--- a/crates/ilp-node/src/lib.rs
+++ b/crates/ilp-node/src/lib.rs
@@ -1,4 +1,4 @@
-#![type_length_limit= "5000000"]
+#![type_length_limit = "5000000"]
 mod instrumentation;
 mod node;
 

--- a/crates/ilp-node/src/lib.rs
+++ b/crates/ilp-node/src/lib.rs
@@ -1,7 +1,3 @@
-// #![type_length_limit = "25000000"]
-// #![type_length_limit = "1500000"] // needed to cargo build --bin ilp-node --feature "monitoring"
-#![type_length_limit = "80000000"] // needed to cargo build --all-features --all-targets
-
 mod instrumentation;
 mod node;
 

--- a/crates/ilp-node/src/lib.rs
+++ b/crates/ilp-node/src/lib.rs
@@ -1,3 +1,4 @@
+#![type_length_limit= "5000000"]
 mod instrumentation;
 mod node;
 

--- a/crates/ilp-node/src/main.rs
+++ b/crates/ilp-node/src/main.rs
@@ -1,4 +1,4 @@
-#![type_length_limit= "5000000"]
+#![type_length_limit = "5000000"]
 mod instrumentation;
 pub mod node;
 

--- a/crates/ilp-node/src/main.rs
+++ b/crates/ilp-node/src/main.rs
@@ -1,3 +1,4 @@
+#![type_length_limit= "5000000"]
 mod instrumentation;
 pub mod node;
 

--- a/crates/ilp-node/src/main.rs
+++ b/crates/ilp-node/src/main.rs
@@ -1,7 +1,3 @@
-// #![type_length_limit = "1500000"] // this is enough for cargo build --bin ilp-node
-// #![type_length_limit = "13500000"] // this is enough for cargo build --bin ilp-node --feature monitoring
-#![type_length_limit = "80000000"] // this is enough for cargo build --all-features --all-targets
-
 mod instrumentation;
 pub mod node;
 

--- a/crates/ilp-node/tests/redis/redis_tests.rs
+++ b/crates/ilp-node/tests/redis/redis_tests.rs
@@ -1,4 +1,4 @@
-#![type_length_limit= "5000000"]
+#![type_length_limit = "5000000"]
 mod btp;
 mod exchange_rates;
 mod three_nodes;

--- a/crates/ilp-node/tests/redis/redis_tests.rs
+++ b/crates/ilp-node/tests/redis/redis_tests.rs
@@ -1,6 +1,3 @@
-// #![type_length_limit = "5000000"] // this is needed for cargo test
-#![type_length_limit = "40000000"] // this is needed for cargo test --all-features --all
-
 mod btp;
 mod exchange_rates;
 mod three_nodes;

--- a/crates/ilp-node/tests/redis/redis_tests.rs
+++ b/crates/ilp-node/tests/redis/redis_tests.rs
@@ -1,3 +1,4 @@
+#![type_length_limit= "5000000"]
 mod btp;
 mod exchange_rates;
 mod three_nodes;

--- a/crates/interledger-service/src/lib.rs
+++ b/crates/interledger-service/src/lib.rs
@@ -140,8 +140,8 @@ pub trait IncomingService<A: Account> {
     /// and/or handle the result of calling the inner service.
     fn wrap<F, R>(self, f: F) -> WrappedService<F, Self, A>
     where
-        F: Fn(IncomingRequest<A>, Self) -> R,
-        R: Future<Output = IlpResult> + Send + 'static,
+        F: Send + Sync + Fn(IncomingRequest<A>, Box<dyn IncomingService<A> + Send>) -> R,
+        R: Future<Output = IlpResult>,
         Self: Clone + Sized,
     {
         WrappedService::wrap_incoming(self, f)
@@ -162,8 +162,8 @@ pub trait OutgoingService<A: Account> {
     /// and/or handle the result of calling the inner service.
     fn wrap<F, R>(self, f: F) -> WrappedService<F, Self, A>
     where
-        F: Fn(OutgoingRequest<A>, Self) -> R,
-        R: Future<Output = IlpResult> + Send + 'static,
+        F: Send + Sync + Fn(OutgoingRequest<A>, Box<dyn OutgoingService<A> + Send>) -> R,
+        R: Future<Output = IlpResult>,
         Self: Clone + Sized,
     {
         WrappedService::wrap_outgoing(self, f)
@@ -259,10 +259,10 @@ pub struct WrappedService<F, I, A> {
 
 impl<F, IO, A, R> WrappedService<F, IO, A>
 where
-    F: Fn(IncomingRequest<A>, IO) -> R,
+    F: Send + Sync + Fn(IncomingRequest<A>, Box<dyn IncomingService<A> + Send>) -> R,
+    R: Future<Output = IlpResult>,
     IO: IncomingService<A> + Clone,
     A: Account,
-    R: Future<Output = IlpResult> + Send + 'static,
 {
     /// Wrap the given service such that the provided function will
     /// be called to handle each request. That function can
@@ -280,22 +280,22 @@ where
 #[async_trait]
 impl<F, IO, A, R> IncomingService<A> for WrappedService<F, IO, A>
 where
-    F: Fn(IncomingRequest<A>, IO) -> R + Send + Sync,
-    IO: IncomingService<A> + Send + Sync + Clone,
-    A: Account,
+    F: Send + Sync + Fn(IncomingRequest<A>, Box<dyn IncomingService<A> + Send>) -> R,
     R: Future<Output = IlpResult> + Send + 'static,
+    IO: IncomingService<A> + Send + Sync + Clone + 'static,
+    A: Account + Sync,
 {
     async fn handle_request(&mut self, request: IncomingRequest<A>) -> IlpResult {
-        (self.f)(request, (*self.inner).clone()).await
+        (self.f)(request, Box::new((*self.inner).clone())).await
     }
 }
 
 impl<F, IO, A, R> WrappedService<F, IO, A>
 where
-    F: Fn(OutgoingRequest<A>, IO) -> R,
+    F: Send + Sync + Fn(OutgoingRequest<A>, Box<dyn OutgoingService<A> + Send>) -> R,
+    R: Future<Output = IlpResult>,
     IO: OutgoingService<A> + Clone,
     A: Account,
-    R: Future<Output = IlpResult> + Send + 'static,
 {
     /// Wrap the given service such that the provided function will
     /// be called to handle each request. That function can
@@ -313,13 +313,13 @@ where
 #[async_trait]
 impl<F, IO, A, R> OutgoingService<A> for WrappedService<F, IO, A>
 where
-    F: Fn(OutgoingRequest<A>, IO) -> R + Send + Sync,
-    IO: OutgoingService<A> + Clone + Send + Sync,
-    A: Account,
+    F: Send + Sync + Fn(OutgoingRequest<A>, Box<dyn OutgoingService<A> + Send>) -> R,
     R: Future<Output = IlpResult> + Send + 'static,
+    IO: OutgoingService<A> + Send + Sync + Clone + 'static,
+    A: Account,
 {
     async fn send_request(&mut self, request: OutgoingRequest<A>) -> IlpResult {
-        (self.f)(request, (*self.inner).clone()).await
+        (self.f)(request, Box::new((*self.inner).clone())).await
     }
 }
 
@@ -344,4 +344,210 @@ pub trait AddressStore: Clone {
     /// Gets the node's ILP Address *synchronously*
     /// (the value is stored in memory because it is read often by all services)
     fn get_ilp_address(&self) -> Address;
+}
+
+// Even though we wrap the types _a lot_ of times in multiple configurations
+// the tests still build nearly instantly. The trick is to make the wrapping function
+// take a trait object instead of the concrete type
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lazy_static::lazy_static;
+    use std::str::FromStr;
+
+    #[test]
+    fn incoming_service_no_exponential_blowup_when_wrapping() {
+        // a normal async function
+        async fn foo<A: Account>(
+            request: IncomingRequest<A>,
+            mut next: Box<dyn IncomingService<A> + Send>,
+        ) -> IlpResult {
+            next.handle_request(request).await
+        }
+
+        // and with a closure (async closure are unstable)
+        let bar = move |request, mut next: Box<dyn IncomingService<TestAccount> + Send>| {
+            async move { next.handle_request(request).await }
+        };
+
+        // base layer
+        let s = BaseService;
+        // our first layer
+        let s: LayeredService<_, TestAccount> = LayeredService::new_incoming(s);
+
+        // wrapped in our closure
+        let s = WrappedService::wrap_incoming(s, bar);
+        let s = WrappedService::wrap_incoming(s, bar);
+        let s = WrappedService::wrap_incoming(s, bar);
+        let s = WrappedService::wrap_incoming(s, bar);
+        let s = WrappedService::wrap_incoming(s, bar);
+
+        // wrap it again in the normal service
+        let s = LayeredService::new_incoming(s);
+
+        // some short syntax
+        let s = s.wrap(bar);
+        let s = s.wrap(foo);
+
+        // called with the full syntax
+        let s = WrappedService::wrap_incoming(s, foo);
+        let s = WrappedService::wrap_incoming(s, foo);
+        let s = WrappedService::wrap_incoming(s, foo);
+        let s = WrappedService::wrap_incoming(s, foo);
+        let s = WrappedService::wrap_incoming(s, foo);
+
+        // more short syntax
+        let s = s.wrap(bar);
+        let s = s.wrap(bar);
+        let _s = s.wrap(bar);
+    }
+
+    #[test]
+    fn outgoing_service_no_exponential_blowup_when_wrapping() {
+        // a normal async function
+        async fn foo<A: Account>(
+            request: OutgoingRequest<A>,
+            mut next: Box<dyn OutgoingService<A> + Send>,
+        ) -> IlpResult {
+            next.send_request(request).await
+        }
+
+        // and with a closure (async closure are unstable)
+        let bar = move |request, mut next: Box<dyn OutgoingService<TestAccount> + Send>| {
+            async move { next.send_request(request).await }
+        };
+
+        // base layer
+        let s = BaseService;
+        // our first layer
+        let s: LayeredService<_, TestAccount> = LayeredService::new_outgoing(s);
+
+        // wrapped in our closure
+        let s = WrappedService::wrap_outgoing(s, bar);
+        let s = WrappedService::wrap_outgoing(s, bar);
+        let s = WrappedService::wrap_outgoing(s, bar);
+        let s = WrappedService::wrap_outgoing(s, bar);
+        let s = WrappedService::wrap_outgoing(s, bar);
+
+        // wrap it again in the normal service
+        let s = LayeredService::new_outgoing(s);
+
+        // some short syntax
+        let s = s.wrap(bar);
+        let s = s.wrap(foo);
+
+        // called with the full syntax
+        let s = WrappedService::wrap_outgoing(s, foo);
+        let s = WrappedService::wrap_outgoing(s, foo);
+        let s = WrappedService::wrap_outgoing(s, foo);
+        let s = WrappedService::wrap_outgoing(s, foo);
+        let s = WrappedService::wrap_outgoing(s, foo);
+
+        // more short syntax
+        let s = s.wrap(bar);
+        let s = s.wrap(bar);
+        let _s = s.wrap(bar);
+    }
+
+    #[derive(Clone)]
+    struct BaseService;
+
+    #[derive(Clone)]
+    struct LayeredService<I, A> {
+        next: I,
+        account_type: PhantomData<A>,
+    }
+
+    impl<I, A> LayeredService<I, A>
+    where
+        I: IncomingService<A> + Send + Sync + 'static,
+        A: Account,
+    {
+        fn new_incoming(next: I) -> Self {
+            Self {
+                next,
+                account_type: PhantomData,
+            }
+        }
+    }
+
+    impl<I, A> LayeredService<I, A>
+    where
+        I: OutgoingService<A> + Send + Sync + 'static,
+        A: Account,
+    {
+        fn new_outgoing(next: I) -> Self {
+            Self {
+                next,
+                account_type: PhantomData,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl<A: Account + 'static> OutgoingService<A> for BaseService {
+        async fn send_request(&mut self, _request: OutgoingRequest<A>) -> IlpResult {
+            unimplemented!()
+        }
+    }
+
+    #[async_trait]
+    impl<A: Account + 'static> IncomingService<A> for BaseService {
+        async fn handle_request(&mut self, _request: IncomingRequest<A>) -> IlpResult {
+            unimplemented!()
+        }
+    }
+
+    #[async_trait]
+    impl<I, A> OutgoingService<A> for LayeredService<I, A>
+    where
+        I: OutgoingService<A> + Send + Sync + 'static,
+        A: Account + Send + Sync + 'static,
+    {
+        async fn send_request(&mut self, _request: OutgoingRequest<A>) -> IlpResult {
+            unimplemented!()
+        }
+    }
+
+    #[async_trait]
+    impl<I, A> IncomingService<A> for LayeredService<I, A>
+    where
+        I: IncomingService<A> + Send + Sync + 'static,
+        A: Account + Send + Sync + 'static,
+    {
+        async fn handle_request(&mut self, _request: IncomingRequest<A>) -> IlpResult {
+            unimplemented!()
+        }
+    }
+
+    // Account test helpers
+    #[derive(Clone, Debug)]
+    pub struct TestAccount;
+
+    lazy_static! {
+        pub static ref ALICE: Username = Username::from_str("alice").unwrap();
+        pub static ref EXAMPLE_ADDRESS: Address = Address::from_str("example.alice").unwrap();
+    }
+
+    impl Account for TestAccount {
+        fn id(&self) -> Uuid {
+            unimplemented!()
+        }
+
+        fn username(&self) -> &Username {
+            &ALICE
+        }
+
+        fn asset_scale(&self) -> u8 {
+            9
+        }
+
+        fn asset_code(&self) -> &str {
+            "XYZ"
+        }
+
+        fn ilp_address(&self) -> &Address {
+            &EXAMPLE_ADDRESS
+        }
+    }
 }

--- a/crates/interledger-service/src/lib.rs
+++ b/crates/interledger-service/src/lib.rs
@@ -366,7 +366,7 @@ mod tests {
         }
 
         // and with a closure (async closure are unstable)
-        let bar = move |request, mut next: Box<dyn IncomingService<TestAccount> + Send>| {
+        let foo2 = move |request, mut next: Box<dyn IncomingService<TestAccount> + Send>| {
             async move { next.handle_request(request).await }
         };
 
@@ -376,17 +376,17 @@ mod tests {
         let s: LayeredService<_, TestAccount> = LayeredService::new_incoming(s);
 
         // wrapped in our closure
-        let s = WrappedService::wrap_incoming(s, bar);
-        let s = WrappedService::wrap_incoming(s, bar);
-        let s = WrappedService::wrap_incoming(s, bar);
-        let s = WrappedService::wrap_incoming(s, bar);
-        let s = WrappedService::wrap_incoming(s, bar);
+        let s = WrappedService::wrap_incoming(s, foo2);
+        let s = WrappedService::wrap_incoming(s, foo2);
+        let s = WrappedService::wrap_incoming(s, foo2);
+        let s = WrappedService::wrap_incoming(s, foo2);
+        let s = WrappedService::wrap_incoming(s, foo2);
 
         // wrap it again in the normal service
         let s = LayeredService::new_incoming(s);
 
         // some short syntax
-        let s = s.wrap(bar);
+        let s = s.wrap(foo2);
         let s = s.wrap(foo);
 
         // called with the full syntax
@@ -397,9 +397,9 @@ mod tests {
         let s = WrappedService::wrap_incoming(s, foo);
 
         // more short syntax
-        let s = s.wrap(bar);
-        let s = s.wrap(bar);
-        let _s = s.wrap(bar);
+        let s = s.wrap(foo2);
+        let s = s.wrap(foo2);
+        let _s = s.wrap(foo2);
     }
 
     #[test]
@@ -413,7 +413,7 @@ mod tests {
         }
 
         // and with a closure (async closure are unstable)
-        let bar = move |request, mut next: Box<dyn OutgoingService<TestAccount> + Send>| {
+        let foo2 = move |request, mut next: Box<dyn OutgoingService<TestAccount> + Send>| {
             async move { next.send_request(request).await }
         };
 
@@ -423,17 +423,17 @@ mod tests {
         let s: LayeredService<_, TestAccount> = LayeredService::new_outgoing(s);
 
         // wrapped in our closure
-        let s = WrappedService::wrap_outgoing(s, bar);
-        let s = WrappedService::wrap_outgoing(s, bar);
-        let s = WrappedService::wrap_outgoing(s, bar);
-        let s = WrappedService::wrap_outgoing(s, bar);
-        let s = WrappedService::wrap_outgoing(s, bar);
+        let s = WrappedService::wrap_outgoing(s, foo2);
+        let s = WrappedService::wrap_outgoing(s, foo2);
+        let s = WrappedService::wrap_outgoing(s, foo2);
+        let s = WrappedService::wrap_outgoing(s, foo2);
+        let s = WrappedService::wrap_outgoing(s, foo2);
 
         // wrap it again in the normal service
         let s = LayeredService::new_outgoing(s);
 
         // some short syntax
-        let s = s.wrap(bar);
+        let s = s.wrap(foo2);
         let s = s.wrap(foo);
 
         // called with the full syntax
@@ -444,9 +444,9 @@ mod tests {
         let s = WrappedService::wrap_outgoing(s, foo);
 
         // more short syntax
-        let s = s.wrap(bar);
-        let s = s.wrap(bar);
-        let _s = s.wrap(bar);
+        let s = s.wrap(foo2);
+        let s = s.wrap(foo2);
+        let _s = s.wrap(foo2);
     }
 
     #[derive(Clone)]


### PR DESCRIPTION
This PR should fail. Exponential type blowup each time we're wrapping our services.

All the [wrapping done in `node.rs` ](https://github.com/interledger-rs/interledger-rs/blob/gakonst/15-futures03-node/crates/ilp-node/src/node.rs#L365-L366)is controlled via the feature-flags `monitoring` and `google-pubsub`.

Related: https://github.com/rust-lang/rust/issues/68508
