### PR TITLE
Add errors to the store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,7 +1063,6 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_path_to_error 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,6 +1040,7 @@ dependencies = [
  "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_path_to_error 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "warp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1248,6 +1249,7 @@ dependencies = [
  "secrecy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,6 +996,7 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "stream-cancel 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tungstenite 0.10.0 (git+https://github.com/snapview/tokio-tungstenite)",
  "tungstenite 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,8 +52,8 @@ name = "assert-json-diff"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -130,7 +130,16 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "buf_redux"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -156,7 +165,7 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -164,7 +173,7 @@ name = "bytes"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -192,10 +201,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chrono"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -238,8 +246,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -275,9 +283,9 @@ dependencies = [
  "rand_os 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xoshiro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -362,7 +370,7 @@ dependencies = [
  "csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -838,9 +846,9 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tungstenite 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -853,7 +861,7 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -872,8 +880,8 @@ dependencies = [
  "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -881,7 +889,7 @@ dependencies = [
  "tracing-subscriber 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "warp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "warp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "yup-oauth2 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -918,6 +926,7 @@ dependencies = [
  "interledger-api 0.3.0",
  "interledger-btp 0.4.0",
  "interledger-ccp 0.3.0",
+ "interledger-errors 0.1.0",
  "interledger-http 0.4.0",
  "interledger-ildcp 0.4.0",
  "interledger-packet 0.4.0",
@@ -941,6 +950,7 @@ dependencies = [
  "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "interledger-btp 0.4.0",
  "interledger-ccp 0.3.0",
+ "interledger-errors 0.1.0",
  "interledger-http 0.4.0",
  "interledger-ildcp 0.4.0",
  "interledger-packet 0.4.0",
@@ -954,13 +964,13 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_path_to_error 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "warp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "warp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -970,9 +980,10 @@ dependencies = [
  "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interledger-errors 0.1.0",
  "interledger-packet 0.4.0",
  "interledger-service 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -990,7 +1001,7 @@ dependencies = [
  "tungstenite 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "warp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "warp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1002,15 +1013,33 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interledger-errors 0.1.0",
  "interledger-packet 0.4.0",
  "interledger-service 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "interledger-errors"
+version = "0.1.0"
+dependencies = [
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interledger-packet 0.4.0",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redis 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_path_to_error 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "warp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1019,24 +1048,26 @@ version = "0.4.0"
 dependencies = [
  "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interledger-errors 0.1.0",
  "interledger-packet 0.4.0",
  "interledger-service 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_path_to_error 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "warp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "warp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1062,13 +1093,13 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_test 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1077,6 +1108,7 @@ name = "interledger-router"
 version = "0.4.0"
 dependencies = [
  "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interledger-errors 0.1.0",
  "interledger-packet 0.4.0",
  "interledger-service 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1093,11 +1125,12 @@ dependencies = [
  "async-trait 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interledger-errors 0.1.0",
  "interledger-packet 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-futures 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1112,9 +1145,10 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interledger-errors 0.1.0",
  "interledger-packet 0.4.0",
  "interledger-service 0.4.0",
  "interledger-settlement 0.3.0",
@@ -1123,7 +1157,7 @@ dependencies = [
  "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1138,6 +1172,7 @@ dependencies = [
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interledger-errors 0.1.0",
  "interledger-http 0.4.0",
  "interledger-packet 0.4.0",
  "interledger-service 0.4.0",
@@ -1152,13 +1187,13 @@ dependencies = [
  "redis 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "warp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "warp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1176,8 +1211,8 @@ dependencies = [
  "interledger-stream 0.4.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1193,6 +1228,7 @@ dependencies = [
  "interledger-api 0.3.0",
  "interledger-btp 0.4.0",
  "interledger-ccp 0.3.0",
+ "interledger-errors 0.1.0",
  "interledger-http 0.4.0",
  "interledger-packet 0.4.0",
  "interledger-router 0.4.0",
@@ -1210,8 +1246,8 @@ dependencies = [
  "redis 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "secrecy 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1226,11 +1262,12 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interledger-errors 0.1.0",
  "interledger-ildcp 0.4.0",
  "interledger-packet 0.4.0",
  "interledger-router 0.4.0",
@@ -1240,7 +1277,7 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1402,13 +1439,32 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mime"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "mime_guess"
+version = "1.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "mime_guess"
@@ -1470,8 +1526,25 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "multipart"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "buf_redux 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime_guess 1.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "twoway 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1590,7 +1663,7 @@ name = "os_type"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1634,6 +1707,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "phf"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "pin-project"
@@ -1732,6 +1840,24 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1740,6 +1866,15 @@ dependencies = [
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1774,10 +1909,49 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1787,6 +1961,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1853,13 +2044,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
-version = "1.3.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1907,8 +2098,8 @@ dependencies = [
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1960,6 +2151,11 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "same-file"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,7 +2196,7 @@ name = "secrecy"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2010,7 +2206,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2048,15 +2244,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2066,12 +2262,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.41"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2079,7 +2275,7 @@ name = "serde_path_to_error"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2087,7 +2283,7 @@ name = "serde_test"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2097,7 +2293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2115,6 +2311,11 @@ dependencies = [
 [[package]]
 name = "sha1"
 version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "siphasher"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2221,15 +2422,15 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror-impl 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2239,7 +2440,7 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "0.3.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2260,8 +2461,8 @@ name = "tinytemplate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2536,7 +2737,7 @@ name = "toml"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2600,11 +2801,11 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matchers 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-core 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-log 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2635,9 +2836,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "twoway"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "typenum"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicase"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "unicase"
@@ -2709,7 +2926,7 @@ dependencies = [
  "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2733,7 +2950,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2787,7 +3004,7 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2798,10 +3015,11 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multipart 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2820,8 +3038,8 @@ version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-macro 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2996,7 +3214,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3004,9 +3222,9 @@ dependencies = [
  "itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3037,6 +3255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 "checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"
+"checksum buf_redux 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
 "checksum bumpalo 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5fb8038c1ddc0a5f73787b130f4cc75151e96ed33e417fde765eb5a81e3532f4"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
@@ -3046,7 +3265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
+"checksum chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum combine 3.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
@@ -3135,12 +3354,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum metrics-observer-prometheus 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4f9bb94f40e189c87cf70ef1c78815b949ab9d28fe76ebb81f15f79bd19a33d6"
 "checksum metrics-runtime 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "15ef9de8e4a0dd82d38f8588ef40c11db7e12b75c45945fd3ef6993a708f7ced"
 "checksum metrics-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d11f8090a8886339f9468a04eeea0711e4cf27538b134014664308041307a1c5"
+"checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+"checksum mime_guess 1.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0d977de9ee851a0b16e932979515c0f3da82403183879811bc97d50bd9cc50f7"
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
 "checksum mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum mockito 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aee38c301104cc75a6628a4360be706fbdf84290c15a120b7e54eca5881c3450"
+"checksum multipart 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "136eed74cadb9edd2651ffba732b19a450316b680e4f48d6c79e905799e19d01"
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
@@ -3159,6 +3381,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+"checksum phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
+"checksum phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
+"checksum phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
+"checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pin-project 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "75fca1c4ff21f60ca2d37b80d72b63dab823a9d19d3cda3a81d18bc03f0ba8c5"
 "checksum pin-project-internal 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6544cd4e4ecace61075a6ec78074beeef98d58aa9a3d07d053d993b2946a90d6"
 "checksum pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
@@ -3172,20 +3398,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+"checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+"checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 "checksum rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 "checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+"checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+"checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+"checksum rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+"checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 "checksum rand_os 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a788ae3edb696cfcba1c19bfd388cc4b8c21f8a408432b199c072825084da58a"
+"checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rand_xoshiro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e18c91676f670f6f0312764c759405f13afb98d5d73819840cf72a518487bff"
 "checksum rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123"
 "checksum rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redis 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3eeb1fe3fc011cde97315f370bc88e4db3c23b08709a04915921e02b1d363b20"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-"checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
+"checksum regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b5508c1941e4e7cb19965abef075d35a9a8b5cdf0846f30b4050e9b55dc55e87"
 "checksum regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
@@ -3194,6 +3428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
+"checksum safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
 "checksum scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
@@ -3205,14 +3440,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum security-framework-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4b39bd9b0b087684013a792c59e3e07a46a01d2322518d8a1104641a0b1be0"
-"checksum serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "ca13fc1a832f793322228923fbb3aba9f3f44444898f835d31ad1b74fa0a2bf8"
-"checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
+"checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+"checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
+"checksum serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "eab8f15f15d6c41a154c1b128a22f2dfabe350ef53c40953d84e36155c91192b"
 "checksum serde_path_to_error 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "359b895005d818163c78a24d272cc98567cce80c2461cf73f513da1d296c0b62"
 "checksum serde_test 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "00d9d9443b1a25de2526ad21a2efc89267df5387c36035fe3902fbda8a79d83c"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+"checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum sized-chunks 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d3e7f23bad2d6694e0f46f5e470ec27eb07b8f3e8b309a4b0dc17501928b9f2"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
@@ -3226,9 +3462,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-"checksum thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6f357d1814b33bc2dc221243f8424104bfe72dbe911d5b71b3816a2dff1c977e"
-"checksum thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2e25d25307eb8436894f727aba8f65d07adf02e5b35a13cebed48bd282bfef"
-"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "205684fd018ca14432b12cce6ea3d46763311a571c3d294e71ba3f01adcf1aad"
+"checksum thiserror-impl 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "57e4d2e50ca050ed44fb58309bdce3efa79948f84f9993ad1978de5eebdce5a7"
+"checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4574b75faccaacddb9b284faecdf0b544b80b6b294f3d062d325c5726a209c20"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
@@ -3262,7 +3498,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum tracing-subscriber 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "192ca16595cdd0661ce319e8eede9c975f227cdaabc4faaefdc256f43d852e45"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum tungstenite 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8a0c2bd5aeb7dcd2bb32e472c8872759308495e5eccc942e929a513cd8d36110"
+"checksum twoway 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+"checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
@@ -3284,7 +3522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 "checksum want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
-"checksum warp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b11768dcc95dbbc7db573192cda35cdbbe59793f8409a4e11b87141a0930d6ed"
+"checksum warp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce153bc4ad61ed81c255cad4f1bf2474a1d284b482b20eecaefb152d0675fb1b"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c"
 "checksum wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "11cdb95816290b525b32587d76419facd99662a07e59d3cdb560488a819d9a45"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ members = [
   "./crates/interledger-spsp",
   "./crates/interledger-store",
   "./crates/interledger-stream",
+  "./crates/interledger-errors",
 ]

--- a/crates/ilp-node/src/lib.rs
+++ b/crates/ilp-node/src/lib.rs
@@ -1,4 +1,4 @@
-#![type_length_limit = "5000000"]
+#![type_length_limit = "7000000"]
 mod instrumentation;
 mod node;
 

--- a/crates/ilp-node/src/main.rs
+++ b/crates/ilp-node/src/main.rs
@@ -1,4 +1,4 @@
-#![type_length_limit = "5000000"]
+#![type_length_limit = "7000000"]
 mod instrumentation;
 pub mod node;
 

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -354,6 +354,7 @@ impl InterledgerNode {
             false,
             outgoing_service,
         )
+        .map_err(|err| error!("{}", err))
         .await?;
         let btp_server_service =
             BtpOutgoingService::new(ilp_address_clone2, btp_client_service.clone());

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -227,16 +227,15 @@ impl InterledgerNode {
     // connector instances to forward packets for that account to us
     pub async fn serve(self) -> Result<(), ()> {
         #[cfg(feature = "monitoring")]
-        let f =
-            futures::future::join(serve_prometheus(self.clone()), self.serve_node()).then(|r| {
-                async move {
-                    if r.0.is_ok() || r.1.is_ok() {
-                        Ok(())
-                    } else {
-                        Err(())
-                    }
+        let f = futures::future::join(serve_prometheus(self.clone()), self.serve_node()).then(
+            |r| async move {
+                if r.0.is_ok() || r.1.is_ok() {
+                    Ok(())
+                } else {
+                    Err(())
                 }
-            });
+            },
+        );
 
         #[cfg(not(feature = "monitoring"))]
         let f = self.serve_node();
@@ -429,12 +428,10 @@ impl InterledgerNode {
         #[cfg(feature = "monitoring")]
         let incoming_service_btp = incoming_service
             .clone()
-            .wrap(|request, mut next| {
-                async move {
-                    let btp = debug_span!(target: "interledger-node", "btp");
-                    let _btp_scope = btp.enter();
-                    next.handle_request(request).in_current_span().await
-                }
+            .wrap(|request, mut next| async move {
+                let btp = debug_span!(target: "interledger-node", "btp");
+                let _btp_scope = btp.enter();
+                next.handle_request(request).in_current_span().await
             })
             .in_current_span();
         #[cfg(not(feature = "monitoring"))]
@@ -451,12 +448,10 @@ impl InterledgerNode {
         #[cfg(feature = "monitoring")]
         let incoming_service_api = incoming_service
             .clone()
-            .wrap(|request, mut next| {
-                async move {
-                    let api = debug_span!(target: "interledger-node", "api");
-                    let _api_scope = api.enter();
-                    next.handle_request(request).in_current_span().await
-                }
+            .wrap(|request, mut next| async move {
+                let api = debug_span!(target: "interledger-node", "api");
+                let _api_scope = api.enter();
+                next.handle_request(request).in_current_span().await
             })
             .in_current_span();
         #[cfg(not(feature = "monitoring"))]
@@ -479,12 +474,10 @@ impl InterledgerNode {
         #[cfg(feature = "monitoring")]
         let incoming_service_http = incoming_service
             .clone()
-            .wrap(|request, mut next| {
-                async move {
-                    let http = debug_span!(target: "interledger-node", "http");
-                    let _http_scope = http.enter();
-                    next.handle_request(request).in_current_span().await
-                }
+            .wrap(|request, mut next| async move {
+                let http = debug_span!(target: "interledger-node", "http");
+                let _http_scope = http.enter();
+                next.handle_request(request).in_current_span().await
             })
             .in_current_span();
         #[cfg(not(feature = "monitoring"))]

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -29,13 +29,15 @@ use interledger::{
     api::{NodeApi, NodeStore},
     btp::{btp_service_as_filter, connect_client, BtpOutgoingService, BtpStore},
     ccp::{CcpRouteManagerBuilder, CcpRoutingAccount, RouteManagerStore, RoutingRelation},
-    http::{error::*, HttpClientService, HttpServer as IlpOverHttpServer, HttpStore},
+    errors::*,
+    http::{HttpClientService, HttpServer as IlpOverHttpServer, HttpStore},
     ildcp::IldcpService,
     packet::Address,
     packet::{ErrorCode, RejectBuilder},
     router::{Router, RouterStore},
     service::{
-        outgoing_service_fn, Account as AccountTrait, AccountStore, OutgoingRequest, Username,
+        outgoing_service_fn, Account as AccountTrait, AccountStore, AddressStore, OutgoingRequest,
+        Username,
     },
     service_util::{
         BalanceStore, EchoService, ExchangeRateFetcher, ExchangeRateService, ExchangeRateStore,
@@ -275,6 +277,7 @@ impl InterledgerNode {
     pub(crate) async fn chain_services<S>(self, store: S, ilp_address: Address) -> Result<(), ()>
     where
         S: NodeStore<Account = Account>
+            + AddressStore
             + BtpStore<Account = Account>
             + HttpStore<Account = Account>
             + StreamNotificationsStore<Account = Account>

--- a/crates/ilp-node/tests/redis/redis_tests.rs
+++ b/crates/ilp-node/tests/redis/redis_tests.rs
@@ -1,4 +1,4 @@
-#![type_length_limit = "5000000"]
+#![type_length_limit = "7000000"]
 mod btp;
 mod exchange_rates;
 mod three_nodes;

--- a/crates/interledger-api/Cargo.toml
+++ b/crates/interledger-api/Cargo.toml
@@ -34,6 +34,7 @@ warp = { version = "0.2", default-features = false }
 secrecy = { version = "0.6", default-features = false, features = ["serde"] }
 lazy_static = "1.4.0"
 async-trait = "0.1.22"
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false, features = ["warp_errors"] }
 
 [dev-dependencies]
 tokio = { version = "0.2.9", features = ["rt-core", "macros"] }

--- a/crates/interledger-api/src/routes/accounts.rs
+++ b/crates/interledger-api/src/routes/accounts.rs
@@ -324,9 +324,10 @@ where
                         pay_request.source_amount,
                     )
                     .map_err(|err| {
-                        error!("Error sending SPSP payment: {:?}", err);
+                        let msg = format!("Error sending SPSP payment: {}", err);
+                        error!("{}", msg);
                         // TODO give a different error message depending on what type of error it is
-                        Rejection::from(ApiError::internal_server_error())
+                        Rejection::from(ApiError::internal_server_error().detail(msg))
                     })
                     .await?;
 
@@ -390,7 +391,7 @@ where
                         .generate_http_response(),
                     )
                 } else {
-                    Err(Rejection::from(ApiError::not_found()))
+                    Err(Rejection::from(ApiError::not_found().detail("no default spsp account was configured")))
                 }
             }
         })
@@ -547,7 +548,6 @@ where
     // account's asset_code
     let default_settlement_engine = store
         .get_asset_settlement_engine(account.asset_code())
-        .map_err(|_| Rejection::from(ApiError::internal_server_error()))
         .await?;
 
     let settlement_engine_url = account

--- a/crates/interledger-api/src/routes/accounts.rs
+++ b/crates/interledger-api/src/routes/accounts.rs
@@ -391,7 +391,9 @@ where
                         .generate_http_response(),
                     )
                 } else {
-                    Err(Rejection::from(ApiError::not_found().detail("no default spsp account was configured")))
+                    Err(Rejection::from(
+                        ApiError::not_found().detail("no default spsp account was configured"),
+                    ))
                 }
             }
         })

--- a/crates/interledger-api/src/routes/accounts.rs
+++ b/crates/interledger-api/src/routes/accounts.rs
@@ -92,11 +92,9 @@ where
     // Converts an account username to an account id or errors out
     let account_username_to_id = warp::path::param::<Username>()
         .and(with_store.clone())
-        .and_then(move |username: Username, store: S| {
-            async move {
-                let id = store.get_account_id_from_username(&username).await?;
-                Ok::<_, Rejection>(id)
-            }
+        .and_then(move |username: Username, store: S| async move {
+            let id = store.get_account_id_from_username(&username).await?;
+            Ok::<_, Rejection>(id)
         })
         .boxed();
 
@@ -152,11 +150,9 @@ where
         .and(warp::header::<SecretString>("authorization"))
         .and(with_store.clone())
         .and_then(
-            move |path_username: Username, auth_string: SecretString, store: S| {
-                async move {
-                    let account = is_authorized_user(store, path_username, auth_string).await?;
-                    Ok::<A, Rejection>(account)
-                }
+            move |path_username: Username, auth_string: SecretString, store: S| async move {
+                let account = is_authorized_user(store, path_username, auth_string).await?;
+                Ok::<A, Rejection>(account)
             },
         )
         .boxed();
@@ -189,11 +185,9 @@ where
         .and(warp::path::end())
         .and(admin_only.clone())
         .and(with_store.clone())
-        .and_then(|store: S| {
-            async move {
-                let accounts = store.get_all_accounts().await?;
-                Ok::<Json, Rejection>(warp::reply::json(&accounts))
-            }
+        .and_then(|store: S| async move {
+            let accounts = store.get_all_accounts().await?;
+            Ok::<Json, Rejection>(warp::reply::json(&accounts))
         })
         .boxed();
 
@@ -224,12 +218,10 @@ where
         .and(admin_or_authorized_user_only.clone())
         .and(warp::path::end())
         .and(with_store.clone())
-        .and_then(|id: Uuid, store: S| {
-            async move {
-                let accounts = store.get_accounts(vec![id]).await?;
+        .and_then(|id: Uuid, store: S| async move {
+            let accounts = store.get_accounts(vec![id]).await?;
 
-                Ok::<Json, Rejection>(warp::reply::json(&accounts[0]))
-            }
+            Ok::<Json, Rejection>(warp::reply::json(&accounts[0]))
         })
         .boxed();
 
@@ -267,11 +259,9 @@ where
         .and(warp::path::end())
         .and(admin_only)
         .and(with_store.clone())
-        .and_then(|id: Uuid, store: S| {
-            async move {
-                let account = store.delete_account(id).await?;
-                Ok::<Json, Rejection>(warp::reply::json(&account))
-            }
+        .and_then(|id: Uuid, store: S| async move {
+            let account = store.delete_account(id).await?;
+            Ok::<Json, Rejection>(warp::reply::json(&account))
         })
         .boxed();
 
@@ -283,11 +273,9 @@ where
         .and(warp::path::end())
         .and(deserialize_json())
         .and(with_store.clone())
-        .and_then(|id: Uuid, settings: AccountSettings, store: S| {
-            async move {
-                let modified_account = store.modify_account_settings(id, settings).await?;
-                Ok::<Json, Rejection>(warp::reply::json(&modified_account))
-            }
+        .and_then(|id: Uuid, settings: AccountSettings, store: S| async move {
+            let modified_account = store.modify_account_settings(id, settings).await?;
+            Ok::<Json, Rejection>(warp::reply::json(&modified_account))
         })
         .boxed();
 

--- a/crates/interledger-api/src/routes/node_settings.rs
+++ b/crates/interledger-api/src/routes/node_settings.rs
@@ -1,11 +1,12 @@
 use crate::{http_retry::Client, ExchangeRates, NodeStore};
 use bytes::Bytes;
 use futures::TryFutureExt;
-use interledger_http::{deserialize_json, error::*, HttpAccount, HttpStore};
+use interledger_errors::*;
+use interledger_http::{deserialize_json, HttpAccount};
 use interledger_packet::Address;
 use interledger_router::RouterStore;
-use interledger_service::{Account, Username};
-use interledger_service_util::{BalanceStore, ExchangeRateStore};
+use interledger_service::{Account, AccountStore, AddressStore, Username};
+use interledger_service_util::ExchangeRateStore;
 use interledger_settlement::core::types::SettlementAccount;
 use log::{error, trace};
 use secrecy::{ExposeSecret, SecretString};
@@ -35,8 +36,8 @@ pub fn node_settings_api<S, A>(
 ) -> impl warp::Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone
 where
     S: NodeStore<Account = A>
-        + HttpStore<Account = A>
-        + BalanceStore<Account = A>
+        + AccountStore<Account = A>
+        + AddressStore
         + ExchangeRateStore
         + RouterStore,
     A: Account + HttpAccount + Send + Sync + SettlementAccount + Serialize + 'static,
@@ -122,10 +123,6 @@ where
                 let routes = store.routing_table().clone();
                 let accounts = store
                     .get_accounts(routes.values().cloned().collect())
-                    .map_err(|_| {
-                        error!("Error getting accounts from store");
-                        Rejection::from(ApiError::internal_server_error())
-                    })
                     .await?;
                 let routes: HashMap<String, String> = HashMap::from_iter(
                     routes
@@ -162,24 +159,12 @@ where
 
                 let mut account_ids: Vec<Uuid> = Vec::new();
                 for username in usernames {
-                    account_ids.push(
-                        store
-                            .get_account_id_from_username(&username)
-                            .map_err(|_| {
-                                error!("Error setting static routes");
-                                Rejection::from(ApiError::internal_server_error())
-                            })
-                            .await?,
-                    );
+                    account_ids.push(store.get_account_id_from_username(&username).await?);
                 }
 
                 let prefixes = routes.keys().map(|s| s.to_string());
                 store
                     .set_static_routes(prefixes.zip(account_ids.into_iter()))
-                    .map_err(|_| {
-                        error!("Error setting static routes");
-                        Rejection::from(ApiError::internal_server_error())
-                    })
                     .await?;
                 Ok::<Json, Rejection>(warp::reply::json(&routes))
             }
@@ -203,20 +188,8 @@ where
                 let username = Username::from_str(username_str)
                     .map_err(|_| Rejection::from(ApiError::bad_request()))?;
                 // Convert the username to an account ID to set it in the store
-                let account_id = store
-                    .get_account_id_from_username(&username)
-                    .map_err(|_| {
-                        error!("No account exists with username: {}", username);
-                        Rejection::from(ApiError::account_not_found())
-                    })
-                    .await?;
-                store
-                    .set_static_route(prefix, account_id)
-                    .map_err(|_| {
-                        error!("Error setting static route");
-                        Rejection::from(ApiError::internal_server_error())
-                    })
-                    .await?;
+                let account_id = store.get_account_id_from_username(&username).await?;
+                store.set_static_route(prefix, account_id).await?;
                 Ok::<String, Rejection>(username.to_string())
             }
         })
@@ -233,11 +206,7 @@ where
         .and_then(move |asset_to_url_map: HashMap<String, Url>, store: S| async move {
             let asset_to_url_map_clone = asset_to_url_map.clone();
             store
-                .set_settlement_engines(asset_to_url_map.clone())
-                .map_err(|_| {
-                    error!("Error setting settlement engines");
-                    Rejection::from(ApiError::internal_server_error())
-                }).await?;
+                .set_settlement_engines(asset_to_url_map.clone()).await?;
             // Create the accounts on the settlement engines for any
             // accounts that are using the default settlement engine URLs
             // (This is done in case we modify the globally configured settlement
@@ -247,8 +216,7 @@ where
             // the accounts are created that doesn't involve loading
             // all of the accounts from the database into memory
             // (even if this isn't called often, it could crash the node at some point)
-            let accounts = store.get_all_accounts()
-                .map_err(|_| Rejection::from(ApiError::internal_server_error())).await?;
+            let accounts = store.get_all_accounts().await?;
 
             let client = Client::default();
             // Try creating the account on the settlement engine if the settlement_engine_url of the

--- a/crates/interledger-api/src/routes/node_settings.rs
+++ b/crates/interledger-api/src/routes/node_settings.rs
@@ -83,11 +83,9 @@ where
         .and(admin_only.clone())
         .and(deserialize_json())
         .and(with_store.clone())
-        .and_then(|rates: ExchangeRates, store: S| {
-            async move {
-                store.set_exchange_rates(rates.0.clone())?;
-                Ok::<_, Rejection>(warp::reply::json(&rates))
-            }
+        .and_then(|rates: ExchangeRates, store: S| async move {
+            store.set_exchange_rates(rates.0.clone())?;
+            Ok::<_, Rejection>(warp::reply::json(&rates))
         })
         .boxed();
 
@@ -96,11 +94,9 @@ where
         .and(warp::path("rates"))
         .and(warp::path::end())
         .and(with_store.clone())
-        .and_then(|store: S| {
-            async move {
-                let rates = store.get_all_exchange_rates()?;
-                Ok::<_, Rejection>(warp::reply::json(&rates))
-            }
+        .and_then(|store: S| async move {
+            let rates = store.get_all_exchange_rates()?;
+            Ok::<_, Rejection>(warp::reply::json(&rates))
         })
         .boxed();
 

--- a/crates/interledger-api/src/routes/node_settings.rs
+++ b/crates/interledger-api/src/routes/node_settings.rs
@@ -51,7 +51,9 @@ where
                 if authorization.expose_secret() == &admin_auth_header {
                     Ok::<(), Rejection>(())
                 } else {
-                    Err(Rejection::from(ApiError::unauthorized().detail("invalid admin auth token provided")))
+                    Err(Rejection::from(
+                        ApiError::unauthorized().detail("invalid admin auth token provided"),
+                    ))
                 }
             }
         })
@@ -83,7 +85,7 @@ where
         .and(with_store.clone())
         .and_then(|rates: ExchangeRates, store: S| {
             async move {
-                let rates = store.set_exchange_rates(rates.0.clone())?;
+                store.set_exchange_rates(rates.0.clone())?;
                 Ok::<_, Rejection>(warp::reply::json(&rates))
             }
         })

--- a/crates/interledger-btp/Cargo.toml
+++ b/crates/interledger-btp/Cargo.toml
@@ -34,6 +34,7 @@ async-trait = "0.1.22"
 tokio = { version = "0.2.8", features = ["rt-core", "time", "stream", "macros"] }
 lazy_static = { version = "1.4.0", default-features = false }
 pin-project = "0.4.6"
+thiserror = "1.0.10"
 
 [dev-dependencies]
 hex = { version = "0.4.0", default-features = false }

--- a/crates/interledger-btp/Cargo.toml
+++ b/crates/interledger-btp/Cargo.toml
@@ -12,6 +12,7 @@ bytes = { version = "0.4.12", default-features = false }
 byteorder = { version = "1.3.2", default-features = false }
 chrono = { version = "0.4.9", default-features = false }
 futures = { version = "0.3.1", default-features = false }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false }
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 log = { version = "0.4.8", default-features = false }

--- a/crates/interledger-btp/src/lib.rs
+++ b/crates/interledger-btp/src/lib.rs
@@ -149,7 +149,7 @@ mod client_server {
                     }
                 })
                 .cloned()
-                .ok_or(BtpStoreError::Unauthorized(username.to_string()))
+                .ok_or_else(|| BtpStoreError::Unauthorized(username.to_string()))
         }
 
         async fn get_btp_outgoing_accounts(&self) -> Result<Vec<TestAccount>, BtpStoreError> {

--- a/crates/interledger-btp/src/service.rs
+++ b/crates/interledger-btp/src/service.rs
@@ -193,14 +193,12 @@ where
         // Close connections trigger
         let read = valve.wrap(read); // close when `write_to_ws` calls `drop(connection)`
         let read = self.stream_valve.wrap(read);
-        let read_from_ws = read.for_each(handle_message_fn).then(move |_| {
-            async move {
-                debug!(
-                    "Finished reading from WebSocket stream for account: {}",
-                    account_id
-                );
-                Ok::<(), ()>(())
-            }
+        let read_from_ws = read.for_each(handle_message_fn).then(move |_| async move {
+            debug!(
+                "Finished reading from WebSocket stream for account: {}",
+                account_id
+            );
+            Ok::<(), ()>(())
         });
         tokio::spawn(read_from_ws);
 

--- a/crates/interledger-ccp/Cargo.toml
+++ b/crates/interledger-ccp/Cargo.toml
@@ -12,6 +12,7 @@ bytes = { version = "0.4.12", default-features = false }
 byteorder = { version = "1.3.2", default-features = false }
 futures = { version = "0.3", default-features = false }
 hex = { version = "0.4.0", default-features = false }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false }
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 lazy_static = { version = "1.4.0", default-features = false }

--- a/crates/interledger-ccp/src/lib.rs
+++ b/crates/interledger-ccp/src/lib.rs
@@ -10,6 +10,7 @@
 //! we know about.
 
 use async_trait::async_trait;
+use interledger_errors::RouteManagerStoreError;
 use interledger_service::Account;
 use std::collections::HashMap;
 use std::{fmt, str::FromStr};
@@ -107,21 +108,23 @@ pub trait RouteManagerStore: Clone {
     /// Gets the local and manually configured routes
     async fn get_local_and_configured_routes(
         &self,
-    ) -> Result<LocalAndConfiguredRoutes<Self::Account>, ()>;
+    ) -> Result<LocalAndConfiguredRoutes<Self::Account>, RouteManagerStoreError>;
 
     /// Gets all accounts which the node should send routes to (Peer and Child accounts)
     /// The caller can also pass a vector of account ids to be ignored
     async fn get_accounts_to_send_routes_to(
         &self,
         ignore_accounts: Vec<Uuid>,
-    ) -> Result<Vec<Self::Account>, ()>;
+    ) -> Result<Vec<Self::Account>, RouteManagerStoreError>;
 
     /// Gets all accounts which the node should receive routes to (Peer and Parent accounts)
-    async fn get_accounts_to_receive_routes_from(&self) -> Result<Vec<Self::Account>, ()>;
+    async fn get_accounts_to_receive_routes_from(
+        &self,
+    ) -> Result<Vec<Self::Account>, RouteManagerStoreError>;
 
     /// Sets the new routes to the store (prefix -> account)
     async fn set_routes(
         &mut self,
         routes: impl IntoIterator<Item = (String, Self::Account)> + Send + 'async_trait,
-    ) -> Result<(), ()>;
+    ) -> Result<(), RouteManagerStoreError>;
 }

--- a/crates/interledger-ccp/src/test_helpers.rs
+++ b/crates/interledger-ccp/src/test_helpers.rs
@@ -2,6 +2,7 @@
 use super::*;
 use crate::{packet::CCP_RESPONSE, server::CcpRouteManager};
 use async_trait::async_trait;
+use interledger_errors::{AddressStoreError, RouteManagerStoreError};
 use interledger_packet::{Address, ErrorCode, RejectBuilder};
 use interledger_service::{
     incoming_service_fn, outgoing_service_fn, AddressStore, IncomingService, OutgoingRequest,
@@ -111,11 +112,11 @@ type RoutingTable<A> = HashMap<String, A>;
 #[async_trait]
 impl AddressStore for TestStore {
     /// Saves the ILP Address in the store's memory and database
-    async fn set_ilp_address(&self, _ilp_address: Address) -> Result<(), ()> {
+    async fn set_ilp_address(&self, _ilp_address: Address) -> Result<(), AddressStoreError> {
         unimplemented!()
     }
 
-    async fn clear_ilp_address(&self) -> Result<(), ()> {
+    async fn clear_ilp_address(&self) -> Result<(), AddressStoreError> {
         unimplemented!()
     }
 
@@ -131,14 +132,15 @@ impl RouteManagerStore for TestStore {
 
     async fn get_local_and_configured_routes(
         &self,
-    ) -> Result<(RoutingTable<TestAccount>, RoutingTable<TestAccount>), ()> {
+    ) -> Result<(RoutingTable<TestAccount>, RoutingTable<TestAccount>), RouteManagerStoreError>
+    {
         Ok((self.local.clone(), self.configured.clone()))
     }
 
     async fn get_accounts_to_send_routes_to(
         &self,
         ignore_accounts: Vec<Uuid>,
-    ) -> Result<Vec<TestAccount>, ()> {
+    ) -> Result<Vec<TestAccount>, RouteManagerStoreError> {
         let mut accounts: Vec<TestAccount> = self
             .local
             .values()
@@ -153,7 +155,9 @@ impl RouteManagerStore for TestStore {
         Ok(accounts)
     }
 
-    async fn get_accounts_to_receive_routes_from(&self) -> Result<Vec<TestAccount>, ()> {
+    async fn get_accounts_to_receive_routes_from(
+        &self,
+    ) -> Result<Vec<TestAccount>, RouteManagerStoreError> {
         let mut accounts: Vec<TestAccount> = self
             .local
             .values()
@@ -169,7 +173,7 @@ impl RouteManagerStore for TestStore {
     async fn set_routes(
         &mut self,
         routes: impl IntoIterator<Item = (String, TestAccount)> + Send + 'async_trait,
-    ) -> Result<(), ()> {
+    ) -> Result<(), RouteManagerStoreError> {
         *self.routes.lock() = HashMap::from_iter(routes.into_iter());
         Ok(())
     }

--- a/crates/interledger-errors/Cargo.toml
+++ b/crates/interledger-errors/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "interledger-errors"
+version = "0.1.0"
+authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+lazy_static = "1.4.0"
+thiserror = "1.0.10"
+serde = { version = "1.0.101", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0.41" }
+serde_path_to_error = { version = "0.1", default-features = false }
+http = { version = "0.2.0", default-features = false }
+chrono = { version = "0.4.9", features = ["clock"], default-features = false }
+regex = { version ="1.3.1", default-features = false, features = ["std"] }
+interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
+
+warp = { version = "0.2.1" }
+redis = { version = "0.15.1", optional = true }
+
+[features]
+warp_errors = []
+redis_errors = ["redis"]

--- a/crates/interledger-errors/Cargo.toml
+++ b/crates/interledger-errors/Cargo.toml
@@ -19,6 +19,7 @@ interledger-packet = { path = "../interledger-packet", version = "^0.4.0", defau
 
 warp = { version = "0.2.1" }
 redis = { version = "0.15.1", optional = true }
+url = "2.1.0"
 
 [features]
 warp_errors = []

--- a/crates/interledger-errors/src/account_store_error.rs
+++ b/crates/interledger-errors/src/account_store_error.rs
@@ -1,5 +1,5 @@
-use crate::error::ApiError;
 use super::BtpStoreError;
+use crate::error::ApiError;
 use std::error::Error as StdError;
 use thiserror::Error;
 

--- a/crates/interledger-errors/src/account_store_error.rs
+++ b/crates/interledger-errors/src/account_store_error.rs
@@ -1,0 +1,55 @@
+use crate::error::ApiError;
+use super::BtpStoreError;
+use std::error::Error as StdError;
+use thiserror::Error;
+
+/// Errors for the AccountStore
+#[derive(Error, Debug)]
+pub enum AccountStoreError {
+    #[error("{0}")]
+    Other(#[from] Box<dyn StdError + Send + 'static>),
+    #[error("account with username/id `{0}` was not found")]
+    AccountNotFound(String),
+    #[error("account with id `{0}` already exists")]
+    AccountExists(String),
+    #[error("wrong account length (expected {expected}, got {actual})")]
+    WrongLength { expected: usize, actual: usize },
+}
+
+impl From<AccountStoreError> for BtpStoreError {
+    fn from(src: AccountStoreError) -> Self {
+        match src {
+            AccountStoreError::AccountNotFound(s) => BtpStoreError::AccountNotFound(s),
+            _ => BtpStoreError::Other(Box::new(src)),
+        }
+    }
+}
+
+impl From<AccountStoreError> for ApiError {
+    fn from(src: AccountStoreError) -> Self {
+        match src {
+            AccountStoreError::AccountNotFound(_) => {
+                ApiError::account_not_found().detail(src.to_string())
+            }
+            AccountStoreError::AccountExists(_) => ApiError::conflict().detail(src.to_string()),
+            _ => ApiError::internal_server_error().detail(src.to_string()),
+        }
+    }
+}
+
+#[cfg(feature = "warp_errors")]
+impl From<AccountStoreError> for warp::Rejection {
+    fn from(src: AccountStoreError) -> Self {
+        ApiError::from(src).into()
+    }
+}
+
+#[cfg(feature = "redis_errors")]
+use redis::RedisError;
+
+#[cfg(feature = "redis_errors")]
+impl From<RedisError> for AccountStoreError {
+    fn from(err: RedisError) -> Self {
+        AccountStoreError::Other(Box::new(err))
+    }
+}

--- a/crates/interledger-errors/src/account_store_error.rs
+++ b/crates/interledger-errors/src/account_store_error.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 
 /// Errors for the AccountStore
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum AccountStoreError {
     #[error("{0}")]
     Other(#[from] Box<dyn StdError + Send + 'static>),

--- a/crates/interledger-errors/src/address_store_error.rs
+++ b/crates/interledger-errors/src/address_store_error.rs
@@ -3,8 +3,9 @@ use interledger_packet::Address;
 use std::error::Error as StdError;
 use thiserror::Error;
 
-/// Errors for the AccountStore
+/// Errors for the AddressStore
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum AddressStoreError {
     #[error("{0}")]
     Other(#[from] Box<dyn StdError + Send>),
@@ -36,6 +37,7 @@ impl From<AddressStoreError> for ApiError {
     }
 }
 
+#[cfg(feature = "warp_errors")]
 impl From<AddressStoreError> for warp::Rejection {
     fn from(src: AddressStoreError) -> Self {
         ApiError::from(src).into()

--- a/crates/interledger-errors/src/address_store_error.rs
+++ b/crates/interledger-errors/src/address_store_error.rs
@@ -1,0 +1,43 @@
+use super::{ApiError, NodeStoreError};
+use interledger_packet::Address;
+use std::error::Error as StdError;
+use thiserror::Error;
+
+/// Errors for the AccountStore
+#[derive(Error, Debug)]
+pub enum AddressStoreError {
+    #[error("{0}")]
+    Other(#[from] Box<dyn StdError + Send>),
+    #[error("Could not save address: {0}")]
+    SetAddress(Address),
+    #[error("Could not save address: {0}")]
+    ClearAddress(Address),
+}
+
+impl From<NodeStoreError> for AddressStoreError {
+    fn from(src: NodeStoreError) -> Self {
+        AddressStoreError::Other(Box::new(src))
+    }
+}
+
+#[cfg(feature = "redis_errors")]
+use redis::RedisError;
+#[cfg(feature = "redis_errors")]
+impl From<RedisError> for AddressStoreError {
+    fn from(src: RedisError) -> Self {
+        AddressStoreError::Other(Box::new(src))
+    }
+}
+
+impl From<AddressStoreError> for ApiError {
+    fn from(src: AddressStoreError) -> Self {
+        // AddressStore erroring is always an internal server error
+        ApiError::internal_server_error().detail(src.to_string())
+    }
+}
+
+impl From<AddressStoreError> for warp::Rejection {
+    fn from(src: AddressStoreError) -> Self {
+        ApiError::from(src).into()
+    }
+}

--- a/crates/interledger-errors/src/balance_store_error.rs
+++ b/crates/interledger-errors/src/balance_store_error.rs
@@ -2,14 +2,12 @@ use crate::error::ApiError;
 use std::error::Error as StdError;
 use thiserror::Error;
 
-/// Errors for the RouteManagerStore
+/// Errors for the BalanceStore
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum BalanceStoreError {
     #[error("{0}")]
     Other(#[from] Box<dyn StdError + Send + 'static>),
-    // Currently Balance store implementations only wrap around internal errors
-    // and do not produce any specific errors. If more errors are needed, this enum
-    // should be expanded
 }
 
 impl From<BalanceStoreError> for ApiError {

--- a/crates/interledger-errors/src/balance_store_error.rs
+++ b/crates/interledger-errors/src/balance_store_error.rs
@@ -1,0 +1,36 @@
+use crate::error::ApiError;
+use std::error::Error as StdError;
+use thiserror::Error;
+
+/// Errors for the RouteManagerStore
+#[derive(Error, Debug)]
+pub enum BalanceStoreError {
+    #[error("{0}")]
+    Other(#[from] Box<dyn StdError + Send + 'static>),
+    // Currently Balance store implementations only wrap around internal errors
+    // and do not produce any specific errors. If more errors are needed, this enum
+    // should be expanded
+}
+
+impl From<BalanceStoreError> for ApiError {
+    fn from(src: BalanceStoreError) -> Self {
+        ApiError::internal_server_error().detail(src.to_string())
+    }
+}
+
+#[cfg(feature = "warp_errors")]
+impl From<BalanceStoreError> for warp::Rejection {
+    fn from(src: BalanceStoreError) -> Self {
+        ApiError::from(src).into()
+    }
+}
+
+#[cfg(feature = "redis_errors")]
+use redis::RedisError;
+
+#[cfg(feature = "redis_errors")]
+impl From<RedisError> for BalanceStoreError {
+    fn from(src: RedisError) -> BalanceStoreError {
+        BalanceStoreError::Other(Box::new(src))
+    }
+}

--- a/crates/interledger-errors/src/btp_store_error.rs
+++ b/crates/interledger-errors/src/btp_store_error.rs
@@ -1,0 +1,43 @@
+use crate::error::ApiError;
+use std::error::Error as StdError;
+use thiserror::Error;
+
+/// Errors for the BtpStore
+#[derive(Error, Debug)]
+pub enum BtpStoreError {
+    #[error("{0}")]
+    Other(#[from] Box<dyn StdError + Send + 'static>),
+    #[error("account with username/id `{0}` was not found")]
+    AccountNotFound(String),
+    #[error("account with id `{0}` is not authorized for this action")]
+    Unauthorized(String),
+}
+
+impl From<BtpStoreError> for ApiError {
+    fn from(src: BtpStoreError) -> Self {
+        match src {
+            BtpStoreError::AccountNotFound(_) => {
+                ApiError::account_not_found().detail(src.to_string())
+            }
+            BtpStoreError::Unauthorized(_) => ApiError::unauthorized().detail(src.to_string()),
+            _ => ApiError::internal_server_error().detail(src.to_string()),
+        }
+    }
+}
+
+#[cfg(feature = "warp_errors")]
+impl From<BtpStoreError> for warp::Rejection {
+    fn from(src: BtpStoreError) -> Self {
+        ApiError::from(src).into()
+    }
+}
+
+#[cfg(feature = "redis_errors")]
+use redis::RedisError;
+
+#[cfg(feature = "redis_errors")]
+impl From<RedisError> for BtpStoreError {
+    fn from(src: RedisError) -> BtpStoreError {
+        BtpStoreError::Other(Box::new(src))
+    }
+}

--- a/crates/interledger-errors/src/btp_store_error.rs
+++ b/crates/interledger-errors/src/btp_store_error.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 
 /// Errors for the BtpStore
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum BtpStoreError {
     #[error("{0}")]
     Other(#[from] Box<dyn StdError + Send + 'static>),

--- a/crates/interledger-errors/src/create_account_error.rs
+++ b/crates/interledger-errors/src/create_account_error.rs
@@ -1,0 +1,44 @@
+use crate::error::ApiError;
+use interledger_packet::ParseError;
+use std::error::Error as StdError;
+use thiserror::Error;
+use url::ParseError as UrlParseError;
+
+/// Errors which can happen when creating an account
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum CreateAccountError {
+    #[error("{0}")]
+    Other(#[from] Box<dyn StdError + Send + 'static>),
+    #[error("the provided suffix is not valid: {0}")]
+    InvalidSuffix(ParseError),
+    #[error("the provided http url is not valid: {0}")]
+    InvalidHttpUrl(UrlParseError),
+    #[error("the provided btp url is not valid: {0}")]
+    InvalidBtpUrl(UrlParseError),
+    #[error("the provided routing relation not valid: {0}")]
+    InvalidRoutingRelation(String),
+}
+
+impl From<CreateAccountError> for ApiError {
+    fn from(src: CreateAccountError) -> Self {
+        ApiError::bad_request().detail(src.to_string())
+    }
+}
+
+#[cfg(feature = "warp_errors")]
+impl From<CreateAccountError> for warp::Rejection {
+    fn from(src: CreateAccountError) -> Self {
+        ApiError::from(src).into()
+    }
+}
+
+#[cfg(feature = "redis_errors")]
+use redis::RedisError;
+
+#[cfg(feature = "redis_errors")]
+impl From<RedisError> for CreateAccountError {
+    fn from(err: RedisError) -> Self {
+        CreateAccountError::Other(Box::new(err))
+    }
+}

--- a/crates/interledger-errors/src/error/error_types.rs
+++ b/crates/interledger-errors/src/error/error_types.rs
@@ -40,6 +40,13 @@ pub const DEFAULT_METHOD_NOT_ALLOWED_TYPE: ApiErrorType = ApiErrorType {
     status: StatusCode::METHOD_NOT_ALLOWED,
 };
 
+/// 409 Conflict HTTP Status Code (used for conflicts)
+pub const DEFAULT_CONFLICT_TYPE: ApiErrorType = ApiErrorType {
+    r#type: &ProblemType::Default,
+    title: "Provided resource already exists",
+    status: StatusCode::CONFLICT,
+};
+
 /// 409 Conflict HTTP Status Code (used for Idempotency Conflicts)
 pub const DEFAULT_IDEMPOTENT_CONFLICT_TYPE: ApiErrorType = ApiErrorType {
     r#type: &ProblemType::Default,

--- a/crates/interledger-errors/src/error/mod.rs
+++ b/crates/interledger-errors/src/error/mod.rs
@@ -173,6 +173,13 @@ impl ApiError {
         ApiError::from_api_error_type(&DEFAULT_IDEMPOTENT_CONFLICT_TYPE)
     }
 
+    #[allow(dead_code)]
+    /// Returns an Conflict [ApiError](./struct.ApiError.html)
+    /// via the [default conflict ApiErrorType](./error_types/constant.DEFAULT_CONFLICT_TYPE.html)
+    pub fn conflict() -> Self {
+        ApiError::from_api_error_type(&DEFAULT_CONFLICT_TYPE)
+    }
+
     /// Returns an Invalid Account Id [ApiError](./struct.ApiError.html)
     pub fn invalid_account_id(invalid_account_id: Option<&str>) -> Self {
         let detail = match invalid_account_id {

--- a/crates/interledger-errors/src/exchange_rate_store_error.rs
+++ b/crates/interledger-errors/src/exchange_rate_store_error.rs
@@ -2,8 +2,9 @@ use crate::error::ApiError;
 use std::error::Error as StdError;
 use thiserror::Error;
 
-/// Errors for the RouteManagerStore
+/// Errors for the ExchangeRateStore
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum ExchangeRateStoreError {
     #[error("{0}")]
     Other(#[from] Box<dyn StdError + Send + 'static>),

--- a/crates/interledger-errors/src/exchange_rate_store_error.rs
+++ b/crates/interledger-errors/src/exchange_rate_store_error.rs
@@ -1,0 +1,25 @@
+use crate::error::ApiError;
+use std::error::Error as StdError;
+use thiserror::Error;
+
+/// Errors for the RouteManagerStore
+#[derive(Error, Debug)]
+pub enum ExchangeRateStoreError {
+    #[error("{0}")]
+    Other(#[from] Box<dyn StdError + Send + 'static>),
+    #[error("Pair {from}/{to} not found")]
+    PairNotFound { from: String, to: String },
+}
+
+impl From<ExchangeRateStoreError> for ApiError {
+    fn from(src: ExchangeRateStoreError) -> Self {
+        ApiError::internal_server_error().detail(src.to_string())
+    }
+}
+
+#[cfg(feature = "warp_errors")]
+impl From<ExchangeRateStoreError> for warp::Rejection {
+    fn from(src: ExchangeRateStoreError) -> Self {
+        ApiError::from(src).into()
+    }
+}

--- a/crates/interledger-errors/src/http_store_error.rs
+++ b/crates/interledger-errors/src/http_store_error.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 
 /// Errors for the HttpStore
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum HttpStoreError {
     #[error("{0}")]
     Other(#[from] Box<dyn StdError + Send + 'static>),

--- a/crates/interledger-errors/src/http_store_error.rs
+++ b/crates/interledger-errors/src/http_store_error.rs
@@ -1,0 +1,43 @@
+use crate::error::ApiError;
+use std::error::Error as StdError;
+use thiserror::Error;
+
+/// Errors for the HttpStore
+#[derive(Error, Debug)]
+pub enum HttpStoreError {
+    #[error("{0}")]
+    Other(#[from] Box<dyn StdError + Send + 'static>),
+    #[error("account with username/id `{0}` was not found")]
+    AccountNotFound(String),
+    #[error("account with id `{0}` is not authorized for this action")]
+    Unauthorized(String),
+}
+
+impl From<HttpStoreError> for ApiError {
+    fn from(src: HttpStoreError) -> Self {
+        match src {
+            HttpStoreError::AccountNotFound(_) => {
+                ApiError::account_not_found().detail(src.to_string())
+            }
+            HttpStoreError::Unauthorized(_) => ApiError::unauthorized().detail(src.to_string()),
+            _ => ApiError::internal_server_error().detail(src.to_string()),
+        }
+    }
+}
+
+#[cfg(feature = "warp_errors")]
+impl From<HttpStoreError> for warp::Rejection {
+    fn from(src: HttpStoreError) -> Self {
+        ApiError::from(src).into()
+    }
+}
+
+#[cfg(feature = "redis_errors")]
+use redis::RedisError;
+
+#[cfg(feature = "redis_errors")]
+impl From<RedisError> for HttpStoreError {
+    fn from(src: RedisError) -> HttpStoreError {
+        HttpStoreError::Other(Box::new(src))
+    }
+}

--- a/crates/interledger-errors/src/lib.rs
+++ b/crates/interledger-errors/src/lib.rs
@@ -28,3 +28,6 @@ pub use exchange_rate_store_error::ExchangeRateStoreError;
 
 mod settlement_errors;
 pub use settlement_errors::{IdempotentStoreError, LeftoversStoreError, SettlementStoreError};
+
+mod create_account_error;
+pub use create_account_error::CreateAccountError;

--- a/crates/interledger-errors/src/lib.rs
+++ b/crates/interledger-errors/src/lib.rs
@@ -1,0 +1,30 @@
+/// [RFC7807](https://tools.ietf.org/html/rfc7807) compliant errors
+mod error;
+pub use error::*;
+
+mod account_store_error;
+pub use account_store_error::AccountStoreError;
+
+mod address_store_error;
+pub use address_store_error::AddressStoreError;
+
+mod http_store_error;
+pub use http_store_error::HttpStoreError;
+
+mod btp_store_error;
+pub use btp_store_error::BtpStoreError;
+
+mod routemanager_store_error;
+pub use routemanager_store_error::RouteManagerStoreError;
+
+mod balance_store_error;
+pub use balance_store_error::BalanceStoreError;
+
+mod node_store_error;
+pub use node_store_error::NodeStoreError;
+
+mod exchange_rate_store_error;
+pub use exchange_rate_store_error::ExchangeRateStoreError;
+
+mod settlement_errors;
+pub use settlement_errors::{IdempotentStoreError, LeftoversStoreError, SettlementStoreError};

--- a/crates/interledger-errors/src/node_store_error.rs
+++ b/crates/interledger-errors/src/node_store_error.rs
@@ -1,4 +1,4 @@
-use super::{AccountStoreError, BtpStoreError};
+use super::{AccountStoreError, BtpStoreError, CreateAccountError};
 use crate::error::ApiError;
 use std::error::Error as StdError;
 use thiserror::Error;
@@ -18,7 +18,7 @@ pub enum NodeStoreError {
     #[error("not all of the given accounts exist")]
     MissingAccounts,
     #[error("invalid account: {0}")]
-    InvalidAccount(String),
+    InvalidAccount(CreateAccountError),
 }
 
 impl From<NodeStoreError> for BtpStoreError {

--- a/crates/interledger-errors/src/node_store_error.rs
+++ b/crates/interledger-errors/src/node_store_error.rs
@@ -3,8 +3,9 @@ use crate::error::ApiError;
 use std::error::Error as StdError;
 use thiserror::Error;
 
-/// Errors for the RouteManagerStore
+/// Errors for the NodeStore
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum NodeStoreError {
     #[error("{0}")]
     Other(#[from] Box<dyn StdError + Send + 'static>),

--- a/crates/interledger-errors/src/node_store_error.rs
+++ b/crates/interledger-errors/src/node_store_error.rs
@@ -1,0 +1,69 @@
+use super::{AccountStoreError, BtpStoreError};
+use crate::error::ApiError;
+use std::error::Error as StdError;
+use thiserror::Error;
+
+/// Errors for the RouteManagerStore
+#[derive(Error, Debug)]
+pub enum NodeStoreError {
+    #[error("{0}")]
+    Other(#[from] Box<dyn StdError + Send + 'static>),
+    #[error("Settlement engine URL loaded was not a valid url: {0}")]
+    InvalidEngineUrl(String),
+    #[error("account with username/id `{0}` was not found")]
+    AccountNotFound(String),
+    #[error("account with id `{0}` already exists")]
+    AccountExists(String),
+    #[error("not all of the given accounts exist")]
+    MissingAccounts,
+    #[error("invalid account: {0}")]
+    InvalidAccount(String),
+}
+
+impl From<NodeStoreError> for BtpStoreError {
+    fn from(src: NodeStoreError) -> Self {
+        match src {
+            NodeStoreError::AccountNotFound(s) => BtpStoreError::AccountNotFound(s),
+            _ => BtpStoreError::Other(Box::new(src)),
+        }
+    }
+}
+
+impl From<AccountStoreError> for NodeStoreError {
+    fn from(src: AccountStoreError) -> Self {
+        match src {
+            AccountStoreError::AccountNotFound(s) => NodeStoreError::AccountNotFound(s),
+            _ => NodeStoreError::Other(Box::new(src)),
+        }
+    }
+}
+
+impl From<NodeStoreError> for ApiError {
+    fn from(src: NodeStoreError) -> Self {
+        match src {
+            NodeStoreError::AccountNotFound(_) => {
+                ApiError::account_not_found().detail(src.to_string())
+            }
+            NodeStoreError::InvalidAccount(_) | NodeStoreError::InvalidEngineUrl(_) => {
+                ApiError::bad_request().detail(src.to_string())
+            }
+            _ => ApiError::internal_server_error().detail(src.to_string()),
+        }
+    }
+}
+
+#[cfg(feature = "warp_errors")]
+impl From<NodeStoreError> for warp::Rejection {
+    fn from(src: NodeStoreError) -> Self {
+        ApiError::from(src).into()
+    }
+}
+
+#[cfg(feature = "redis_errors")]
+use redis::RedisError;
+#[cfg(feature = "redis_errors")]
+impl From<RedisError> for NodeStoreError {
+    fn from(src: RedisError) -> Self {
+        NodeStoreError::Other(Box::new(src))
+    }
+}

--- a/crates/interledger-errors/src/routemanager_store_error.rs
+++ b/crates/interledger-errors/src/routemanager_store_error.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 
 /// Errors for the RouteManagerStore
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum RouteManagerStoreError {
     #[error("{0}")]
     Other(#[from] Box<dyn StdError + Send + 'static>),

--- a/crates/interledger-errors/src/routemanager_store_error.rs
+++ b/crates/interledger-errors/src/routemanager_store_error.rs
@@ -1,0 +1,49 @@
+use super::{AccountStoreError, NodeStoreError};
+use crate::error::ApiError;
+use std::error::Error as StdError;
+use thiserror::Error;
+
+/// Errors for the RouteManagerStore
+#[derive(Error, Debug)]
+pub enum RouteManagerStoreError {
+    #[error("{0}")]
+    Other(#[from] Box<dyn StdError + Send + 'static>),
+    // TODO: What else should we include for this type of store?
+}
+
+impl From<AccountStoreError> for RouteManagerStoreError {
+    fn from(src: AccountStoreError) -> Self {
+        RouteManagerStoreError::Other(Box::new(src))
+    }
+}
+
+impl From<NodeStoreError> for RouteManagerStoreError {
+    fn from(src: NodeStoreError) -> Self {
+        RouteManagerStoreError::Other(Box::new(src))
+    }
+}
+
+impl From<RouteManagerStoreError> for ApiError {
+    fn from(src: RouteManagerStoreError) -> Self {
+        match src {
+            _ => ApiError::method_not_allowed(),
+        }
+    }
+}
+
+#[cfg(feature = "warp_errors")]
+impl From<RouteManagerStoreError> for warp::Rejection {
+    fn from(src: RouteManagerStoreError) -> Self {
+        ApiError::from(src).into()
+    }
+}
+
+#[cfg(feature = "redis_errors")]
+use redis::RedisError;
+
+#[cfg(feature = "redis_errors")]
+impl From<RedisError> for RouteManagerStoreError {
+    fn from(src: RedisError) -> RouteManagerStoreError {
+        RouteManagerStoreError::Other(Box::new(src))
+    }
+}

--- a/crates/interledger-errors/src/routemanager_store_error.rs
+++ b/crates/interledger-errors/src/routemanager_store_error.rs
@@ -9,7 +9,6 @@ use thiserror::Error;
 pub enum RouteManagerStoreError {
     #[error("{0}")]
     Other(#[from] Box<dyn StdError + Send + 'static>),
-    // TODO: What else should we include for this type of store?
 }
 
 impl From<AccountStoreError> for RouteManagerStoreError {

--- a/crates/interledger-errors/src/settlement_errors.rs
+++ b/crates/interledger-errors/src/settlement_errors.rs
@@ -1,0 +1,105 @@
+use crate::error::ApiError;
+use std::error::Error as StdError;
+use thiserror::Error;
+
+/// Errors for the LeftoversStore
+#[derive(Error, Debug)]
+pub enum LeftoversStoreError {
+    #[error("{0}")]
+    Other(#[from] Box<dyn StdError + Send + 'static>),
+    // TODO: What else should we include for this type of store?
+}
+
+impl From<LeftoversStoreError> for ApiError {
+    fn from(src: LeftoversStoreError) -> Self {
+        match src {
+            _ => ApiError::method_not_allowed(),
+        }
+    }
+}
+
+#[cfg(feature = "warp_errors")]
+impl From<LeftoversStoreError> for warp::Rejection {
+    fn from(src: LeftoversStoreError) -> Self {
+        ApiError::from(src).into()
+    }
+}
+
+/// Errors for the IdempotentStore
+#[derive(Error, Debug)]
+pub enum IdempotentStoreError {
+    #[error("{0}")]
+    Other(#[from] Box<dyn StdError + Send + 'static>),
+    // TODO: What else should we include for this type of store?
+}
+
+impl From<IdempotentStoreError> for ApiError {
+    fn from(src: IdempotentStoreError) -> Self {
+        match src {
+            _ => ApiError::method_not_allowed(),
+        }
+    }
+}
+
+#[cfg(feature = "warp_errors")]
+impl From<IdempotentStoreError> for warp::Rejection {
+    fn from(src: IdempotentStoreError) -> Self {
+        ApiError::from(src).into()
+    }
+}
+
+/// Errors for the SettlementStore
+#[derive(Error, Debug)]
+pub enum SettlementStoreError {
+    #[error("{0}")]
+    Other(#[from] Box<dyn StdError + Send + 'static>),
+    #[error("could not update balance for incoming settlement")]
+    BalanceUpdateFailure,
+    #[error("could not refund settlement")]
+    RefundFailure,
+}
+
+impl From<SettlementStoreError> for ApiError {
+    fn from(src: SettlementStoreError) -> Self {
+        match src {
+            _ => ApiError::method_not_allowed(),
+        }
+    }
+}
+
+impl From<LeftoversStoreError> for SettlementStoreError {
+    fn from(src: LeftoversStoreError) -> SettlementStoreError {
+        SettlementStoreError::Other(Box::new(src))
+    }
+}
+
+#[cfg(feature = "warp_errors")]
+impl From<SettlementStoreError> for warp::Rejection {
+    fn from(src: SettlementStoreError) -> Self {
+        ApiError::from(src).into()
+    }
+}
+
+#[cfg(feature = "redis_errors")]
+use redis::RedisError;
+
+#[cfg(feature = "redis_errors")]
+impl From<RedisError> for SettlementStoreError {
+    fn from(src: RedisError) -> SettlementStoreError {
+        SettlementStoreError::Other(Box::new(src))
+    }
+}
+
+#[cfg(feature = "redis_errors")]
+impl From<RedisError> for LeftoversStoreError {
+    fn from(src: RedisError) -> LeftoversStoreError {
+        LeftoversStoreError::Other(Box::new(src))
+    }
+}
+
+#[cfg(feature = "redis_errors")]
+impl From<RedisError> for IdempotentStoreError {
+    fn from(src: RedisError) -> IdempotentStoreError {
+        IdempotentStoreError::Other(Box::new(src))
+    }
+}

--- a/crates/interledger-errors/src/settlement_errors.rs
+++ b/crates/interledger-errors/src/settlement_errors.rs
@@ -4,10 +4,10 @@ use thiserror::Error;
 
 /// Errors for the LeftoversStore
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum LeftoversStoreError {
     #[error("{0}")]
     Other(#[from] Box<dyn StdError + Send + 'static>),
-    // TODO: What else should we include for this type of store?
 }
 
 impl From<LeftoversStoreError> for ApiError {
@@ -27,10 +27,10 @@ impl From<LeftoversStoreError> for warp::Rejection {
 
 /// Errors for the IdempotentStore
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum IdempotentStoreError {
     #[error("{0}")]
     Other(#[from] Box<dyn StdError + Send + 'static>),
-    // TODO: What else should we include for this type of store?
 }
 
 impl From<IdempotentStoreError> for ApiError {
@@ -50,6 +50,7 @@ impl From<IdempotentStoreError> for warp::Rejection {
 
 /// Errors for the SettlementStore
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum SettlementStoreError {
     #[error("{0}")]
     Other(#[from] Box<dyn StdError + Send + 'static>),

--- a/crates/interledger-http/Cargo.toml
+++ b/crates/interledger-http/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 [dependencies]
 bytes = { version = "0.5", default-features = false }
 futures = { version = "0.3", default-features = false }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false }
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 log = { version = "0.4.8", default-features = false }

--- a/crates/interledger-http/src/server.rs
+++ b/crates/interledger-http/src/server.rs
@@ -1,6 +1,7 @@
-use super::{error::*, HttpStore};
+use super::HttpStore;
 use bytes::{Bytes, BytesMut};
 use futures::TryFutureExt;
+use interledger_errors::ApiError;
 use interledger_packet::Prepare;
 use interledger_service::Username;
 use interledger_service::{IncomingRequest, IncomingService};
@@ -46,6 +47,7 @@ where
             &path_username,
             &password.expose_secret()[BEARER_TOKEN_START..],
         )
+        .map_err(|_| ())
         .await
 }
 
@@ -149,6 +151,7 @@ mod tests {
     use async_trait::async_trait;
     use bytes::BytesMut;
     use http::Response;
+    use interledger_errors::{default_rejection_handler, HttpStoreError};
     use interledger_packet::{Address, ErrorCode, PrepareBuilder, RejectBuilder};
     use interledger_service::{incoming_service_fn, Account};
     use lazy_static::lazy_static;
@@ -262,15 +265,16 @@ mod tests {
     #[async_trait]
     impl HttpStore for TestStore {
         type Account = TestAccount;
+
         async fn get_account_from_http_auth(
             &self,
             username: &Username,
             token: &str,
-        ) -> Result<Self::Account, ()> {
+        ) -> Result<Self::Account, HttpStoreError> {
             if username == &*USERNAME && token == AUTH_PASSWORD {
                 Ok(TestAccount)
             } else {
-                Err(())
+                Err(HttpStoreError::Unauthorized(username.to_string()))
             }
         }
     }

--- a/crates/interledger-router/Cargo.toml
+++ b/crates/interledger-router/Cargo.toml
@@ -18,3 +18,4 @@ async-trait = "0.1.22"
 [dev-dependencies]
 lazy_static = { version = "1.4.0", default-features = false }
 tokio = { version = "0.2.6", features = ["rt-core", "macros"]}
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false }

--- a/crates/interledger-router/src/router.rs
+++ b/crates/interledger-router/src/router.rs
@@ -140,6 +140,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use interledger_errors::*;
     use interledger_packet::{Address, FulfillBuilder, PrepareBuilder};
     use interledger_service::outgoing_service_fn;
     use lazy_static::lazy_static;
@@ -190,12 +191,18 @@ mod tests {
     impl AccountStore for TestStore {
         type Account = TestAccount;
 
-        async fn get_accounts(&self, account_ids: Vec<Uuid>) -> Result<Vec<TestAccount>, ()> {
+        async fn get_accounts(
+            &self,
+            account_ids: Vec<Uuid>,
+        ) -> Result<Vec<TestAccount>, AccountStoreError> {
             Ok(account_ids.into_iter().map(TestAccount).collect())
         }
 
         // stub implementation (not used in these tests)
-        async fn get_account_id_from_username(&self, _username: &Username) -> Result<Uuid, ()> {
+        async fn get_account_id_from_username(
+            &self,
+            _username: &Username,
+        ) -> Result<Uuid, AccountStoreError> {
             Ok(Uuid::new_v4())
         }
     }
@@ -203,11 +210,11 @@ mod tests {
     #[async_trait]
     impl AddressStore for TestStore {
         /// Saves the ILP Address in the store's memory and database
-        async fn set_ilp_address(&self, _ilp_address: Address) -> Result<(), ()> {
+        async fn set_ilp_address(&self, _ilp_address: Address) -> Result<(), AddressStoreError> {
             Ok(())
         }
 
-        async fn clear_ilp_address(&self) -> Result<(), ()> {
+        async fn clear_ilp_address(&self) -> Result<(), AddressStoreError> {
             Ok(())
         }
 

--- a/crates/interledger-service-util/Cargo.toml
+++ b/crates/interledger-service-util/Cargo.toml
@@ -13,6 +13,7 @@ byteorder = { version = "1.3.2", default-features = false }
 chrono = { version = "0.4.9", default-features = false, features = ["clock"] }
 futures = { version = "0.3.1", default-features = false }
 hex = { version = "0.4.0", default-features = false }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false }
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 interledger-settlement = { path = "../interledger-settlement", version = "^0.3.0", default-features = false, features = ["settlement_api"] }
@@ -24,6 +25,7 @@ secrecy = { version = "0.6", default-features = false, features = ["alloc", "ser
 serde = { version = "1.0.101", default-features = false, features = ["derive"]}
 tokio = { version = "0.2.6", default-features = false, features = ["macros", "time"] }
 async-trait = "0.1.22"
+uuid = "0.8.1"
 
 [dev-dependencies]
 uuid = { version = "0.8.1", default-features = false}

--- a/crates/interledger-service-util/src/echo_service.rs
+++ b/crates/interledger-service-util/src/echo_service.rs
@@ -215,6 +215,7 @@ impl<'a> EchoResponseBuilder<'a> {
 #[cfg(test)]
 mod echo_tests {
     use super::*;
+    use interledger_errors::AddressStoreError;
     use interledger_packet::{FulfillBuilder, PrepareBuilder};
     use interledger_service::incoming_service_fn;
     use lazy_static::lazy_static;
@@ -235,11 +236,11 @@ mod echo_tests {
     #[async_trait]
     impl AddressStore for TestStore {
         /// Saves the ILP Address in the store's memory and database
-        async fn set_ilp_address(&self, _ilp_address: Address) -> Result<(), ()> {
+        async fn set_ilp_address(&self, _ilp_address: Address) -> Result<(), AddressStoreError> {
             unimplemented!()
         }
 
-        async fn clear_ilp_address(&self) -> Result<(), ()> {
+        async fn clear_ilp_address(&self) -> Result<(), AddressStoreError> {
             unimplemented!()
         }
 

--- a/crates/interledger-service-util/src/rate_limit_service.rs
+++ b/crates/interledger-service-util/src/rate_limit_service.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use interledger_packet::{ErrorCode, RejectBuilder};
 use interledger_service::{Account, AddressStore, IlpResult, IncomingRequest, IncomingService};
 use log::{error, warn};
+use std::fmt::Debug;
 use std::marker::PhantomData;
 
 /// Extension trait for [`Account`](../interledger_service/trait.Account.html) with rate limiting related information
@@ -50,7 +51,7 @@ pub trait RateLimitStore {
         &self,
         account: Self::Account,
         prepare_amount: u64,
-    ) -> Result<(), ()>;
+    ) -> Result<(), RateLimitError>;
 }
 
 /// # Rate Limit Service

--- a/crates/interledger-service-util/src/validator_service.rs
+++ b/crates/interledger-service-util/src/validator_service.rs
@@ -214,14 +214,17 @@ impl Account for TestAccount {
 struct TestStore;
 
 #[cfg(test)]
+use interledger_errors::AddressStoreError;
+
+#[cfg(test)]
 #[async_trait]
 impl AddressStore for TestStore {
     /// Saves the ILP Address in the store's memory and database
-    async fn set_ilp_address(&self, _ilp_address: Address) -> Result<(), ()> {
+    async fn set_ilp_address(&self, _ilp_address: Address) -> Result<(), AddressStoreError> {
         unimplemented!()
     }
 
-    async fn clear_ilp_address(&self) -> Result<(), ()> {
+    async fn clear_ilp_address(&self) -> Result<(), AddressStoreError> {
         unimplemented!()
     }
 

--- a/crates/interledger-service/Cargo.toml
+++ b/crates/interledger-service/Cargo.toml
@@ -13,6 +13,7 @@ trace = ["tracing-futures"]
 
 [dependencies]
 futures = { version = "0.3.1", default-features = true }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0" }
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
 serde = { version = "1.0.101", default-features = false, features = ["derive"] }
 base64 = { version = "0.10.1", default-features = false }

--- a/crates/interledger-service/src/lib.rs
+++ b/crates/interledger-service/src/lib.rs
@@ -367,8 +367,8 @@ mod tests {
         }
 
         // and with a closure (async closure are unstable)
-        let foo2 = move |request, mut next: Box<dyn IncomingService<TestAccount> + Send>| {
-            async move { next.handle_request(request).await }
+        let foo2 = move |request, mut next: Box<dyn IncomingService<TestAccount> + Send>| async move {
+            next.handle_request(request).await
         };
 
         // base layer
@@ -414,8 +414,8 @@ mod tests {
         }
 
         // and with a closure (async closure are unstable)
-        let foo2 = move |request, mut next: Box<dyn OutgoingService<TestAccount> + Send>| {
-            async move { next.send_request(request).await }
+        let foo2 = move |request, mut next: Box<dyn OutgoingService<TestAccount> + Send>| async move {
+            next.send_request(request).await
         };
 
         // base layer

--- a/crates/interledger-service/src/lib.rs
+++ b/crates/interledger-service/src/lib.rs
@@ -27,6 +27,7 @@
 //! HttpServerService --> ValidatorService --> StreamReceiverService
 
 use async_trait::async_trait;
+use interledger_errors::{AccountStoreError, AddressStoreError};
 use interledger_packet::{Address, Fulfill, Prepare, Reject};
 use std::{
     fmt::{self, Debug},
@@ -181,14 +182,14 @@ pub trait AccountStore {
         &self,
         // The account ids (UUID format) of the accounts you are fetching
         account_ids: Vec<Uuid>,
-    ) -> Result<Vec<Self::Account>, ()>;
+    ) -> Result<Vec<Self::Account>, AccountStoreError>;
 
     /// Loads the account id which corresponds to the provided username
     async fn get_account_id_from_username(
         &self,
         // The username of the account you are fetching
         username: &Username,
-    ) -> Result<Uuid, ()>;
+    ) -> Result<Uuid, AccountStoreError>;
 }
 
 /// Create an IncomingService that calls the given handler for each request.
@@ -336,10 +337,10 @@ pub trait AddressStore: Clone {
         &self,
         // The new ILP Address of the node
         ilp_address: Address,
-    ) -> Result<(), ()>;
+    ) -> Result<(), AddressStoreError>;
 
     /// Resets the node's ILP Address to local.host
-    async fn clear_ilp_address(&self) -> Result<(), ()>;
+    async fn clear_ilp_address(&self) -> Result<(), AddressStoreError>;
 
     /// Gets the node's ILP Address *synchronously*
     /// (the value is stored in memory because it is read often by all services)

--- a/crates/interledger-settlement/Cargo.toml
+++ b/crates/interledger-settlement/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 bytes = { version = "0.5", default-features = false }
 futures = { version = "0.3.1", default-features = false, features = ["compat"] }
 hyper = { version = "0.13.1", default-features = false }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false, features = ["redis_errors"] }
 interledger-http = { path = "../interledger-http", version = "^0.4.0", default-features = false }
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }

--- a/crates/interledger-settlement/src/api/node_api.rs
+++ b/crates/interledger-settlement/src/api/node_api.rs
@@ -8,6 +8,7 @@ use crate::core::{
     },
 };
 use bytes::Bytes;
+use futures::future::Either;
 use futures::TryFutureExt;
 use hyper::{Response, StatusCode};
 use interledger_errors::*;
@@ -22,7 +23,6 @@ use std::{
 };
 use uuid::Uuid;
 use warp::{self, reject::Rejection, Filter};
-use futures::future::Either;
 
 /// Prepare packet's execution condition as defined in the [RFC](https://interledger.org/rfcs/0038-settlement-engines/#exchanging-messages)
 static PEER_PROTOCOL_CONDITION: [u8; 32] = [

--- a/crates/interledger-settlement/src/core/engines_api.rs
+++ b/crates/interledger-settlement/src/core/engines_api.rs
@@ -10,7 +10,7 @@ use super::{
 use bytes::Bytes;
 use http::StatusCode;
 use hyper::Response;
-use interledger_http::error::default_rejection_handler;
+use interledger_errors::default_rejection_handler;
 use serde::{Deserialize, Serialize};
 use warp::Filter;
 
@@ -219,6 +219,7 @@ mod tests {
     use async_trait::async_trait;
     use bytes::Bytes;
     use http::StatusCode;
+    use interledger_errors::*;
     use parking_lot::RwLock;
     use serde_json::{json, Value};
     use std::collections::HashMap;
@@ -256,7 +257,7 @@ mod tests {
         async fn load_idempotent_data(
             &self,
             idempotency_key: String,
-        ) -> Result<Option<IdempotentData>, ()> {
+        ) -> Result<Option<IdempotentData>, IdempotentStoreError> {
             let cache = self.cache.read();
             if let Some(data) = cache.get(&idempotency_key) {
                 let mut guard = self.cache_hits.write();
@@ -273,7 +274,7 @@ mod tests {
             input_hash: [u8; 32],
             status_code: StatusCode,
             data: Bytes,
-        ) -> Result<(), ()> {
+        ) -> Result<(), IdempotentStoreError> {
             let mut cache = self.cache.write();
             cache.insert(
                 idempotency_key,

--- a/crates/interledger-settlement/src/core/idempotency.rs
+++ b/crates/interledger-settlement/src/core/idempotency.rs
@@ -4,7 +4,8 @@ use bytes::Bytes;
 use futures::Future;
 use futures::TryFutureExt;
 use http::StatusCode;
-use interledger_http::error::*;
+use interledger_errors::IdempotentStoreError;
+use interledger_errors::*;
 use log::error;
 
 /// Data stored for the idempotency features
@@ -37,7 +38,7 @@ pub trait IdempotentStore {
     async fn load_idempotent_data(
         &self,
         idempotency_key: String,
-    ) -> Result<Option<IdempotentData>, ()>;
+    ) -> Result<Option<IdempotentData>, IdempotentStoreError>;
 
     /// Saves the data that was passed along with the api request for later
     /// The store also saves the hash of the input, so that it errors out on requests
@@ -48,7 +49,7 @@ pub trait IdempotentStore {
         input_hash: [u8; 32],
         status_code: StatusCode,
         data: Bytes,
-    ) -> Result<(), ()>;
+    ) -> Result<(), IdempotentStoreError>;
 }
 
 /// Helper function that returns any idempotent data that corresponds to a

--- a/crates/interledger-store/Cargo.toml
+++ b/crates/interledger-store/Cargo.toml
@@ -46,6 +46,7 @@ secrecy = { version = "0.6", features = ["serde", "bytes"] }
 zeroize = { version = "1.0.0", default-features = false }
 num-bigint = { version = "0.2.3", default-features = false, features = ["std"]}
 uuid = { version = "0.8.1", default-features = false, features = ["serde"] }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false, features = ["redis_errors"] }
 
 # redis feature
 redis_crate = { package = "redis", version = "0.15.1", default-features = false, features = ["tokio-rt-core"], optional = true }

--- a/crates/interledger-store/Cargo.toml
+++ b/crates/interledger-store/Cargo.toml
@@ -51,6 +51,7 @@ interledger-errors = { path = "../interledger-errors", version = "^0.1.0", defau
 # redis feature
 redis_crate = { package = "redis", version = "0.15.1", default-features = false, features = ["tokio-rt-core"], optional = true }
 async-trait = "0.1.22"
+thiserror = "1.0.10"
 
 [dev-dependencies]
 env_logger = { version = "0.7.0", default-features = false }

--- a/crates/interledger-store/src/account.rs
+++ b/crates/interledger-store/src/account.rs
@@ -110,33 +110,41 @@ impl Account {
         id: Uuid,
         details: AccountDetails,
         node_ilp_address: Address,
-    ) -> Result<Account, ()> {
+    ) -> Result<Account, String> {
         let ilp_address = match details.ilp_address {
             Some(a) => a,
             None => node_ilp_address
                 .with_suffix(details.username.as_bytes())
-                .map_err(|_| {
+                .map_err(|err| {
                     error!(
                         "Could not append username {} to address {}",
                         details.username, node_ilp_address
-                    )
+                    );
+                    err.to_string()
                 })?,
         };
 
         let ilp_over_http_url = if let Some(ref url) = details.ilp_over_http_url {
-            Some(Url::parse(url).map_err(|err| error!("Invalid URL: {:?}", err))?)
+            Some(Url::parse(url).map_err(|err| {
+                error!("Invalid URL: {:?}", err);
+                err.to_string()
+            })?)
         } else {
             None
         };
 
         let ilp_over_btp_url = if let Some(ref url) = details.ilp_over_btp_url {
-            Some(Url::parse(url).map_err(|err| error!("Invalid URL: {:?}", err))?)
+            Some(Url::parse(url).map_err(|err| {
+                error!("Invalid URL: {:?}", err);
+                err.to_string()
+            })?)
         } else {
             None
         };
 
         let routing_relation = if let Some(ref relation) = details.routing_relation {
-            RoutingRelation::from_str(relation)?
+            RoutingRelation::from_str(relation)
+                .map_err(|_| "Could not parse provided routing relation to string".to_string())?
         } else {
             RoutingRelation::NonRoutingAccount
         };

--- a/crates/interledger-store/src/redis/mod.rs
+++ b/crates/interledger-store/src/redis/mod.rs
@@ -233,7 +233,7 @@ impl RedisStoreBuilder {
                         },
                         routing_table.clone(),
                     )
-                    .map_err(|_| ())
+                    .map_err(|err| error!("{}", err))
                     .await;
                 } else {
                     debug!("Not polling routes anymore because connection was closed");

--- a/crates/interledger-store/src/redis/mod.rs
+++ b/crates/interledger-store/src/redis/mod.rs
@@ -349,9 +349,7 @@ impl RedisStore {
                 "An account already exists with the same {}. Cannot insert account: {:?}",
                 account.id, account
             );
-            return Err(NodeStoreError::AccountExists(
-                account.username.to_string(),
-            ));
+            return Err(NodeStoreError::AccountExists(account.username.to_string()));
         }
 
         let mut pipe = redis_crate::pipe();

--- a/crates/interledger-store/src/redis/mod.rs
+++ b/crates/interledger-store/src/redis/mod.rs
@@ -330,7 +330,7 @@ impl RedisStore {
     async fn redis_insert_account(
         &mut self,
         encrypted: AccountWithEncryptedTokens,
-    ) -> Result<AccountWithEncryptedTokens, AccountStoreError> {
+    ) -> Result<AccountWithEncryptedTokens, NodeStoreError> {
         let account = encrypted.account.clone();
         let ret = encrypted.clone();
         let mut connection = self.connection.clone();
@@ -349,7 +349,7 @@ impl RedisStore {
                 "An account already exists with the same {}. Cannot insert account: {:?}",
                 account.id, account
             );
-            return Err(AccountStoreError::AccountExists(
+            return Err(NodeStoreError::AccountExists(
                 account.username.to_string(),
             ));
         }

--- a/crates/interledger-store/src/redis/mod.rs
+++ b/crates/interledger-store/src/redis/mod.rs
@@ -26,6 +26,7 @@ use http::StatusCode;
 use interledger_api::{AccountDetails, AccountSettings, EncryptedAccountSettings, NodeStore};
 use interledger_btp::BtpStore;
 use interledger_ccp::{CcpRoutingAccount, RouteManagerStore, RoutingRelation};
+use interledger_errors::*;
 use interledger_http::HttpStore;
 use interledger_packet::Address;
 use interledger_router::RouterStore;
@@ -90,6 +91,8 @@ fn prefixed_idempotency_key(idempotency_key: String) -> String {
 fn accounts_key(account_id: Uuid) -> String {
     format!("accounts:{}", account_id)
 }
+
+// TODO: Add descriptive errors inside the lua scripts!
 
 // The following are Lua scripts that are used to atomically execute the given logic
 // inside Redis. This allows for more complex logic without needing multiple round
@@ -230,6 +233,7 @@ impl RedisStoreBuilder {
                         },
                         routing_table.clone(),
                     )
+                    .map_err(|_| ())
                     .await;
                 } else {
                     debug!("Not polling routes anymore because connection was closed");
@@ -315,12 +319,9 @@ pub struct RedisStore {
 
 impl RedisStore {
     /// Gets all the account ids from Redis
-    async fn get_all_accounts_ids(&self) -> Result<Vec<Uuid>, ()> {
+    async fn get_all_accounts_ids(&self) -> Result<Vec<Uuid>, NodeStoreError> {
         let mut connection = self.connection.clone();
-        let account_ids: Vec<RedisAccountId> = connection
-            .smembers("accounts")
-            .map_err(|err| error!("Error getting account IDs: {:?}", err))
-            .await?;
+        let account_ids: Vec<RedisAccountId> = connection.smembers("accounts").await?;
         Ok(account_ids.iter().map(|rid| rid.0).collect())
     }
 
@@ -329,7 +330,7 @@ impl RedisStore {
     async fn redis_insert_account(
         &mut self,
         encrypted: AccountWithEncryptedTokens,
-    ) -> Result<AccountWithEncryptedTokens, ()> {
+    ) -> Result<AccountWithEncryptedTokens, AccountStoreError> {
         let account = encrypted.account.clone();
         let ret = encrypted.clone();
         let mut connection = self.connection.clone();
@@ -342,21 +343,15 @@ impl RedisStore {
             pipe.exists(PARENT_ILP_KEY);
         }
 
-        let results: Vec<bool> = pipe
-            .query_async(&mut connection.clone())
-            .map_err(|err| {
-                error!(
-                    "Error checking whether account details already exist: {:?}",
-                    err
-                )
-            })
-            .await?;
+        let results: Vec<bool> = pipe.query_async(&mut connection.clone()).await?;
         if results.iter().any(|val| *val) {
             warn!(
                 "An account already exists with the same {}. Cannot insert account: {:?}",
                 account.id, account
             );
-            return Err(());
+            return Err(AccountStoreError::AccountExists(
+                account.username.to_string(),
+            ));
         }
 
         let mut pipe = redis_crate::pipe();
@@ -411,9 +406,7 @@ impl RedisStore {
 
         // The parent account settings are done via the API. We just
         // had to check for the existence of a parent
-        pipe.query_async(&mut connection)
-            .map_err(|err| error!("Error inserting account into DB: {:?}", err))
-            .await?;
+        pipe.query_async(&mut connection).await?;
 
         update_routes(connection, routing_table).await?;
         debug!(
@@ -428,7 +421,7 @@ impl RedisStore {
     async fn redis_update_account(
         &self,
         encrypted: AccountWithEncryptedTokens,
-    ) -> Result<AccountWithEncryptedTokens, ()> {
+    ) -> Result<AccountWithEncryptedTokens, NodeStoreError> {
         let account = encrypted.account.clone();
         let mut connection = self.connection.clone();
         let routing_table = self.routes.clone();
@@ -439,17 +432,14 @@ impl RedisStore {
         // TODO: Do not allow this update to happen if
         // AccountDetails.RoutingRelation == Parent and parent is
         // already set
-        let exists: bool = connection
-            .exists(accounts_key(account.id))
-            .map_err(|err| error!("Error checking whether ID exists: {:?}", err))
-            .await?;
+        let exists: bool = connection.exists(accounts_key(account.id)).await?;
 
         if !exists {
             warn!(
                 "No account exists with ID {}, cannot update account {:?}",
                 account.id, account
             );
-            return Err(());
+            return Err(NodeStoreError::AccountNotFound(account.id.to_string()));
         }
         let mut pipe = redis_crate::pipe();
         pipe.atomic();
@@ -486,9 +476,7 @@ impl RedisStore {
         )
         .ignore();
 
-        pipe.query_async(&mut connection)
-            .map_err(|err| error!("Error inserting account into DB: {:?}", err))
-            .await?;
+        pipe.query_async(&mut connection).await?;
         update_routes(connection, routing_table).await?;
         debug!(
             "Inserted account {} (id: {}, ILP address: {})",
@@ -503,7 +491,7 @@ impl RedisStore {
         &self,
         id: Uuid,
         settings: EncryptedAccountSettings,
-    ) -> Result<AccountWithEncryptedTokens, ()> {
+    ) -> Result<AccountWithEncryptedTokens, NodeStoreError> {
         let connection = self.connection.clone();
         let mut self_clone = self.clone();
 
@@ -558,27 +546,32 @@ impl RedisStore {
             pipe.hset(accounts_key(id), "settle_to", settle_to);
         }
 
-        pipe.query_async(&mut connection.clone())
-            .map_err(|err| error!("Error modifying user account: {:?}", err))
-            .await?;
+        pipe.query_async(&mut connection.clone()).await?;
 
         // return the updated account
         self_clone.redis_get_account(id).await
     }
 
     /// Gets the account (tokens remain encrypted) corresponding to the provided `id` from Redis.
-    async fn redis_get_account(&mut self, id: Uuid) -> Result<AccountWithEncryptedTokens, ()> {
+    async fn redis_get_account(
+        &mut self,
+        id: Uuid,
+    ) -> Result<AccountWithEncryptedTokens, NodeStoreError> {
         let mut accounts: Vec<AccountWithEncryptedTokens> = LOAD_ACCOUNTS
             .arg(id.to_string())
             .invoke_async(&mut self.connection.clone())
-            .map_err(|err| error!("Error loading accounts: {:?}", err))
             .await?;
-        accounts.pop().ok_or(())
+        accounts
+            .pop()
+            .ok_or_else(|| NodeStoreError::AccountNotFound(id.to_string()))
     }
 
     /// Deletes the account corresponding to the provided `id` from Redis.
     /// Returns the deleted account (tokens remain encrypted)
-    async fn redis_delete_account(&mut self, id: Uuid) -> Result<AccountWithEncryptedTokens, ()> {
+    async fn redis_delete_account(
+        &mut self,
+        id: Uuid,
+    ) -> Result<AccountWithEncryptedTokens, NodeStoreError> {
         let mut connection = self.connection.clone();
         let routing_table = self.routes.clone();
         let encrypted = self.redis_get_account(id).await?;
@@ -611,9 +604,7 @@ impl RedisStore {
 
         pipe.del(uncredited_amount_key(id));
 
-        pipe.query_async(&mut connection)
-            .map_err(|err| error!("Error deleting account from DB: {:?}", err))
-            .await?;
+        pipe.query_async(&mut connection).await?;
 
         update_routes(connection, routing_table).await?;
         debug!("Deleted account {}", account.id);
@@ -626,7 +617,10 @@ impl AccountStore for RedisStore {
     type Account = Account;
 
     // TODO cache results to avoid hitting Redis for each packet
-    async fn get_accounts(&self, account_ids: Vec<Uuid>) -> Result<Vec<Account>, ()> {
+    async fn get_accounts(
+        &self,
+        account_ids: Vec<Uuid>,
+    ) -> Result<Vec<Account>, AccountStoreError> {
         let decryption_key = self.decryption_key.clone();
         let num_accounts = account_ids.len();
         let mut script = LOAD_ACCOUNTS.prepare_invoke();
@@ -636,10 +630,8 @@ impl AccountStore for RedisStore {
 
         // Need to clone the connection here to avoid lifetime errors
         let connection = self.connection.clone();
-        let accounts: Vec<AccountWithEncryptedTokens> = script
-            .invoke_async(&mut connection.clone())
-            .map_err(|err| error!("Error loading accounts: {:?}", err))
-            .await?;
+        let accounts: Vec<AccountWithEncryptedTokens> =
+            script.invoke_async(&mut connection.clone()).await?;
 
         // Decrypt the accounts. TODO: This functionality should be
         // decoupled from redis so that it gets reused by the other backends
@@ -650,22 +642,24 @@ impl AccountStore for RedisStore {
                 .collect();
             Ok(accounts)
         } else {
-            Err(())
+            Err(AccountStoreError::AccountNotFound(
+                "provided account uuids were not found".to_owned(),
+            ))
         }
     }
 
-    async fn get_account_id_from_username(&self, username: &Username) -> Result<Uuid, ()> {
+    async fn get_account_id_from_username(
+        &self,
+        username: &Username,
+    ) -> Result<Uuid, AccountStoreError> {
         let username = username.clone();
         let mut connection = self.connection.clone();
-        let id: Option<RedisAccountId> = connection
-            .hget("usernames", username.as_ref())
-            .map_err(move |err| error!("Error getting account id: {:?}", err))
-            .await?;
+        let id: Option<RedisAccountId> = connection.hget("usernames", username.as_ref()).await?;
         match id {
             Some(rid) => Ok(rid.0),
             None => {
                 debug!("Username not found: {}", username);
-                Err(())
+                Err(AccountStoreError::AccountNotFound(username.to_string()))
             }
         }
     }
@@ -721,16 +715,10 @@ impl StreamNotificationsStore for RedisStore {
 impl BalanceStore for RedisStore {
     /// Returns the balance **from the account holder's perspective**, meaning the sum of
     /// the Payable Balance and Pending Outgoing minus the Receivable Balance and the Pending Incoming.
-    async fn get_balance(&self, account: Account) -> Result<i64, ()> {
+    async fn get_balance(&self, account_id: Uuid) -> Result<i64, BalanceStoreError> {
         let mut connection = self.connection.clone();
         let values: Vec<i64> = connection
-            .hget(accounts_key(account.id), &["balance", "prepaid_amount"])
-            .map_err(move |err| {
-                error!(
-                    "Error getting balance for account: {} {:?}",
-                    account.id, err
-                )
-            })
+            .hget(accounts_key(account_id), &["balance", "prepaid_amount"])
             .await?;
 
         let balance = values[0];
@@ -740,25 +728,18 @@ impl BalanceStore for RedisStore {
 
     async fn update_balances_for_prepare(
         &self,
-        from_account: Account, // TODO: Make this take only the id
+        from_account_id: Uuid,
         incoming_amount: u64,
-    ) -> Result<(), ()> {
+    ) -> Result<(), BalanceStoreError> {
         // Don't do anything if the amount was 0
         if incoming_amount == 0 {
             return Ok(());
         }
 
-        let from_account_id = from_account.id;
         let balance: i64 = PROCESS_PREPARE
             .arg(RedisAccountId(from_account_id))
             .arg(incoming_amount)
             .invoke_async(&mut self.connection.clone())
-            .map_err(move |err| {
-                warn!(
-                    "Error handling prepare from account: {}:  {:?}",
-                    from_account_id, err
-                )
-            })
             .await?;
 
         trace!(
@@ -770,23 +751,16 @@ impl BalanceStore for RedisStore {
 
     async fn update_balances_for_fulfill(
         &self,
-        to_account: Account, // TODO: Make this take only the id
+        to_account_id: Uuid,
         outgoing_amount: u64,
-    ) -> Result<(i64, u64), ()> {
+    ) -> Result<(i64, u64), BalanceStoreError> {
         if outgoing_amount == 0 {
             return Ok((0, 0));
         }
-        let to_account_id = to_account.id;
         let (balance, amount_to_settle): (i64, u64) = PROCESS_FULFILL
             .arg(RedisAccountId(to_account_id))
             .arg(outgoing_amount)
             .invoke_async(&mut self.connection.clone())
-            .map_err(move |err| {
-                error!(
-                    "Error handling Fulfill received from account: {}: {:?}",
-                    to_account_id, err
-                )
-            })
             .await?;
 
         trace!(
@@ -801,36 +775,30 @@ impl BalanceStore for RedisStore {
 
     async fn update_balances_for_reject(
         &self,
-        from_account: Account, // TODO: Make this take only the id
+        from_account_id: Uuid,
         incoming_amount: u64,
-    ) -> Result<(), ()> {
+    ) -> Result<(), BalanceStoreError> {
         if incoming_amount == 0 {
             return Ok(());
         }
 
-        let from_account_id = from_account.id;
         let balance: i64 = PROCESS_REJECT
             .arg(RedisAccountId(from_account_id))
             .arg(incoming_amount)
             .invoke_async(&mut self.connection.clone())
-            .map_err(move |err| {
-                warn!(
-                    "Error handling reject for packet from account: {}: {:?}",
-                    from_account_id, err
-                )
-            })
             .await?;
 
         trace!(
             "Processed reject for incoming amount: {}. Account {} has balance (including prepaid amount): {}",
             incoming_amount, from_account_id, balance
         );
+
         Ok(())
     }
 }
 
 impl ExchangeRateStore for RedisStore {
-    fn get_exchange_rates(&self, asset_codes: &[&str]) -> Result<Vec<f64>, ()> {
+    fn get_exchange_rates(&self, asset_codes: &[&str]) -> Result<Vec<f64>, ExchangeRateStoreError> {
         let rates: Vec<f64> = asset_codes
             .iter()
             .filter_map(|code| (*self.exchange_rates.read()).get(*code).cloned())
@@ -838,15 +806,22 @@ impl ExchangeRateStore for RedisStore {
         if rates.len() == asset_codes.len() {
             Ok(rates)
         } else {
-            Err(())
+            // todo add error type
+            Err(ExchangeRateStoreError::PairNotFound {
+                from: asset_codes[0].to_string(),
+                to: asset_codes[1].to_string(),
+            })
         }
     }
 
-    fn get_all_exchange_rates(&self) -> Result<HashMap<String, f64>, ()> {
+    fn get_all_exchange_rates(&self) -> Result<HashMap<String, f64>, ExchangeRateStoreError> {
         Ok((*self.exchange_rates.read()).clone())
     }
 
-    fn set_exchange_rates(&self, rates: HashMap<String, f64>) -> Result<(), ()> {
+    fn set_exchange_rates(
+        &self,
+        rates: HashMap<String, f64>,
+    ) -> Result<(), ExchangeRateStoreError> {
         // TODO publish rate updates through a pubsub mechanism to support horizontally scaling nodes
         (*self.exchange_rates.write()) = rates;
         Ok(())
@@ -861,7 +836,7 @@ impl BtpStore for RedisStore {
         &self,
         username: &Username,
         token: &str,
-    ) -> Result<Self::Account, ()> {
+    ) -> Result<Self::Account, BtpStoreError> {
         // TODO make sure it can't do script injection!
         // TODO cache the result so we don't hit redis for every packet (is that
         // necessary if redis is often used as a cache?)
@@ -873,7 +848,6 @@ impl BtpStore for RedisStore {
         let account: Option<AccountWithEncryptedTokens> = ACCOUNT_FROM_USERNAME
             .arg(username.as_ref())
             .invoke_async(&mut connection)
-            .map_err(|err| error!("Error getting account from BTP token: {:?}", err))
             .await?;
 
         if let Some(account) = account {
@@ -887,28 +861,25 @@ impl BtpStore for RedisStore {
                         "Found account {} but BTP auth token was wrong",
                         account.username
                     );
-                    Err(())
+                    Err(BtpStoreError::Unauthorized(username.to_string()))
                 }
             } else {
                 debug!(
                     "Account {} does not have an incoming btp token configured",
                     account.username
                 );
-                Err(())
+                Err(BtpStoreError::Unauthorized(username.to_string()))
             }
         } else {
             warn!("No account found with BTP token");
-            Err(())
+            Err(BtpStoreError::AccountNotFound(username.to_string()))
         }
     }
 
-    async fn get_btp_outgoing_accounts(&self) -> Result<Vec<Self::Account>, ()> {
+    async fn get_btp_outgoing_accounts(&self) -> Result<Vec<Self::Account>, BtpStoreError> {
         let mut connection = self.connection.clone();
 
-        let account_ids: Vec<RedisAccountId> = connection
-            .smembers("btp_outgoing")
-            .map_err(|err| error!("Error getting members of set btp_outgoing: {:?}", err))
-            .await?;
+        let account_ids: Vec<RedisAccountId> = connection.smembers("btp_outgoing").await?;
         let account_ids: Vec<Uuid> = account_ids.into_iter().map(|id| id.0).collect();
 
         if account_ids.is_empty() {
@@ -930,14 +901,13 @@ impl HttpStore for RedisStore {
         &self,
         username: &Username,
         token: &str,
-    ) -> Result<Self::Account, ()> {
+    ) -> Result<Self::Account, HttpStoreError> {
         // TODO make sure it can't do script injection!
         let decryption_key = self.decryption_key.clone();
         let token = token.to_owned();
         let account: Option<AccountWithEncryptedTokens> = ACCOUNT_FROM_USERNAME
             .arg(username.as_ref())
             .invoke_async(&mut self.connection.clone())
-            .map_err(|err| error!("Error getting account from HTTP auth: {:?}", err))
             .await?;
 
         if let Some(account) = account {
@@ -947,14 +917,14 @@ impl HttpStore for RedisStore {
                 if t == Bytes::from(token) {
                     Ok(account)
                 } else {
-                    Err(())
+                    Err(HttpStoreError::Unauthorized(username.to_string()))
                 }
             } else {
-                Err(())
+                Err(HttpStoreError::Unauthorized(username.to_string()))
             }
         } else {
             warn!("No account found with given HTTP auth");
-            Err(())
+            Err(HttpStoreError::AccountNotFound(username.to_string()))
         }
     }
 }
@@ -969,10 +939,14 @@ impl RouterStore for RedisStore {
 impl NodeStore for RedisStore {
     type Account = Account;
 
-    async fn insert_account(&self, account: AccountDetails) -> Result<Account, ()> {
+    async fn insert_account(
+        &self,
+        account: AccountDetails,
+    ) -> Result<Self::Account, NodeStoreError> {
         let encryption_key = self.encryption_key.clone();
         let id = Uuid::new_v4();
-        let account = Account::try_from(id, account, self.get_ilp_address())?;
+        let account = Account::try_from(id, account, self.get_ilp_address())
+            .map_err(NodeStoreError::InvalidAccount)?;
         debug!(
             "Generated account id for {}: {}",
             account.username.clone(),
@@ -987,17 +961,22 @@ impl NodeStore for RedisStore {
         Ok(account)
     }
 
-    async fn delete_account(&self, id: Uuid) -> Result<Account, ()> {
+    async fn delete_account(&self, id: Uuid) -> Result<Account, NodeStoreError> {
         let decryption_key = self.decryption_key.clone();
         let mut self_clone = self.clone();
         let account = self_clone.redis_delete_account(id).await?;
         Ok(account.decrypt_tokens(&decryption_key.expose_secret().0))
     }
 
-    async fn update_account(&self, id: Uuid, account: AccountDetails) -> Result<Self::Account, ()> {
+    async fn update_account(
+        &self,
+        id: Uuid,
+        account: AccountDetails,
+    ) -> Result<Self::Account, NodeStoreError> {
         let encryption_key = self.encryption_key.clone();
         let decryption_key = self.decryption_key.clone();
-        let account = Account::try_from(id, account, self.get_ilp_address())?;
+        let account = Account::try_from(id, account, self.get_ilp_address())
+            .map_err(NodeStoreError::InvalidAccount)?;
 
         debug!(
             "Generated account id for {}: {}",
@@ -1016,7 +995,7 @@ impl NodeStore for RedisStore {
         &self,
         id: Uuid,
         settings: AccountSettings,
-    ) -> Result<Self::Account, ()> {
+    ) -> Result<Self::Account, NodeStoreError> {
         let encryption_key = self.encryption_key.clone();
         let decryption_key = self.decryption_key.clone();
         let settings = EncryptedAccountSettings {
@@ -1059,7 +1038,7 @@ impl NodeStore for RedisStore {
     }
 
     // TODO limit the number of results and page through them
-    async fn get_all_accounts(&self) -> Result<Vec<Self::Account>, ()> {
+    async fn get_all_accounts(&self) -> Result<Vec<Self::Account>, NodeStoreError> {
         let decryption_key = self.decryption_key.clone();
         let mut connection = self.connection.clone();
 
@@ -1070,10 +1049,8 @@ impl NodeStore for RedisStore {
             script.arg(id.to_string());
         }
 
-        let accounts: Vec<AccountWithEncryptedTokens> = script
-            .invoke_async(&mut connection)
-            .map_err(|err| error!("Error getting account ids: {:?}", err))
-            .await?;
+        let accounts: Vec<AccountWithEncryptedTokens> =
+            script.invoke_async(&mut connection).await?;
 
         // TODO this should be refactored so that it gets reused in multiple backends
         let accounts: Vec<Account> = accounts
@@ -1084,7 +1061,7 @@ impl NodeStore for RedisStore {
         Ok(accounts)
     }
 
-    async fn set_static_routes<R>(&self, routes: R) -> Result<(), ()>
+    async fn set_static_routes<R>(&self, routes: R) -> Result<(), NodeStoreError>
     where
         R: IntoIterator<Item = (String, Uuid)> + Send + 'async_trait,
     {
@@ -1102,19 +1079,12 @@ impl NodeStore for RedisStore {
 
         let routing_table = self.routes.clone();
 
-        let accounts_exist: Vec<bool> = pipe
-            .query_async(&mut connection)
-            .map_err(|err| {
-                error!(
-                    "Error checking if accounts exist while setting static routes: {:?}",
-                    err
-                )
-            })
-            .await?;
+        let accounts_exist: Vec<bool> = pipe.query_async(&mut connection).await?;
 
         if !accounts_exist.iter().all(|a| *a) {
             error!("Error setting static routes because not all of the given accounts exist");
-            return Err(());
+            // TODO add proper error variant for "not all accoutns were found"
+            return Err(NodeStoreError::MissingAccounts);
         }
 
         let mut pipe = redis_crate::pipe();
@@ -1124,39 +1094,32 @@ impl NodeStore for RedisStore {
             .hset_multiple(STATIC_ROUTES_KEY, &routes)
             .ignore();
 
-        pipe.query_async(&mut connection)
-            .map_err(|err| error!("Error setting static routes: {:?}", err))
-            .await?;
+        pipe.query_async(&mut connection).await?;
 
         update_routes(connection, routing_table).await?;
         Ok(())
     }
 
-    async fn set_static_route(&self, prefix: String, account_id: Uuid) -> Result<(), ()> {
+    async fn set_static_route(
+        &self,
+        prefix: String,
+        account_id: Uuid,
+    ) -> Result<(), NodeStoreError> {
         let routing_table = self.routes.clone();
         let prefix_clone = prefix.clone();
         let mut connection = self.connection.clone();
 
-        let exists: bool = connection
-            .exists(accounts_key(account_id))
-            .map_err(|err| {
-                error!(
-                    "Error checking if account exists before setting static route: {:?}",
-                    err
-                )
-            })
-            .await?;
+        let exists: bool = connection.exists(accounts_key(account_id)).await?;
         if !exists {
             error!(
                 "Cannot set static route for prefix: {} because account {} does not exist",
                 prefix_clone, account_id
             );
-            return Err(());
+            return Err(NodeStoreError::AccountNotFound(account_id.to_string()));
         }
 
         connection
             .hset(STATIC_ROUTES_KEY, prefix, RedisAccountId(account_id))
-            .map_err(|err| error!("Error setting static route: {:?}", err))
             .await?;
 
         update_routes(connection, routing_table).await?;
@@ -1164,30 +1127,21 @@ impl NodeStore for RedisStore {
         Ok(())
     }
 
-    async fn set_default_route(&self, account_id: Uuid) -> Result<(), ()> {
+    async fn set_default_route(&self, account_id: Uuid) -> Result<(), NodeStoreError> {
         let routing_table = self.routes.clone();
         // TODO replace this with a lua script to do both calls at once
         let mut connection = self.connection.clone();
-        let exists: bool = connection
-            .exists(accounts_key(account_id))
-            .map_err(|err| {
-                error!(
-                    "Error checking if account exists before setting default route: {:?}",
-                    err
-                )
-            })
-            .await?;
+        let exists: bool = connection.exists(accounts_key(account_id)).await?;
         if !exists {
             error!(
                 "Cannot set default route because account {} does not exist",
                 account_id
             );
-            return Err(());
+            return Err(NodeStoreError::AccountNotFound(account_id.to_string()));
         }
 
         connection
             .set(DEFAULT_ROUTE_KEY, RedisAccountId(account_id))
-            .map_err(|err| error!("Error setting default route: {:?}", err))
             .await?;
         debug!("Set default route to account id: {}", account_id);
         update_routes(connection, routing_table).await?;
@@ -1197,7 +1151,7 @@ impl NodeStore for RedisStore {
     async fn set_settlement_engines(
         &self,
         asset_to_url_map: impl IntoIterator<Item = (String, Url)> + Send + 'async_trait,
-    ) -> Result<(), ()> {
+    ) -> Result<(), NodeStoreError> {
         let mut connection = self.connection.clone();
         let asset_to_url_map: Vec<(String, String)> = asset_to_url_map
             .into_iter()
@@ -1206,19 +1160,18 @@ impl NodeStore for RedisStore {
         debug!("Setting settlement engines to {:?}", asset_to_url_map);
         connection
             .hset_multiple(SETTLEMENT_ENGINES_KEY, &asset_to_url_map)
-            .map_err(|err| error!("Error setting settlement engines: {:?}", err))
             .await?;
         Ok(())
     }
 
-    async fn get_asset_settlement_engine(&self, asset_code: &str) -> Result<Option<Url>, ()> {
+    async fn get_asset_settlement_engine(
+        &self,
+        asset_code: &str,
+    ) -> Result<Option<Url>, NodeStoreError> {
         let mut connection = self.connection.clone();
         let asset_code = asset_code.to_owned();
 
-        let url: Option<String> = connection
-            .hget(SETTLEMENT_ENGINES_KEY, asset_code)
-            .map_err(|err| error!("Error getting settlement engine: {:?}", err))
-            .await?;
+        let url: Option<String> = connection.hget(SETTLEMENT_ENGINES_KEY, asset_code).await?;
         if let Some(url) = url {
             match Url::parse(url.as_str()) {
                 Ok(url) => Ok(Some(url)),
@@ -1227,7 +1180,7 @@ impl NodeStore for RedisStore {
                         "Settlement engine URL loaded from Redis was not a valid URL: {:?}",
                         err
                     );
-                    Err(())
+                    Err(NodeStoreError::InvalidEngineUrl(err.to_string()))
                 }
             }
         } else {
@@ -1240,7 +1193,7 @@ impl NodeStore for RedisStore {
 impl AddressStore for RedisStore {
     // Updates the ILP address of the store & iterates over all children and
     // updates their ILP Address to match the new address.
-    async fn set_ilp_address(&self, ilp_address: Address) -> Result<(), ()> {
+    async fn set_ilp_address(&self, ilp_address: Address) -> Result<(), AddressStoreError> {
         debug!("Setting ILP address to: {}", ilp_address);
         let routing_table = self.routes.clone();
         let mut connection = self.connection.clone();
@@ -1252,7 +1205,6 @@ impl AddressStore for RedisStore {
         // Save it to Redis
         connection
             .set(PARENT_ILP_KEY, ilp_address.as_bytes())
-            .map_err(|err| error!("Error setting ILP address {:?}", err))
             .await?;
 
         let accounts = self.get_all_accounts().await?;
@@ -1306,18 +1258,16 @@ impl AddressStore for RedisStore {
             }
         }
 
-        pipe.query_async(&mut connection.clone())
-            .map_err(|err| error!("Error updating children: {:?}", err))
-            .await?;
+        pipe.query_async(&mut connection.clone()).await?;
         update_routes(connection, routing_table).await?;
         Ok(())
     }
 
-    async fn clear_ilp_address(&self) -> Result<(), ()> {
+    async fn clear_ilp_address(&self) -> Result<(), AddressStoreError> {
         let mut connection = self.connection.clone();
         connection
             .del(PARENT_ILP_KEY)
-            .map_err(|err| error!("Error removing parent address: {:?}", err))
+            .map_err(|err| AddressStoreError::Other(Box::new(err)))
             .await?;
 
         // overwrite the ilp address with the default value
@@ -1340,13 +1290,10 @@ impl RouteManagerStore for RedisStore {
     async fn get_accounts_to_send_routes_to(
         &self,
         ignore_accounts: Vec<Uuid>,
-    ) -> Result<Vec<Account>, ()> {
+    ) -> Result<Vec<Account>, RouteManagerStoreError> {
         let mut connection = self.connection.clone();
 
-        let account_ids: Vec<RedisAccountId> = connection
-            .smembers("send_routes_to")
-            .map_err(|err| error!("Error getting members of set send_routes_to: {:?}", err))
-            .await?;
+        let account_ids: Vec<RedisAccountId> = connection.smembers("send_routes_to").await?;
         let account_ids: Vec<Uuid> = account_ids
             .into_iter()
             .map(|id| id.0)
@@ -1360,17 +1307,11 @@ impl RouteManagerStore for RedisStore {
         Ok(accounts)
     }
 
-    async fn get_accounts_to_receive_routes_from(&self) -> Result<Vec<Account>, ()> {
+    async fn get_accounts_to_receive_routes_from(
+        &self,
+    ) -> Result<Vec<Account>, RouteManagerStoreError> {
         let mut connection = self.connection.clone();
-        let account_ids: Vec<RedisAccountId> = connection
-            .smembers("receive_routes_from")
-            .map_err(|err| {
-                error!(
-                    "Error getting members of set receive_routes_from: {:?}",
-                    err
-                )
-            })
-            .await?;
+        let account_ids: Vec<RedisAccountId> = connection.smembers("receive_routes_from").await?;
         let account_ids: Vec<Uuid> = account_ids.into_iter().map(|id| id.0).collect();
 
         if account_ids.is_empty() {
@@ -1383,12 +1324,10 @@ impl RouteManagerStore for RedisStore {
 
     async fn get_local_and_configured_routes(
         &self,
-    ) -> Result<(RoutingTable<Account>, RoutingTable<Account>), ()> {
+    ) -> Result<(RoutingTable<Account>, RoutingTable<Account>), RouteManagerStoreError> {
         let mut connection = self.connection.clone();
-        let static_routes: Vec<(String, RedisAccountId)> = connection
-            .hgetall(STATIC_ROUTES_KEY)
-            .map_err(|err| error!("Error getting static routes: {:?}", err))
-            .await?;
+        let static_routes: Vec<(String, RedisAccountId)> =
+            connection.hgetall(STATIC_ROUTES_KEY).await?;
 
         let accounts = self.get_all_accounts().await?;
 
@@ -1422,7 +1361,7 @@ impl RouteManagerStore for RedisStore {
     async fn set_routes(
         &mut self,
         routes: impl IntoIterator<Item = (String, Account)> + Send + 'async_trait,
-    ) -> Result<(), ()> {
+    ) -> Result<(), RouteManagerStoreError> {
         let routes: Vec<(String, RedisAccountId)> = routes
             .into_iter()
             .map(|(prefix, account)| (prefix, RedisAccountId(account.id)))
@@ -1431,7 +1370,7 @@ impl RouteManagerStore for RedisStore {
         let mut connection = self.connection.clone();
 
         // Save routes to Redis
-        let routing_tale = self.routes.clone();
+        let routing_table = self.routes.clone();
         let mut pipe = redis_crate::pipe();
         pipe.atomic()
             .del(ROUTES_KEY)
@@ -1439,12 +1378,11 @@ impl RouteManagerStore for RedisStore {
             .hset_multiple(ROUTES_KEY, &routes)
             .ignore();
 
-        pipe.query_async(&mut connection)
-            .map_err(|err| error!("Error setting routes: {:?}", err))
-            .await?;
+        pipe.query_async(&mut connection).await?;
         trace!("Saved {} routes to Redis", num_routes);
 
-        update_routes(connection, routing_tale).await
+        update_routes(connection, routing_table).await?;
+        Ok(())
     }
 }
 
@@ -1521,7 +1459,7 @@ impl RateLimitStore for RedisStore {
         &self,
         account: Account,
         prepare_amount: u64,
-    ) -> Result<(), ()> {
+    ) -> Result<(), RateLimitError> {
         if let Some(limit) = account.amount_per_minute_limit {
             let mut connection = self.connection.clone();
             let limit = limit - 1;
@@ -1534,7 +1472,7 @@ impl RateLimitStore for RedisStore {
                 // TODO make sure this doesn't overflow
                 .arg(0i64 - (prepare_amount as i64))
                 .query_async(&mut connection)
-                .map_err(|err| error!("Error refunding throughput limit: {:?}", err))
+                .map_err(|_| RateLimitError::StoreError)
                 .await?;
         }
 
@@ -1547,17 +1485,10 @@ impl IdempotentStore for RedisStore {
     async fn load_idempotent_data(
         &self,
         idempotency_key: String,
-    ) -> Result<Option<IdempotentData>, ()> {
-        let idempotency_key_clone = idempotency_key.clone();
+    ) -> Result<Option<IdempotentData>, IdempotentStoreError> {
         let mut connection = self.connection.clone();
         let ret: HashMap<String, String> = connection
             .hgetall(prefixed_idempotency_key(idempotency_key.clone()))
-            .map_err(move |err| {
-                error!(
-                    "Error loading idempotency key {}: {:?}",
-                    idempotency_key_clone, err
-                )
-            })
             .await?;
 
         if let (Some(status_code), Some(data), Some(input_hash_slice)) = (
@@ -1584,7 +1515,7 @@ impl IdempotentStore for RedisStore {
         input_hash: [u8; 32],
         status_code: StatusCode,
         data: Bytes,
-    ) -> Result<(), ()> {
+    ) -> Result<(), IdempotentStoreError> {
         let mut pipe = redis_crate::pipe();
         let mut connection = self.connection.clone();
         pipe.atomic()
@@ -1599,9 +1530,7 @@ impl IdempotentStore for RedisStore {
             .ignore()
             .expire(&prefixed_idempotency_key(idempotency_key.clone()), 86400)
             .ignore();
-        pipe.query_async(&mut connection)
-            .map_err(|err| error!("Error caching: {:?}", err))
-            .await?;
+        pipe.query_async(&mut connection).await?;
 
         trace!(
             "Cached {:?}: {:?}, {:?}",
@@ -1622,19 +1551,13 @@ impl SettlementStore for RedisStore {
         account_id: Uuid,
         amount: u64,
         idempotency_key: Option<String>,
-    ) -> Result<(), ()> {
+    ) -> Result<(), SettlementStoreError> {
         let idempotency_key = idempotency_key.unwrap();
         let balance: i64 = PROCESS_INCOMING_SETTLEMENT
             .arg(RedisAccountId(account_id))
             .arg(amount)
             .arg(idempotency_key)
             .invoke_async(&mut self.connection.clone())
-            .map_err(move |err| {
-                error!(
-                    "Error processing incoming settlement from account: {} for amount: {}: {:?}",
-                    account_id, amount, err
-                )
-            })
             .await?;
         trace!(
             "Processed incoming settlement from account: {} for amount: {}. Balance is now: {}",
@@ -1645,7 +1568,11 @@ impl SettlementStore for RedisStore {
         Ok(())
     }
 
-    async fn refund_settlement(&self, account_id: Uuid, settle_amount: u64) -> Result<(), ()> {
+    async fn refund_settlement(
+        &self,
+        account_id: Uuid,
+        settle_amount: u64,
+    ) -> Result<(), SettlementStoreError> {
         trace!(
             "Refunding settlement for account: {} of amount: {}",
             account_id,
@@ -1655,12 +1582,6 @@ impl SettlementStore for RedisStore {
             .arg(RedisAccountId(account_id))
             .arg(settle_amount)
             .invoke_async(&mut self.connection.clone())
-            .map_err(move |err| {
-                error!(
-                    "Error refunding settlement for account: {} of amount: {}: {:?}",
-                    account_id, settle_amount, err
-                )
-            })
             .await?;
 
         trace!(
@@ -1770,7 +1691,7 @@ impl LeftoversStore for RedisStore {
     async fn get_uncredited_settlement_amount(
         &self,
         account_id: Uuid,
-    ) -> Result<(Self::AssetType, u8), ()> {
+    ) -> Result<(Self::AssetType, u8), LeftoversStoreError> {
         let mut pipe = redis_crate::pipe();
         pipe.atomic();
         // get the amounts and instantly delete them
@@ -1778,10 +1699,7 @@ impl LeftoversStore for RedisStore {
         pipe.del(uncredited_amount_key(account_id.to_string()))
             .ignore();
 
-        let amounts: Vec<AmountWithScale> = pipe
-            .query_async(&mut self.connection.clone())
-            .map_err(move |err| error!("Error getting uncredited_settlement_amount {:?}", err))
-            .await?;
+        let amounts: Vec<AmountWithScale> = pipe.query_async(&mut self.connection.clone()).await?;
 
         // this call will only return 1 element
         let amount = amounts[0].clone();
@@ -1792,7 +1710,7 @@ impl LeftoversStore for RedisStore {
         &self,
         account_id: Uuid,
         uncredited_settlement_amount: (Self::AssetType, u8),
-    ) -> Result<(), ()> {
+    ) -> Result<(), LeftoversStoreError> {
         trace!(
             "Saving uncredited_settlement_amount {:?} {:?}",
             account_id,
@@ -1811,7 +1729,6 @@ impl LeftoversStore for RedisStore {
                     scale: uncredited_settlement_amount.1,
                 },
             )
-            .map_err(move |err| error!("Error saving uncredited_settlement_amount: {:?}", err))
             .await?;
 
         Ok(())
@@ -1821,7 +1738,7 @@ impl LeftoversStore for RedisStore {
         &self,
         account_id: Uuid,
         local_scale: u8,
-    ) -> Result<Self::AssetType, ()> {
+    ) -> Result<Self::AssetType, LeftoversStoreError> {
         let mut connection = self.connection.clone();
         trace!("Loading uncredited_settlement_amount {:?}", account_id);
         let amount = self.get_uncredited_settlement_amount(account_id).await?;
@@ -1839,20 +1756,19 @@ impl LeftoversStore for RedisStore {
                         scale: std::cmp::max(local_scale, amount.1),
                     },
                 )
-                .map_err(move |err| error!("Error saving uncredited_settlement_amount: {:?}", err))
                 .await?;
         }
 
         Ok(scaled_amount)
     }
 
-    async fn clear_uncredited_settlement_amount(&self, account_id: Uuid) -> Result<(), ()> {
+    async fn clear_uncredited_settlement_amount(
+        &self,
+        account_id: Uuid,
+    ) -> Result<(), LeftoversStoreError> {
         trace!("Clearing uncredited_settlement_amount {:?}", account_id);
         let mut connection = self.connection.clone();
-        connection
-            .del(uncredited_amount_key(account_id))
-            .map_err(move |err| error!("Error clearing uncredited_settlement_amount: {:?}", err))
-            .await?;
+        connection.del(uncredited_amount_key(account_id)).await?;
         Ok(())
     }
 }
@@ -1865,15 +1781,13 @@ use futures::future::TryFutureExt;
 async fn update_routes(
     mut connection: RedisReconnect,
     routing_table: Arc<RwLock<Arc<HashMap<String, Uuid>>>>,
-) -> Result<(), ()> {
+) -> Result<(), RedisError> {
     let mut pipe = redis_crate::pipe();
     pipe.hgetall(ROUTES_KEY)
         .hgetall(STATIC_ROUTES_KEY)
         .get(DEFAULT_ROUTE_KEY);
-    let (routes, static_routes, default_route): (RouteVec, RouteVec, Option<RedisAccountId>) = pipe
-        .query_async(&mut connection)
-        .map_err(|err| error!("Error polling for routing table updates: {:?}", err))
-        .await?;
+    let (routes, static_routes, default_route): (RouteVec, RouteVec, Option<RedisAccountId>) =
+        pipe.query_async(&mut connection).await?;
     trace!(
         "Loaded routes from redis. Static routes: {:?}, default route: {:?}, other routes: {:?}",
         static_routes,

--- a/crates/interledger-stream/Cargo.toml
+++ b/crates/interledger-stream/Cargo.toml
@@ -35,3 +35,4 @@ pin-project = "0.4.7"
 [dev-dependencies]
 interledger-router = { path = "../interledger-router", version = "^0.4.0", default-features = false }
 lazy_static = { version = "1.4.0", default-features = false }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0" }

--- a/crates/interledger-stream/src/lib.rs
+++ b/crates/interledger-stream/src/lib.rs
@@ -28,6 +28,7 @@ pub mod test_helpers {
     use super::*;
     use async_trait::async_trait;
     use futures::channel::mpsc::UnboundedSender;
+    use interledger_errors::{AccountStoreError, AddressStoreError};
     use interledger_packet::Address;
     use interledger_router::RouterStore;
     use interledger_service::{Account, AccountStore, AddressStore, Username};
@@ -99,12 +100,18 @@ pub mod test_helpers {
     impl AccountStore for TestStore {
         type Account = TestAccount;
 
-        async fn get_accounts(&self, _account_ids: Vec<Uuid>) -> Result<Vec<Self::Account>, ()> {
+        async fn get_accounts(
+            &self,
+            _account_ids: Vec<Uuid>,
+        ) -> Result<Vec<Self::Account>, AccountStoreError> {
             Ok(vec![self.route.1.clone()])
         }
 
         // stub implementation (not used in these tests)
-        async fn get_account_id_from_username(&self, _username: &Username) -> Result<Uuid, ()> {
+        async fn get_account_id_from_username(
+            &self,
+            _username: &Username,
+        ) -> Result<Uuid, AccountStoreError> {
             Ok(Uuid::new_v4())
         }
     }
@@ -120,11 +127,11 @@ pub mod test_helpers {
     #[async_trait]
     impl AddressStore for TestStore {
         /// Saves the ILP Address in the store's memory and database
-        async fn set_ilp_address(&self, _ilp_address: Address) -> Result<(), ()> {
+        async fn set_ilp_address(&self, _ilp_address: Address) -> Result<(), AddressStoreError> {
             unimplemented!()
         }
 
-        async fn clear_ilp_address(&self) -> Result<(), ()> {
+        async fn clear_ilp_address(&self) -> Result<(), AddressStoreError> {
             unimplemented!()
         }
 

--- a/crates/interledger/Cargo.toml
+++ b/crates/interledger/Cargo.toml
@@ -44,6 +44,7 @@ interledger-ccp = { path = "../interledger-ccp", version = "^0.3.0", optional = 
 interledger-http = { path = "../interledger-http", version = "^0.4.0", optional = true, default-features = false }
 interledger-ildcp = { path = "../interledger-ildcp", version = "^0.4.0", optional = true, default-features = false }
 interledger-packet = { path = "../interledger-packet", version = "^0.4.0", default-features = false }
+interledger-errors = { path = "../interledger-errors", version = "^0.1.0", default-features = false }
 interledger-router = { path = "../interledger-router", version = "^0.4.0", optional = true, default-features = false }
 interledger-service = { path = "../interledger-service", version = "^0.4.0", default-features = false }
 interledger-service-util = { path = "../interledger-service-util", version = "^0.4.0", optional = true, default-features = false }

--- a/crates/interledger/src/lib.rs
+++ b/crates/interledger/src/lib.rs
@@ -11,6 +11,11 @@ pub mod packet {
     pub use interledger_packet::*;
 }
 
+/// Error types used with the Interledger.rs components.
+pub mod errors {
+    pub use interledger_errors::*;
+}
+
 /// HTTP API for interacting with the Interledger.rs components.
 #[cfg(feature = "api")]
 pub mod api {


### PR DESCRIPTION
The objective of this PR is to solidify the errors across the codebase (while now they're just `()`). In addition, we'd like to reduce the usage of `map_err`, since it can get annoying to have to do that everywhere. 

In addition, when consuming store errors at higher level crates such as the API we'd lose information, e.g. we couldn't know if the store call errored because an account was not found, if the account's id was not found, or if the socket was dropped.

To do that, the following plan is executed:
- [x] We create a new `interledger-errors` crate which will house all of these errors. 
     - This is consumed by most crates and is very low in the dependency chain. I decided to create this due to wanting to implement `From<RedisError> for T`, `From<T> for warp::Reject` and `From<T> for ApiError`, where `T` is each error type. 
    - Had I not introduced a separate crate, I'd have to add a new module for errors in each crate and add `warp` as a direct dependency to them which I preferred to avoid, and keep it as an implicit dependency via the errors crate.
- [x] Each error has variants for all possible cases it may encounter
- [x] Each error matches against internal error `Other` types and casts it to its own, if it know which one it is, e.g. passing a `AccountStoreError::AccountNotFound` to a `BtpStoreError` would normally go to the `Other` variant, while in this case we'd like it to propagate to the `BtpStoreError::AccountNotFound` variant
- [x] Each of these errors utilizes `thiserror`. It contains either specific errors for the errors that type cares about, or an `Other` variant which takes a `Box<dyn StdError>`, to bubble up errors which come directly from the store, redis for example
- [x] Remove lots of `map_err` calls from API store calls. 
- [x] Remove lots of `map_err` calls from Redis store calls.


As a driveby change, I decided to simplify a few traits, specifically:
1. `BalanceStore`: We had a longstanding TODO which required provided an Account as associated type, while all that's needed is the account's id. I've removed that associated type and dependency on the `AccountStore` trait and replaced the argument with `Uuid`, for the account's id. 
1. `NodeStore`: Previously depended on `AddressStore`, that was not required



Closes: #58 
Closes: #583 
Closes: #317 
Closes https://github.com/interledger-rs/interledger-rs/issues/364