### PR TITLE
STREAM sender reliability improvements

### DIFF
--- a/crates/interledger-api/src/routes/accounts.rs
+++ b/crates/interledger-api/src/routes/accounts.rs
@@ -29,7 +29,7 @@ use warp::{self, reply::Json, Filter, Rejection};
 pub const BEARER_TOKEN_START: usize = 7;
 
 const fn get_default_max_slippage() -> f64 {
-    0.01
+    0.015
 }
 
 #[derive(Deserialize, Debug)]

--- a/docs/api.yml
+++ b/docs/api.yml
@@ -472,7 +472,7 @@ components:
           oneOf:
             - type: number
             - type: string
-          default: 0.01
+          default: 0.015
           description: Maximum acceptable slippage percentage below calculated minimum exchange rate
     PaymentResponse:
       type: object


### PR DESCRIPTION
- Fix #513: Compute minimum source amount necessary to deliver money, corresponding to the minimum destination amount. This enables STREAM payments across peers in which a credit limit is hit and settlement occurs during the payment. Previously, T04s would reduce the source amount to 1, which will always fail due to rounding or not meeting the minimum exchange rate.
- Fix #634: Distribute dust amounts across remaining packets. By chance, the last packet in a STREAM payment may be too small that it won't meet the minimum destination amount due to rounding errors. This heuristic approximates in advance if this may happen and increases each packet amount slightly so there's no dust amount.
- Fix #633: Only apply T00, T01, F99 to fail-fast behavior. e.g. T04s should not trigger the fail-fast behavior, since they take time to resolve, not simply a number of packets -- this was a bug.
- Fix #467: Continue sending on R01 errors, which are triggered when the router receives a packet that rounds to 0. For other relative errors, e.g. R00, R02, the behavior stays the same, since they're likely terminal.
- Increase default slippage to 1.5%. This is so if operators set a 1% spread, the sender works by default.