### PR TITLE
Fix/indefinitely growing logs

### DIFF
--- a/crates/ilp-cli/src/interpreter.rs
+++ b/crates/ilp-cli/src/interpreter.rs
@@ -1,5 +1,4 @@
 use clap::ArgMatches;
-use http;
 use reqwest::{
     self,
     blocking::{Client, Response},

--- a/crates/ilp-node/src/instrumentation/google_pubsub.rs
+++ b/crates/ilp-node/src/instrumentation/google_pubsub.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "google_pubsub")]
-use base64;
 use chrono::Utc;
 use futures::{compat::Future01CompatExt, Future, TryFutureExt};
 use interledger::{

--- a/crates/ilp-node/src/instrumentation/prometheus.rs
+++ b/crates/ilp-node/src/instrumentation/prometheus.rs
@@ -1,6 +1,5 @@
 use crate::InterledgerNode;
 use metrics_core::{Builder, Drain, Observe};
-use metrics_runtime;
 use serde::Deserialize;
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 use tracing::{error, info};

--- a/crates/ilp-node/src/instrumentation/trace.rs
+++ b/crates/ilp-node/src/instrumentation/trace.rs
@@ -36,9 +36,10 @@ pub async fn trace_incoming<A: Account>(
         from.asset_scale = %request.from.asset_scale(),
     );
 
-    let span = match details_span.is_none() {
-        true => request_span,
-        false => details_span,
+    let span = if details_span.is_none() {
+        request_span
+    } else {
+        details_span
     };
 
     trace_response(next.handle_request(request).instrument(span).await)
@@ -66,9 +67,10 @@ pub async fn trace_forwarding<A: Account>(
         to.asset_scale = %request.from.asset_scale(),
     );
 
-    let span = match details_span.is_none() {
-        true => request_span,
-        false => details_span,
+    let span = if details_span.is_none() {
+        request_span
+    } else {
+        details_span
     };
 
     next.send_request(request).instrument(span).await
@@ -104,9 +106,10 @@ pub async fn trace_outgoing<A: Account + CcpRoutingAccount>(
     let ignore_rejects = request.prepare.destination().scheme() == "peer"
         && request.to.routing_relation() == RoutingRelation::Child;
 
-    let span = match details_span.is_none() {
-        true => request_span,
-        false => details_span,
+    let span = if details_span.is_none() {
+        request_span
+    } else {
+        details_span
     };
     let result = next.send_request(request).instrument(span).await;
     if let Err(ref err) = result {

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -437,8 +437,7 @@ impl InterledgerNode {
                     .clone()
                     .wrap(|request, mut next| async move {
                         let btp = debug_span!(target: "interledger-node", "btp");
-                        let _btp_scope = btp.enter();
-                        next.handle_request(request).in_current_span().await
+                        next.handle_request(request).instrument(btp).await
                     })
                     .in_current_span();
             } else {
@@ -460,8 +459,7 @@ impl InterledgerNode {
                     .clone()
                     .wrap(|request, mut next| async move {
                         let api = debug_span!(target: "interledger-node", "api");
-                        let _api_scope = api.enter();
-                        next.handle_request(request).in_current_span().await
+                        next.handle_request(request).instrument(api).await
                     })
                     .in_current_span();
             } else {
@@ -489,8 +487,7 @@ impl InterledgerNode {
                     .clone()
                     .wrap(|request, mut next| async move {
                         let http = debug_span!(target: "interledger-node", "http");
-                        let _http_scope = http.enter();
-                        next.handle_request(request).in_current_span().await
+                        next.handle_request(request).instrument(http).await
                     })
                     .in_current_span();
             } else {

--- a/crates/ilp-node/tests/redis/test_helpers.rs
+++ b/crates/ilp-node/tests/redis/test_helpers.rs
@@ -1,5 +1,4 @@
 use futures::TryFutureExt;
-use hex;
 use interledger::stream::StreamDelivery;
 use interledger::{packet::Address, service::Account as AccountTrait, store::account::Account};
 use ring::rand::{SecureRandom, SystemRandom};

--- a/crates/interledger-btp/src/errors.rs
+++ b/crates/interledger-btp/src/errors.rs
@@ -1,5 +1,3 @@
-use chrono;
-use std;
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;
 

--- a/crates/interledger-btp/src/packet.rs
+++ b/crates/interledger-btp/src/packet.rs
@@ -260,7 +260,6 @@ impl Serializable<BtpError> for BtpError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hex;
 
     mod btp_message {
         use super::*;

--- a/crates/interledger-ccp/src/fixtures.rs
+++ b/crates/interledger-ccp/src/fixtures.rs
@@ -1,7 +1,6 @@
 /* kcov-ignore-start */
 use crate::packet::*;
 use bytes::Bytes;
-use hex;
 use interledger_packet::Address;
 #[cfg(test)]
 use once_cell::sync::Lazy;

--- a/crates/interledger-ccp/src/packet.rs
+++ b/crates/interledger-ccp/src/packet.rs
@@ -1,6 +1,5 @@
 use byteorder::{BigEndian, ReadBytesExt};
 use bytes::{BufMut, Bytes};
-use hex;
 use interledger_packet::{
     oer::{BufOerExt, MutBufOerExt},
     Address, Fulfill, FulfillBuilder, ParseError, Prepare, PrepareBuilder,

--- a/crates/interledger-ccp/src/routing_table.rs
+++ b/crates/interledger-ccp/src/routing_table.rs
@@ -1,5 +1,4 @@
 use crate::packet::{Route, RouteUpdateRequest};
-use hex;
 use once_cell::sync::Lazy;
 use ring::rand::{SecureRandom, SystemRandom};
 use std::collections::HashMap;

--- a/crates/interledger-errors/src/ccprouting_store_error.rs
+++ b/crates/interledger-errors/src/ccprouting_store_error.rs
@@ -24,10 +24,8 @@ impl From<NodeStoreError> for CcpRoutingStoreError {
 }
 
 impl From<CcpRoutingStoreError> for ApiError {
-    fn from(src: CcpRoutingStoreError) -> Self {
-        match src {
-            _ => ApiError::method_not_allowed(),
-        }
+    fn from(_src: CcpRoutingStoreError) -> Self {
+        ApiError::method_not_allowed()
     }
 }
 

--- a/crates/interledger-errors/src/settlement_errors.rs
+++ b/crates/interledger-errors/src/settlement_errors.rs
@@ -11,10 +11,8 @@ pub enum LeftoversStoreError {
 }
 
 impl From<LeftoversStoreError> for ApiError {
-    fn from(src: LeftoversStoreError) -> Self {
-        match src {
-            _ => ApiError::method_not_allowed(),
-        }
+    fn from(_src: LeftoversStoreError) -> Self {
+        ApiError::method_not_allowed()
     }
 }
 
@@ -34,10 +32,8 @@ pub enum IdempotentStoreError {
 }
 
 impl From<IdempotentStoreError> for ApiError {
-    fn from(src: IdempotentStoreError) -> Self {
-        match src {
-            _ => ApiError::method_not_allowed(),
-        }
+    fn from(_src: IdempotentStoreError) -> Self {
+        ApiError::method_not_allowed()
     }
 }
 
@@ -61,10 +57,8 @@ pub enum SettlementStoreError {
 }
 
 impl From<SettlementStoreError> for ApiError {
-    fn from(src: SettlementStoreError) -> Self {
-        match src {
-            _ => ApiError::method_not_allowed(),
-        }
+    fn from(_src: SettlementStoreError) -> Self {
+        ApiError::method_not_allowed()
     }
 }
 

--- a/crates/interledger-packet/src/packet.rs
+++ b/crates/interledger-packet/src/packet.rs
@@ -1,4 +1,3 @@
-use hex;
 use std::fmt;
 use std::io::prelude::*;
 use std::io::Cursor;

--- a/crates/interledger-rates/src/lib.rs
+++ b/crates/interledger-rates/src/lib.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio;
 use tracing::{debug, error, trace, warn};
 
 mod cryptocompare;

--- a/crates/interledger-service-util/src/validator_service.rs
+++ b/crates/interledger-service-util/src/validator_service.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
-use hex;
 use interledger_packet::{ErrorCode, RejectBuilder};
 use interledger_service::*;
 use ring::digest::{digest, SHA256};

--- a/crates/interledger-service/src/trace.rs
+++ b/crates/interledger-service/src/trace.rs
@@ -11,10 +11,9 @@ where
 {
     async fn handle_request(&mut self, request: IncomingRequest<A>) -> IlpResult {
         let span = self.span().clone();
-        let _enter = span.enter();
         self.inner_mut()
             .handle_request(request)
-            .in_current_span()
+            .instrument(span)
             .await
     }
 }
@@ -27,10 +26,9 @@ where
 {
     async fn send_request(&mut self, request: OutgoingRequest<A>) -> IlpResult {
         let span = self.span().clone();
-        let _enter = span.enter();
         self.inner_mut()
             .send_request(request)
-            .in_current_span()
+            .instrument(span)
             .await
     }
 }

--- a/crates/interledger-service/src/trace.rs
+++ b/crates/interledger-service/src/trace.rs
@@ -10,10 +10,9 @@ where
     A: Account + 'static,
 {
     async fn handle_request(&mut self, request: IncomingRequest<A>) -> IlpResult {
-        let span = self.span().clone();
         self.inner_mut()
             .handle_request(request)
-            .instrument(span)
+            .in_current_span()
             .await
     }
 }
@@ -25,10 +24,9 @@ where
     A: Account + 'static,
 {
     async fn send_request(&mut self, request: OutgoingRequest<A>) -> IlpResult {
-        let span = self.span().clone();
         self.inner_mut()
             .send_request(request)
-            .instrument(span)
+            .in_current_span()
             .await
     }
 }

--- a/crates/interledger-service/src/username.rs
+++ b/crates/interledger-service/src/username.rs
@@ -150,7 +150,6 @@ mod tests {
 
     #[test]
     fn deserialize_usernames() {
-        use serde_json;
         let rejected_deserialize: Result<Username, _> =
             serde_json::from_str(r#""no-hyphens-allowed""#);
         assert!(rejected_deserialize.is_err());

--- a/crates/interledger-spsp/src/lib.rs
+++ b/crates/interledger-spsp/src/lib.rs
@@ -47,7 +47,6 @@ pub struct SpspResponse {
 // From https://github.com/serde-rs/json/issues/360#issuecomment-330095360
 #[doc(hidden)]
 mod serde_base64 {
-    use base64;
     use serde::{de, Deserialize, Deserializer, Serializer};
 
     pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/interledger-store/src/redis/mod.rs
+++ b/crates/interledger-store/src/redis/mod.rs
@@ -51,7 +51,6 @@ use redis_crate::{
 };
 use secrecy::{ExposeSecret, Secret, SecretBytesMut};
 use serde::{Deserialize, Serialize};
-use serde_json;
 use std::{
     collections::{HashMap, HashSet},
     fmt::Display,

--- a/crates/interledger-stream/src/congestion.rs
+++ b/crates/interledger-stream/src/congestion.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "metrics_csv")]
 use chrono::Utc;
-#[cfg(feature = "metrics_csv")]
-use csv;
 use interledger_packet::{ErrorCode, MaxPacketAmountDetails, Reject};
 #[cfg(test)]
 use once_cell::sync::Lazy;

--- a/crates/interledger-stream/src/packet.rs
+++ b/crates/interledger-stream/src/packet.rs
@@ -448,7 +448,7 @@ impl From<u8> for ErrorCode {
 
 /// Helper trait for having a common interface to read/write on Frames
 pub trait SerializableFrame<'a>: Sized {
-    fn put_contents(&self, buf: &mut impl MutBufOerExt) -> ();
+    fn put_contents(&self, buf: &mut impl MutBufOerExt);
 
     fn read_contents(reader: &'a [u8]) -> Result<Self, ParseError>;
 }

--- a/crates/interledger-stream/src/server.rs
+++ b/crates/interledger-stream/src/server.rs
@@ -1,11 +1,9 @@
 use super::crypto::*;
 use super::packet::*;
 use async_trait::async_trait;
-use base64;
 use bytes::{Bytes, BytesMut};
 use chrono::{DateTime, Utc};
 use futures::channel::mpsc::UnboundedSender;
-use hex;
 use interledger_packet::{
     Address, ErrorCode, Fulfill, FulfillBuilder, PacketType as IlpPacketType, Prepare, Reject,
     RejectBuilder,


### PR DESCRIPTION
Fix a problem with indefinitely growing logs. The previous versions with enters didn't exit spans in async context. This one exits.