### PR TITLE
make interledger-http build individually; remove unneeded calls to warp::Filter::boxed

### DIFF
--- a/crates/interledger-api/src/routes/node_settings.rs
+++ b/crates/interledger-api/src/routes/node_settings.rs
@@ -59,9 +59,8 @@ where
         })
         // This call makes it so we do not pass on a () value on
         // success to the next filter, it just gets rid of it
-        .untuple_one()
-        .boxed();
-    let with_store = warp::any().map(move || store.clone()).boxed();
+        .untuple_one();
+    let with_store = warp::any().map(move || store.clone());
 
     // GET /
     let get_root = warp::get()
@@ -73,8 +72,7 @@ where
                 ilp_address: store.get_ilp_address(),
                 version: node_version.clone(),
             })
-        })
-        .boxed();
+        });
 
     // PUT /rates
     let put_rates = warp::put()
@@ -86,8 +84,7 @@ where
         .and_then(|rates: ExchangeRates, store: S| async move {
             store.set_exchange_rates(rates.0.clone())?;
             Ok::<_, Rejection>(warp::reply::json(&rates))
-        })
-        .boxed();
+        });
 
     // GET /rates
     let get_rates = warp::get()
@@ -97,8 +94,7 @@ where
         .and_then(|store: S| async move {
             let rates = store.get_all_exchange_rates()?;
             Ok::<_, Rejection>(warp::reply::json(&rates))
-        })
-        .boxed();
+        });
 
     // GET /routes
     // Response: Map of ILP Address prefix -> Username
@@ -123,8 +119,7 @@ where
 
                 Ok::<Json, Rejection>(warp::reply::json(&routes))
             }
-        })
-        .boxed();
+        });
 
     // PUT /routes/static
     // Body: Map of ILP Address prefix -> Username
@@ -158,8 +153,7 @@ where
                     .await?;
                 Ok::<Json, Rejection>(warp::reply::json(&routes))
             }
-        })
-        .boxed();
+        });
 
     // PUT /routes/static/:prefix
     // Body: Username
@@ -182,8 +176,7 @@ where
                 store.set_static_route(prefix, account_id).await?;
                 Ok::<String, Rejection>(username.to_string())
             }
-        })
-        .boxed();
+        });
 
     // PUT /settlement/engines
     let put_settlement_engines = warp::put()
@@ -226,8 +219,7 @@ where
                 }
             }
             Ok::<Json, Rejection>(warp::reply::json(&asset_to_url_map_clone))
-        })
-        .boxed();
+        });
 
     get_root
         .or(put_rates)
@@ -236,7 +228,6 @@ where
         .or(put_static_routes)
         .or(put_static_route)
         .or(put_settlement_engines)
-        .boxed()
 }
 
 #[cfg(test)]

--- a/crates/interledger-http/Cargo.toml
+++ b/crates/interledger-http/Cargo.toml
@@ -24,7 +24,7 @@ serde_path_to_error = { version = "0.1", default-features = false }
 http = { version = "0.2.0", default-features = false }
 once_cell = { version = "1.3.1", default-features = false }
 mime = { version ="0.3.14", default-features = false }
-secrecy = { version = "0.6", default-features = false }
+secrecy = { version = "0.6", default-features = false, features = ["alloc"] }
 async-trait = { version = "0.1.22", default-features = false }
 
 [dev-dependencies]

--- a/crates/interledger-http/src/server.rs
+++ b/crates/interledger-http/src/server.rs
@@ -115,7 +115,7 @@ where
     ) -> impl warp::Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
         let store = self.store.clone();
         let incoming = self.incoming.clone();
-        let with_store = warp::any().map(move || store.clone()).boxed();
+        let with_store = warp::any().map(move || store.clone());
         let with_incoming = warp::any().map(move || incoming.clone());
         warp::post()
             .and(warp::path("accounts"))

--- a/crates/interledger-settlement/src/api/node_api.rs
+++ b/crates/interledger-settlement/src/api/node_api.rs
@@ -130,7 +130,7 @@ where
     O: OutgoingService<A> + Clone + Send + Sync + 'static,
     A: SettlementAccount + Account + Send + Sync + 'static,
 {
-    let with_store = warp::any().map(move || store.clone()).boxed();
+    let with_store = warp::any().map(move || store.clone());
     let idempotency = warp::header::optional::<String>("idempotency-key");
     let account_id_filter = warp::path("accounts").and(warp::path::param::<String>()); // account_id
 
@@ -147,7 +147,7 @@ where
 
     // POST /accounts/:account_id/messages (optional idempotency-key header)
     // Body is a Vec<u8> object
-    let with_outgoing_handler = warp::any().map(move || outgoing_handler.clone()).boxed();
+    let with_outgoing_handler = warp::any().map(move || outgoing_handler.clone());
     let messages_endpoint = account_id_filter.and(warp::path("messages"));
     let messages = warp::post()
         .and(messages_endpoint)

--- a/crates/interledger-settlement/src/core/engines_api.rs
+++ b/crates/interledger-settlement/src/core/engines_api.rs
@@ -154,8 +154,8 @@ where
     E: SettlementEngine + Clone + Send + Sync + 'static,
     S: IdempotentStore + Clone + Send + Sync + 'static,
 {
-    let with_store = warp::any().map(move || store.clone()).boxed();
-    let with_engine = warp::any().map(move || engine.clone()).boxed();
+    let with_store = warp::any().map(move || store.clone());
+    let with_engine = warp::any().map(move || engine.clone());
     let idempotency = warp::header::optional::<String>("idempotency-key");
     let account_id = warp::path("accounts").and(warp::path::param::<String>()); // account_id
 


### PR DESCRIPTION
- fix the individual build of the `interledger-http` crate that currently fails due to `secrecy::SecretString` requiring the `alloc` feature
- remove calls to `.boxed()` where it is of no consequence to the return values of functions; they introduce extra indirection via `Arc`