### PR TITLE
Squash a few perf-related TODOs

### DIFF
--- a/crates/interledger-api/src/routes/accounts.rs
+++ b/crates/interledger-api/src/routes/accounts.rs
@@ -397,8 +397,7 @@ where
             let default_spsp_account = default_spsp_account.clone();
             let server_secret_clone = server_secret.clone();
             async move {
-                // TODO don't clone this
-                if let Some(username) = default_spsp_account.clone() {
+                if let Some(ref username) = default_spsp_account {
                     let id = store.get_account_id_from_username(&username).await?;
 
                     // TODO this shouldn't take multiple store calls

--- a/crates/interledger-http/src/client.rs
+++ b/crates/interledger-http/src/client.rs
@@ -9,7 +9,7 @@ use reqwest::{
     Client, ClientBuilder, Response as HttpResponse,
 };
 use secrecy::{ExposeSecret, SecretString};
-use std::{convert::TryFrom, marker::PhantomData, sync::Arc, time::Duration};
+use std::{convert::TryFrom, iter::FromIterator, marker::PhantomData, sync::Arc, time::Duration};
 use tracing::{error, trace};
 
 /// The HttpClientService implements [OutgoingService](../../interledger_service/trait.OutgoingService)
@@ -157,8 +157,8 @@ async fn parse_packet_from_response(response: HttpResponse, ilp_address: Address
             .build()
         })
         .await?;
-    // TODO can we get the body as a BytesMut so we don't need to copy?
-    let body = BytesMut::from(body.as_ref());
+
+    let body = BytesMut::from_iter(body.into_iter());
     match Packet::try_from(body) {
         Ok(Packet::Fulfill(fulfill)) => Ok(fulfill),
         Ok(Packet::Reject(reject)) => Err(reject),

--- a/crates/interledger-packet/src/packet.rs
+++ b/crates/interledger-packet/src/packet.rs
@@ -11,6 +11,7 @@ use chrono::{DateTime, TimeZone, Utc};
 use super::oer::{self, BufOerExt, MutBufOerExt};
 use super::{Address, ErrorCode, ParseError};
 use std::convert::TryFrom;
+use std::iter::FromIterator;
 
 const AMOUNT_LEN: usize = 8;
 const EXPIRY_LEN: usize = 17;
@@ -590,9 +591,7 @@ impl TryFrom<bytes05::BytesMut> for Prepare {
     type Error = ParseError;
 
     fn try_from(buffer: bytes05::BytesMut) -> Result<Self, Self::Error> {
-        // TODO: Is this the best we can do?
-        let b = buffer.to_vec();
-        let buffer = BytesMut::from(b);
+        let buffer = BytesMut::from_iter(buffer.into_iter());
         Prepare::try_from(buffer)
     }
 }
@@ -601,9 +600,7 @@ impl TryFrom<bytes05::BytesMut> for Packet {
     type Error = ParseError;
 
     fn try_from(buffer: bytes05::BytesMut) -> Result<Self, Self::Error> {
-        // TODO: Is this the best we can do?
-        let b = buffer.to_vec();
-        let buffer = BytesMut::from(b);
+        let buffer = BytesMut::from_iter(buffer.into_iter());
         Packet::try_from(buffer)
     }
 }

--- a/crates/interledger-spsp/src/client.rs
+++ b/crates/interledger-spsp/src/client.rs
@@ -60,7 +60,7 @@ where
         &from_account,
         store,
         addr,
-        &shared_secret,
+        shared_secret,
         source_amount,
         slippage,
     )

--- a/crates/interledger-store/src/redis/reconnect.rs
+++ b/crates/interledger-store/src/redis/reconnect.rs
@@ -40,11 +40,11 @@ impl RedisReconnect {
     }
 
     /// Reconnects to redis
-    pub async fn reconnect(self) -> Result<Self> {
+    pub async fn reconnect(&self) -> Result<()> {
         let shared_connection = get_shared_connection(self.redis_info.clone()).await?;
         (*self.conn.write()) = shared_connection;
         debug!("Reconnected to Redis");
-        Ok(self)
+        Ok(())
     }
 
     fn get_shared_connection(&self) -> MultiplexedConnection {
@@ -66,8 +66,8 @@ impl ConnectionLike for RedisReconnect {
                 Err(error) => {
                     if error.is_connection_dropped() {
                         debug!("Redis connection was dropped, attempting to reconnect");
-                        // TODO: Is this correct syntax? Otherwise we get an unused result warning
-                        let _ = self.clone().reconnect().await;
+                        // FIXME: this conceals potential reconnect errors
+                        let _ = self.reconnect().await;
                     }
                     Err(error)
                 }
@@ -90,8 +90,8 @@ impl ConnectionLike for RedisReconnect {
                 Err(error) => {
                     if error.is_connection_dropped() {
                         debug!("Redis connection was dropped, attempting to reconnect");
-                        // TODO: Is this correct syntax? Otherwise we get an unused result warning
-                        let _ = self.clone().reconnect().await;
+                        // FIXME: this conceals potential reconnect errors
+                        let _ = self.reconnect().await;
                     }
                     Err(error)
                 }

--- a/crates/interledger-stream/src/client.rs
+++ b/crates/interledger-stream/src/client.rs
@@ -294,7 +294,7 @@ pub async fn send_money<I, A, S>(
     from_account: &A,
     store: S,
     destination_account: Address,
-    shared_secret: &[u8],
+    shared_secret: Vec<u8>,
     source_amount: u64,
     slippage: f64,
 ) -> Result<StreamDelivery, Error>
@@ -303,7 +303,6 @@ where
     A: Account + Send + Sync + 'static,
     S: ExchangeRateStore + Send + Sync + 'static,
 {
-    // TODO Can we avoid copying here?
     let shared_secret = Bytes::from(shared_secret);
 
     let from = from_account.ilp_address();
@@ -766,7 +765,7 @@ mod send_money_tests {
                 price_2: None,
             },
             Address::from_str("example.destination").unwrap(),
-            &[0; 32][..],
+            vec![0; 32],
             100,
             0.0,
         )
@@ -821,7 +820,7 @@ mod send_money_tests {
             &account,
             store,
             destination_address.clone(),
-            &[0; 32][..],
+            vec![0; 32],
             50,
             0.0,
         )
@@ -906,7 +905,7 @@ mod send_money_tests {
                 price_2: None,
             },
             destination_address.clone(),
-            &[0; 32][..],
+            vec![0; 32],
             50,
             0.0,
         )

--- a/crates/interledger-stream/src/lib.rs
+++ b/crates/interledger-stream/src/lib.rs
@@ -245,7 +245,7 @@ mod send_money_to_receiver {
                 price_2: None,
             },
             destination_account,
-            &shared_secret[..],
+            shared_secret.to_vec(),
             100,
             0.0,
         )
@@ -309,7 +309,7 @@ mod send_money_to_receiver {
             &sender_account,
             store,
             destination_account,
-            &shared_secret[..],
+            shared_secret.to_vec(),
             1000,
             0.014,
         )

--- a/crates/interledger-stream/src/packet.rs
+++ b/crates/interledger-stream/src/packet.rs
@@ -30,8 +30,7 @@ pub struct StreamPacketBuilder<'a> {
 impl<'a> StreamPacketBuilder<'a> {
     /// Serializes the builder into a Stream Packet
     pub fn build(&self) -> StreamPacket {
-        // TODO predict length first
-        let mut buffer_unencrypted = Vec::new();
+        let mut buffer_unencrypted = Vec::with_capacity(26);
 
         buffer_unencrypted.put_u8(STREAM_VERSION);
         buffer_unencrypted.put_u8(self.ilp_packet_type as u8);


### PR DESCRIPTION
These changes mostly target unnecessary allocations; individual commits describe specific changes.

In [one case](https://github.com/interledger-rs/interledger-rs/commit/4b76734e98a9f80419186b67cb871a38448fe3e6) I changed the `TODO` to `FIXME`, because it's a bit of a liability; it can be easily fixed, but doing so requires 2 related tests to be adjusted:
```
---- balances_test::prepare_then_fulfill_with_settlement stdout ----
thread 'balances_test::prepare_then_fulfill_with_settlement' panicked at 'assertion failed: `(left == right)`
  left: `"No such file or directory (os error 2)"`,
 right: `"Broken pipe (os error 32)"`', crates/interledger-store/tests/redis/balances_test.rs:197:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- accounts_test::delete_accounts stdout ----
thread 'accounts_test::delete_accounts' panicked at 'assertion failed: `(left == right)`
  left: `"No such file or directory (os error 2)"`,
 right: `"Broken pipe (os error 32)"`', crates/interledger-store/tests/redis/accounts_test.rs:182:5

failures:
    accounts_test::delete_accounts
    balances_test::prepare_then_fulfill_with_settlement
```
which I am happy to do if it's desirable.
