### PR TITLE
Add time-based settlement to complement the threshold-based

### DIFF
--- a/crates/ilp-node/src/main.rs
+++ b/crates/ilp-node/src/main.rs
@@ -133,8 +133,12 @@ async fn main() {
             .long("settle_every")
             .takes_value(true)
             .help("Settlement delay, in seconds, the peering accounts will be settled after \
-                this many seconds after the first fulfill packet unless the balance exceeds \
-                settlement threshold before."),
+                this many seconds after the first fulfill packet unless the balance had \
+                exceeded the settlement threshold.\n\n\
+                \
+                Note: In a cluster configuration where multiple nodes share a \
+                single database and database accounts, using this can result in \
+                many settlements."),
         ]);
 
     let mut config = get_env_config("ilp");

--- a/crates/ilp-node/src/main.rs
+++ b/crates/ilp-node/src/main.rs
@@ -129,6 +129,12 @@ async fn main() {
                 old data. For example, a value of 1000ms (1 second) would mean that the \
                 node forgets the oldest 1 second of histogram data points every second. \
                 Defaults to 10000ms (10 seconds)."),
+        Arg::with_name("settle_every")
+            .long("settle_every")
+            .takes_value(true)
+            .help("Settlement delay, in seconds, the peering accounts will be settled after \
+                this many seconds after the first fulfill packet unless the balance exceeds \
+                settlement threshold before."),
         ]);
 
     let mut config = get_env_config("ilp");

--- a/crates/ilp-node/src/main.rs
+++ b/crates/ilp-node/src/main.rs
@@ -132,7 +132,7 @@ async fn main() {
         Arg::with_name("settle_every")
             .long("settle_every")
             .takes_value(true)
-            .help("Settlement delay, in seconds, the peering accounts will be settled after \
+            .help("Settlement delay, in seconds; the peering accounts will be settled after \
                 this many seconds after the first fulfill packet unless the balance had \
                 exceeded the settlement threshold.\n\n\
                 \

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -229,6 +229,8 @@ pub struct InterledgerNode {
     pub google_pubsub: Option<PubsubConfig>,
     /// The delay in seconds to settle peering account to `settle_to` level in addition to settling
     /// the account when it exceeds the settlement threshold.
+    ///
+    /// See further notes at `--help` output.
     #[cfg(feature = "balance-tracking")]
     pub settle_every: Option<NonZeroU32>,
 }

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -402,7 +402,7 @@ impl InterledgerNode {
             Some(seconds) => {
                 use futures::stream::StreamExt;
                 let delay = Duration::from_secs(seconds.get().into());
-                let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+                let (tx, rx) = tokio::sync::mpsc::channel(128);
 
                 start_delayed_settlement(delay, rx.fuse(), store.clone());
 

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -64,10 +64,11 @@ use interledger::{
 use num_bigint::BigUint;
 use once_cell::sync::Lazy;
 use serde::{de::Error as DeserializeError, Deserialize, Deserializer};
+#[cfg(feature = "balance-tracking")]
+use std::num::NonZeroU32;
 use std::{
     convert::TryFrom,
     net::SocketAddr,
-    num::NonZeroU32,
     str::{self, FromStr},
     time::Duration,
 };

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -67,6 +67,7 @@ use serde::{de::Error as DeserializeError, Deserialize, Deserializer};
 use std::{
     convert::TryFrom,
     net::SocketAddr,
+    num::NonZeroU32,
     str::{self, FromStr},
     time::Duration,
 };
@@ -79,7 +80,7 @@ use warp::{self, Filter};
 #[cfg(feature = "redis")]
 use crate::redis_store::*;
 #[cfg(feature = "balance-tracking")]
-use interledger::service_util::BalanceService;
+use interledger::service_util::{start_delayed_settlement, BalanceService};
 
 #[doc(hidden)]
 pub use interledger::rates::ExchangeRateProvider;
@@ -226,6 +227,10 @@ pub struct InterledgerNode {
     pub prometheus: Option<PrometheusConfig>,
     #[cfg(feature = "google-pubsub")]
     pub google_pubsub: Option<PubsubConfig>,
+    /// The delay in seconds to settle peering account to `settle_to` level in addition to settling
+    /// the account when it exceeds the settlement threshold.
+    #[cfg(feature = "balance-tracking")]
+    pub settle_every: Option<NonZeroU32>,
 }
 
 impl InterledgerNode {
@@ -391,8 +396,21 @@ impl InterledgerNode {
         let outgoing_service = ExpiryShortenerService::new(outgoing_service);
         let outgoing_service =
             StreamReceiverService::new(secret_seed.clone(), store.clone(), outgoing_service);
+
         #[cfg(feature = "balance-tracking")]
-        let outgoing_service = BalanceService::new(store.clone(), outgoing_service);
+        let outgoing_service = match self.settle_every {
+            Some(seconds) => {
+                use futures::stream::StreamExt;
+                let delay = Duration::from_secs(seconds.get().into());
+                let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+                start_delayed_settlement(delay, rx.fuse(), store.clone());
+
+                BalanceService::new(store.clone(), Some(tx), outgoing_service)
+            }
+            None => BalanceService::new(store.clone(), None, outgoing_service),
+        };
+
         let outgoing_service =
             ExchangeRateService::new(exchange_rate_spread, store.clone(), outgoing_service);
 

--- a/crates/ilp-node/tests/redis/redis_tests.rs
+++ b/crates/ilp-node/tests/redis/redis_tests.rs
@@ -3,6 +3,7 @@ mod btp;
 mod exchange_rates;
 mod payments_incoming;
 mod three_nodes;
+mod time_based_settlement;
 
 // Only run prometheus tests if the monitoring feature is turned on
 #[cfg(feature = "monitoring")]

--- a/crates/ilp-node/tests/redis/time_based_settlement.rs
+++ b/crates/ilp-node/tests/redis/time_based_settlement.rs
@@ -1,0 +1,330 @@
+use crate::redis_helpers::{connection_info_to_string, get_open_port, TestContext};
+use crate::test_helpers::{create_account_on_node, random_secret};
+use ilp_node::InterledgerNode;
+use serde_json::json;
+use std::convert::TryFrom;
+
+#[tokio::test]
+#[cfg(feature = "balance-tracking")]
+async fn time_based_settlement() {
+    // Create two nodes, two payments:
+    //
+    // 1. over settlement threshold
+    // 2. wait for 1/4 of configured settle_every to get the settlement
+    // 3. below settlement threshold
+    // 4. expect to get the settlement in 3/4..5/4 of configured settle_every
+    //
+    // This was created following example of payments_incoming. The routing could be different.
+
+    let settle_threshold = 500;
+    let settle_to = 0;
+    let settle_delay = std::time::Duration::from_secs(1);
+
+    let context = TestContext::new();
+
+    let mut node_a_connections = context.get_client_connection_info();
+    node_a_connections.db = 1;
+    let mut node_b_connections = context.get_client_connection_info();
+    node_b_connections.db = 2;
+
+    let node_a_http = get_open_port(None);
+    let node_a_settlement = get_open_port(None);
+    let node_b_http = get_open_port(None);
+    let node_b_settlement = get_open_port(None);
+
+    // Launch a in-test settlement engine which will communicate the API back to us through the
+    // channel. Shutdown channel might not be necessary.
+    let (_shutdown, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+    let (node_b_settlement_engine, settlement_engine_server) = warp::serve(settlement_engine(tx))
+        .bind_with_graceful_shutdown(([127, 0, 0, 1], 0), async move {
+            // not sure if this is required
+            let _ = shutdown_rx.await;
+        });
+
+    tokio::task::spawn(settlement_engine_server);
+
+    let asset_code = "XYZ";
+    let asset_scale: usize = 9;
+    let http_secret = "default account holder";
+    let btp_secret = "token";
+
+    // accounts to be created on node a
+    let alice_on_a = json!({
+        "username": "alice_on_a",
+        "asset_code": asset_code,
+        "asset_scale": asset_scale,
+        "ilp_over_http_incoming_token": http_secret,
+    });
+    let b_on_a = json!({
+        "username": "b_on_a",
+        "asset_code": asset_code,
+        "asset_scale": asset_scale,
+        "ilp_over_btp_url": format!("ws://localhost:{}/accounts/{}/ilp/btp", node_b_http, "a_on_b"),
+        "ilp_over_btp_outgoing_token" : btp_secret,
+        "routing_relation": "Parent",
+        "settlement_engine_url": format!("http://{}:{}", node_b_settlement_engine.ip(), node_b_settlement_engine.port()),
+    });
+
+    // accounts to be created on node b
+    let a_on_b = json!({
+        "username": "a_on_b",
+        "asset_code": asset_code,
+        "asset_scale": asset_scale,
+        "ilp_over_btp_incoming_token" : btp_secret,
+        "routing_relation": "Child",
+        "prepaid_balance": "0",
+        "settle_threshold": settle_threshold,
+        "settle_to": settle_to,
+    });
+    let bob_on_b = json!({
+        "username": "bob_on_b",
+        "asset_code": asset_code,
+        "asset_scale": asset_scale,
+        "ilp_over_http_incoming_token" : http_secret,
+        "prepaid_balance": "0",
+        "settle_threshold": settle_threshold,
+        "settle_to": settle_to,
+        "settlement_engine_url": format!("http://{}:{}", node_b_settlement_engine.ip(), node_b_settlement_engine.port()),
+    });
+
+    // node a config
+    let node_a: InterledgerNode = serde_json::from_value(json!({
+        "admin_auth_token": "admin",
+        "database_url": connection_info_to_string(node_a_connections),
+        "http_bind_address": format!("127.0.0.1:{}", node_a_http),
+        "settlement_api_bind_address": format!("127.0.0.1:{}", node_a_settlement),
+        "secret_seed": random_secret(),
+        "route_broadcast_interval": 200,
+        "exchange_rate": {
+            "poll_interval": 60000
+        },
+    }))
+    .expect("Error creating node_a.");
+
+    // node b config
+    let node_b: InterledgerNode = serde_json::from_value(json!({
+        "ilp_address": "example.parent",
+        "default_spsp_account": "bob_on_b",
+        "admin_auth_token": "admin",
+        "database_url": connection_info_to_string(node_b_connections),
+        "http_bind_address": format!("127.0.0.1:{}", node_b_http),
+        "settlement_api_bind_address": format!("127.0.0.1:{}", node_b_settlement),
+        "secret_seed": random_secret(),
+        "route_broadcast_interval": 200,
+        "exchange_rate": {
+            "poll_interval": 60000
+        },
+        // different from the other cases
+        "settle_every": settle_delay.as_secs(),
+        "settlement_engine_url": format!("http://{}:{}", node_b_settlement_engine.ip(), node_b_settlement_engine.port()),
+    }))
+    .expect("Error creating node_b.");
+
+    // start node b and open its accounts
+    node_b.serve(None).await.unwrap();
+    create_account_on_node(node_b_http, a_on_b, "admin")
+        .await
+        .unwrap();
+    create_account_on_node(node_b_http, bob_on_b, "admin")
+        .await
+        .unwrap();
+
+    let bob_on_b_id = match rx.recv().await.unwrap() {
+        SettlementEngineEvent::AccountCreation(id) => id,
+        x => unreachable!("{:?}", x),
+    };
+
+    // start node a and open its accounts
+    node_a.serve(None).await.unwrap();
+    create_account_on_node(node_a_http, alice_on_a, "admin")
+        .await
+        .unwrap();
+    create_account_on_node(node_a_http, b_on_a, "admin")
+        .await
+        .unwrap();
+
+    let _b_on_a_id = match rx.recv().await.unwrap() {
+        SettlementEngineEvent::AccountCreation(id) => id,
+        x => unreachable!("{:?}", x),
+    };
+
+    // no need to listen to notifications
+    crate::test_helpers::send_money_to_username(
+        node_a_http,
+        node_b_http,
+        settle_threshold + 1,
+        "bob_on_b",
+        "alice_on_a",
+        http_secret,
+    )
+    .await
+    .unwrap();
+
+    match tokio::time::timeout(settle_delay / 8, rx.recv()).await {
+        Ok(Some(SettlementEngineEvent::Settlement {
+            account,
+            amount,
+            scale,
+        })) => {
+            assert_eq!(account, bob_on_b_id);
+            assert_eq!(amount, settle_threshold + 1);
+            assert_eq!(scale, 9);
+        }
+        x => unreachable!("{:?}", x),
+    };
+
+    let before = std::time::Instant::now();
+
+    crate::test_helpers::send_money_to_username(
+        node_a_http,
+        node_b_http,
+        settle_threshold - 1,
+        "bob_on_b",
+        "alice_on_a",
+        http_secret,
+    )
+    .await
+    .unwrap();
+
+    match tokio::time::timeout(settle_delay * 2, rx.recv()).await {
+        Ok(Some(SettlementEngineEvent::Settlement {
+            account,
+            amount,
+            scale,
+        })) => {
+            assert_eq!(account, bob_on_b_id);
+            assert_eq!(amount, settle_threshold - 1);
+            assert_eq!(scale, 9);
+        }
+        x => unreachable!("{:?}", x),
+    };
+
+    let elapsed = before.elapsed();
+
+    let expected = i64::try_from(settle_delay.as_millis()).unwrap();
+    let relative = i64::try_from(elapsed.as_millis()).unwrap() - expected;
+
+    assert!(
+        relative.abs() < (expected / 4),
+        "settlement took unexpected amount of time: {:?}",
+        elapsed
+    );
+}
+
+#[derive(Debug)]
+enum SettlementEngineEvent {
+    AccountCreation(uuid::Uuid),
+    Settlement {
+        account: uuid::Uuid,
+        amount: u64,
+        scale: usize,
+    },
+    UnexpectedRequest(String),
+}
+
+/// Minimal settlement engine API for the test purposes.
+fn settlement_engine(
+    tx: tokio::sync::mpsc::Sender<SettlementEngineEvent>,
+) -> impl warp::Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    use uuid::Uuid;
+    use warp::Filter;
+
+    // need to catch POST /accounts b"{\"id\":\"58f9c44b-f47b-4f2b-84eb-5822ba3996f5\"}"
+    // and POST accounts/58f9c44b-f47b-4f2b-84eb-5822ba3996f5/settlements: b"{\"amount\":\"1000\",\"scale\":9}"
+
+    #[derive(serde::Deserialize)]
+    struct AccountInfo {
+        id: Uuid,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct SettlementInfo {
+        amount: String,
+        scale: usize,
+    }
+
+    #[derive(Debug)]
+    struct InternalError;
+
+    impl warp::reject::Reject for InternalError {}
+
+    let create_account = {
+        let tx = tx.clone();
+        warp::post()
+            .and(warp::path!("accounts"))
+            .and(warp::body::json())
+            .and_then(move |body: AccountInfo| {
+                let mut tx = tx.clone();
+                async move {
+                    tracing::trace!("begin sending");
+                    tx.send(SettlementEngineEvent::AccountCreation(body.id))
+                        .await
+                        .map_err(|_| warp::reject::custom(InternalError))?;
+                    tracing::trace!("after sending");
+                    Ok::<_, warp::Rejection>((warp::reply(),))
+                }
+            })
+    };
+
+    let create_settlement = {
+        let tx = tx.clone();
+
+        warp::post()
+            .and(warp::path!("accounts" / Uuid / "settlements"))
+            .and(warp::body::json())
+            .and_then(move |id: Uuid, body: SettlementInfo| {
+                let mut tx = tx.clone();
+                let amount = body.amount.parse::<u64>().unwrap();
+                let scale = body.scale;
+                async move {
+                    tx.send(SettlementEngineEvent::Settlement {
+                        account: id,
+                        amount,
+                        scale,
+                    })
+                    .await
+                    .map_err(|_| warp::reject::custom(InternalError))?;
+                    Ok::<_, warp::Rejection>((warp::reply(),))
+                }
+            })
+    };
+
+    let others = warp::any()
+        .and(warp::path::peek())
+        .and(warp::body::bytes())
+        .and_then(move |p: warp::path::Peek, body| {
+            let mut tx = tx.clone();
+            tracing::warn!("{}: {:02x?}", p.as_str(), body);
+            async move {
+                tx.send(SettlementEngineEvent::UnexpectedRequest(
+                    p.as_str().to_owned(),
+                ))
+                .await
+                .map_err(|_| warp::reject::custom(InternalError))?;
+
+                Ok::<_, warp::Rejection>((warp::reply(),))
+            }
+        });
+
+    let recover = |err: warp::Rejection| {
+        use warp::hyper::http::StatusCode;
+        let code;
+        let message;
+
+        if err.is_not_found() {
+            code = StatusCode::NOT_FOUND;
+            message = "Not found";
+        } else {
+            code = StatusCode::INTERNAL_SERVER_ERROR;
+            message = "Internal server error";
+        }
+
+        futures::future::ready(Ok::<_, _>(warp::reply::with_status(message, code)))
+    };
+
+    warp::any()
+        .and(create_account.or(create_settlement).or(others))
+        .recover(recover)
+        .with(warp::trace::named("fake_settlement_engine"))
+}

--- a/crates/interledger-api/src/routes/test_helpers.rs
+++ b/crates/interledger-api/src/routes/test_helpers.rs
@@ -358,6 +358,13 @@ impl BalanceStore for TestStore {
     ) -> Result<(), BalanceStoreError> {
         unimplemented!()
     }
+
+    async fn update_balances_for_delayed_settlement(
+        &self,
+        _: Uuid,
+    ) -> Result<(i64, u64), BalanceStoreError> {
+        unimplemented!()
+    }
 }
 
 #[async_trait]

--- a/crates/interledger-service-util/src/balance_service.rs
+++ b/crates/interledger-service-util/src/balance_service.rs
@@ -255,7 +255,7 @@ where
         .await?;
 
     // this message is really important, if you want to recover the balance after a crash; all of
-    // the "amount that need to be settled" must be summed and added to accounts "balance".
+    // the "amount that need to be settled" must be summed and added to the account's "balance".
     debug!(
         "Account {} balance after fulfill: {}. Amount that needs to be settled: {}",
         to.id(),
@@ -344,7 +344,7 @@ where
             );
         }
     } else {
-        debug!("Settlement for account {} for {} failed as the account has no settlement-engine details",
+        debug!("Settlement for account {} for {} failed as the account has no settlement engine details",
             to.id(), amount);
     }
 
@@ -469,14 +469,14 @@ impl fmt::Display for ExitReason {
         match *self {
             InputClosed => write!(fmt, "Input was closed and ran out of timed settlements"),
             Shutdown => write!(fmt, "Tokio is shutting down"),
-            Capacity => write!(fmt, "Timer service is over capacity"),
+            Capacity => write!(fmt, "Timer service capacity exceeded"),
             Other(ref e) => write!(fmt, "Other: {}", e),
         }
     }
 }
 
 /// Start a background task for time based settlement. If time based settlement is configured but
-/// this task is never started the time based settlement does not happen and a warning is logged
+/// this task is never started, the time-based settlement does not happen and a warning is logged
 /// every minute on eligble random peering account.
 pub fn start_delayed_settlement<St, Store, Acct>(
     delay: Duration,
@@ -497,7 +497,7 @@ where
     let client = SettlementClient::default();
     tokio::spawn(async move {
         info!(
-            "Starting to run delayed settlements with timeout of {:?}",
+            "Starting to run delayed settlements with a timeout of {:?}",
             delay
         );
 
@@ -589,7 +589,7 @@ where
                                 }
                                 Err(e) => {
                                     warn!(
-                                        "Failed to load account {} for time based settlement: {}",
+                                        "Failed to load account {} for time-based settlement: {}",
                                         id, e
                                     );
                                     Err(())
@@ -597,10 +597,10 @@ where
                             }?;
 
                             let (balance, amount_to_settle) = store.update_balances_for_delayed_settlement(id).await
-                                .map_err(|e| warn!("Time based settlement failed for {}: {}", id, e))?;
+                                .map_err(|e| warn!("Time-based settlement failed for {}: {}", id, e))?;
 
                             debug!(
-                                "Account {} balance at time based settlement: {}, Amount that needs to be settled: {}",
+                                "Account {} balance at time-based settlement: {}, amount that needs to be settled: {}",
                                 to.id(), balance, amount_to_settle
                             );
 

--- a/crates/interledger-service-util/src/balance_service.rs
+++ b/crates/interledger-service-util/src/balance_service.rs
@@ -8,7 +8,8 @@ use interledger_settlement::core::{
     SettlementClient,
 };
 use std::marker::PhantomData;
-use tracing::{debug, error};
+use std::{fmt, time::Duration};
+use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
 
 // TODO: Remove AccountStore dependency, use `AccountId: ToString` as associated type
@@ -39,6 +40,17 @@ pub trait BalanceStore {
         from_account_id: Uuid,
         incoming_amount: u64,
     ) -> Result<(), BalanceStoreError>;
+
+    /// Removes any positive amount to settle over `settle_to` from `balance`. Similarly to other
+    /// balance updates once this call succeeds the amount needed to be settled is only in the
+    /// interledger node so crashing while the HTTP request to settlement-engine hasn't gone
+    /// through or this balance hasn't been refunded will lead to loss of the "amount to settle".
+    ///
+    /// Returns (balance, amount_to_settle).
+    async fn update_balances_for_delayed_settlement(
+        &self,
+        to_account_id: Uuid,
+    ) -> Result<(i64, u64), BalanceStoreError>;
 }
 
 /// # Balance Service
@@ -51,6 +63,7 @@ pub struct BalanceService<S, O, A> {
     store: S,
     next: O,
     settlement_client: SettlementClient,
+    policy: Policy,
     account_type: PhantomData<A>,
 }
 
@@ -60,11 +73,19 @@ where
     O: OutgoingService<A>,
     A: Account + SettlementAccount,
 {
-    pub fn new(store: S, next: O) -> Self {
+    pub fn new(
+        store: S,
+        sender: Option<tokio::sync::mpsc::UnboundedSender<ManageTimeout>>,
+        next: O,
+    ) -> Self {
         BalanceService {
             store,
             next,
             settlement_client: SettlementClient::default(),
+            policy: match sender {
+                Some(tx) => Policy::TimeBased(tx),
+                None => Policy::ThresholdOnly,
+            },
             account_type: PhantomData,
         }
     }
@@ -91,6 +112,7 @@ where
         // prepare.amount is 0, because the original amount could be rounded down
         // to 0 when exchange rate and scale change are applied.
         if request.prepare.amount() == 0 && request.original_amount == 0 {
+            // wonder if timeout should still be set here?
             return self.next.send_request(request).await;
         }
 
@@ -101,7 +123,6 @@ where
         let from_id = from.id();
         let to = request.to.clone();
         let to_clone = to.clone();
-        let to_id = to.id();
         let incoming_amount = request.original_amount;
         let outgoing_amount = request.prepare.amount();
         let ilp_address = self.store.get_ilp_address();
@@ -118,7 +139,7 @@ where
         // operate as-if the settlement engine has completed. Finally, if the request to the settlement-engine
         // fails, this amount will be re-added back to balance.
         self.store
-            .update_balances_for_prepare(from.id(), incoming_amount)
+            .update_balances_for_prepare(from_id, incoming_amount)
             .map_err(move |_| {
                 debug!("Rejecting packet because it would exceed a balance limit");
                 RejectBuilder {
@@ -141,46 +162,16 @@ where
                     // we need to propagate it backwards ASAP. If we do not give the
                     // previous node the fulfillment in time, they won't pay us back
                     // for the packet we forwarded. Note this means that we will
-                    // relay the fulfillment _even if saving to the DB fails._
-                    tokio::spawn(async move {
-                        let (balance, amount_to_settle) = store
-                            .update_balances_for_fulfill(to.id(), outgoing_amount)
-                            .map_err(|err| error!("Error applying balance changes for fulfill from account: {} to account: {}. Incoming amount was: {}, outgoing amount was: {}. Error: {}", from_id, to_id, incoming_amount, outgoing_amount, err))
-                            .await?;
-                        debug!(
-                            "Account balance after fulfill: {}. Amount that needs to be settled: {}",
-                            balance, amount_to_settle
-                        );
-                        if amount_to_settle > 0 {
-                            if let Some(engine_details) = to.settlement_engine_details() {
-                                let engine_url = engine_details.url;
-                                // Note that if this program crashes after changing the balance (in the PROCESS_FULFILL script)
-                                // and the send_settlement fails but the program isn't alive to hear that, the balance will be incorrect.
-                                // No other instance will know that it was trying to send an outgoing settlement. We could
-                                // make this more robust by saving something to the DB about the outgoing settlement when we change the balance
-                                // but then we would also need to prevent a situation where every connector instance is polling the
-                                // settlement engine for the status of each
-                                // outgoing settlement and putting unnecessary
-                                // load on the settlement engine.
-                                if settlement_client
-                                    .send_settlement(
-                                        to.id(),
-                                        engine_url,
-                                        amount_to_settle,
-                                        to.asset_scale(),
-                                    )
-                                    .await
-                                    .is_err()
-                                {
-                                    store
-                                        .refund_settlement(to_id, amount_to_settle)
-                                        .map_err(|_| ())
-                                        .await?;
-                                }
-                            }
-                        }
-                        Ok::<(), ()>(())
-                    });
+                    // relay the fulfillment _even if saving to the DB fails.
+                    settle_or_rollback_later(
+                        incoming_amount,
+                        outgoing_amount,
+                        store,
+                        from_id,
+                        to,
+                        settlement_client,
+                        self.policy.clone(),
+                    );
                 }
 
                 Ok(fulfill)
@@ -211,6 +202,354 @@ where
     }
 }
 
+// See comments above in the BalanceStore::send_request why this is done in another task.
+fn settle_or_rollback_later<Acct, Store>(
+    incoming_amount: u64,
+    outgoing_amount: u64,
+    store: Store,
+    from_id: Uuid,
+    to: Acct,
+    settlement_client: SettlementClient,
+    policy: Policy,
+) where
+    Acct: SettlementAccount + Send + Sync + 'static,
+    Store: BalanceStore + SettlementStore<Account = Acct> + Send + Sync + 'static,
+{
+    tokio::spawn(settle_or_rollback_now(
+        incoming_amount,
+        outgoing_amount,
+        store,
+        from_id,
+        to,
+        settlement_client,
+        policy,
+    ));
+}
+
+async fn settle_or_rollback_now<Acct, Store>(
+    incoming_amount: u64,
+    outgoing_amount: u64,
+    store: Store,
+    from_id: Uuid,
+    to: Acct,
+    settlement_client: SettlementClient,
+    policy: Policy,
+) -> Result<(), ()>
+where
+    Acct: SettlementAccount + Send + Sync + 'static,
+    Store: BalanceStore + SettlementStore<Account = Acct> + Send + Sync + 'static,
+{
+    let (balance, amount_to_settle) = store
+        .update_balances_for_fulfill(to.id(), outgoing_amount)
+        .map_err(|err| error!("Error applying balance changes for fulfill from account: {} to account: {}. Incoming amount was: {}, outgoing amount was: {}. Error: {}", from_id, to.id(), incoming_amount, outgoing_amount, err))
+        .await?;
+
+    // this message is really important, if you want to recover the balance after a crash; all of
+    // the "amount that need to be settled" must be summed and added to accounts "balance".
+    debug!(
+        "Account {} balance after fulfill: {}. Amount that needs to be settled: {}",
+        to.id(),
+        balance,
+        amount_to_settle
+    );
+
+    if amount_to_settle == 0 {
+        // so we might have some balance, but it's not over the threshold
+        // this might still end up scheduling a no-op as we should really be comparing to
+        // `settle_to` which we do not have access here.
+        if balance > 0 {
+            // so if we have the timeout configured, we should now make sure that there is a
+            // timeout pending or new one is created right now.
+            //
+            // two different approaches:
+            //  - some Arc<Mutex<Something>>
+            //  - some channel of Account ids
+            //
+            // the new settlement thing will need to settle any balance x to settle_to,
+            // where x >= settle_to
+            policy.settle_later(to.id());
+        }
+        return Ok(());
+    }
+
+    // cancel a pending settlement always before trying it
+    policy.clear_later(to.id());
+
+    settle_or_rollback(store, to, amount_to_settle, settlement_client).await
+}
+
+async fn settle_or_rollback<Store, Acct>(
+    store: Store,
+    to: Acct,
+    amount: u64,
+    client: SettlementClient,
+) -> Result<(), ()>
+where
+    Store: SettlementStore<Account = Acct> + 'static,
+    Acct: SettlementAccount + 'static,
+{
+    if amount == 0 {
+        debug!("Nothing to settle for account {}", to.id());
+        return Ok(());
+    }
+
+    if let Some(engine_details) = to.settlement_engine_details() {
+        let engine_url = engine_details.url;
+        // Note that if this program crashes after changing the balance (in the PROCESS_FULFILL script)
+        // and the send_settlement fails but the program isn't alive to hear that, the balance will be incorrect.
+        // No other instance will know that it was trying to send an outgoing settlement. We could
+        // make this more robust by saving something to the DB about the outgoing settlement when we change the balance
+        // but then we would also need to prevent a situation where every connector instance is polling the
+        // settlement engine for the status of each
+        // outgoing settlement and putting unnecessary
+        // load on the settlement engine.
+
+        let result = client
+            .send_settlement(to.id(), engine_url, amount, to.asset_scale())
+            .await;
+
+        if let Err(client_error) = result {
+            warn!(
+                "Settlement for account {} for {} failed: {}",
+                to.id(),
+                amount,
+                client_error
+            );
+
+            store
+                .refund_settlement(to.id(), amount)
+                .map_err(|e| {
+                    error!(
+                        "Refunding account {} after failed settlement failed, amount: {}: {}",
+                        to.id(),
+                        amount,
+                        e
+                    )
+                })
+                .await?;
+        } else {
+            info!(
+                "Settlement for account {} for {} succeeded",
+                to.id(),
+                amount
+            );
+        }
+    } else {
+        debug!("Settlement for account {} for {} failed as the account has no settlement-engine details",
+            to.id(), amount);
+    }
+
+    Ok(())
+}
+
+/// Captures the behaviour of either operating in a delayed settlement or threshold-only
+/// environment.
+// Tried to go with this as a trait first but perhaps it works better as an enum.
+#[derive(Debug, Clone)]
+enum Policy {
+    ThresholdOnly,
+    TimeBased(tokio::sync::mpsc::UnboundedSender<ManageTimeout>),
+}
+
+impl Policy {
+    /// Called to clear a pending timeout, if there's any
+    fn clear_later(&self, account_id: Uuid) {
+        match *self {
+            Policy::ThresholdOnly => {}
+            Policy::TimeBased(ref sender) => {
+                let _ = sender.send(ManageTimeout::Clear(account_id));
+            } // FIXME: not sure what do with an error, like it's a quite bad situation
+        }
+    }
+
+    /// Called to signal this account id needs to be settled later
+    fn settle_later(&self, account_id: Uuid) {
+        match *self {
+            Policy::ThresholdOnly => {}
+            Policy::TimeBased(ref sender) => {
+                let _ = sender.send(ManageTimeout::Set(account_id));
+            } // FIXME: not sure what do with an error, like it's a quite bad situation
+        }
+    }
+}
+
+/// When configured to operate with time based settlement `ManageTimeout` models the commands sent
+/// over to background task to manage the timeouts.
+pub enum ManageTimeout {
+    Clear(Uuid),
+    Set(Uuid),
+}
+
+#[derive(Debug)]
+enum ExitReason {
+    InputClosed,
+    Shutdown,
+    Capacity,
+    Other(tokio::time::Error),
+}
+
+impl fmt::Display for ExitReason {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        use ExitReason::*;
+        match *self {
+            InputClosed => write!(fmt, "Input was closed and ran out of timed settlements"),
+            Shutdown => write!(fmt, "Tokio is shutting down"),
+            Capacity => write!(fmt, "Timer service is over capacity"),
+            Other(ref e) => write!(fmt, "Other: {}", e),
+        }
+    }
+}
+
+pub fn start_delayed_settlement<St, Store, Acct>(
+    delay: Duration,
+    cmds: St,
+    store: Store,
+) -> tokio::task::JoinHandle<()>
+where
+    St: futures::stream::FusedStream<Item = ManageTimeout> + Send + Sync + 'static + Unpin,
+    Store: BalanceStore
+        + SettlementStore<Account = Acct>
+        + AccountStore<Account = Acct>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    Acct: SettlementAccount + Send + Sync + 'static,
+{
+    let client = SettlementClient::default();
+    tokio::spawn(async move {
+        info!(
+            "Starting to run delayed settlements with timeout of {:?}",
+            delay
+        );
+
+        let exit_reason = run_timeouts_and_settle_on_delay(delay, cmds, store, client).await;
+
+        info!(
+            "Stopped running timeouts and delayed settlements: {}",
+            exit_reason
+        );
+    })
+}
+
+async fn run_timeouts_and_settle_on_delay<St, Store, Acct>(
+    delay: Duration,
+    mut cmds: St,
+    store: Store,
+    client: SettlementClient,
+) -> ExitReason
+where
+    St: futures::stream::FusedStream<Item = ManageTimeout> + Send + Sync + 'static + Unpin,
+    Store: BalanceStore
+        + SettlementStore<Account = Acct>
+        + AccountStore<Account = Acct>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    Acct: SettlementAccount + Send + Sync + 'static,
+{
+    use futures::stream::StreamExt;
+    use std::collections::HashMap;
+    use tokio::time::DelayQueue;
+
+    let mut timeouts = DelayQueue::new();
+    let mut in_queue = HashMap::new();
+
+    loop {
+        tokio::select! {
+            cmd = cmds.select_next_some() => {
+                match cmd {
+                    ManageTimeout::Clear(id) => {
+                        let key = in_queue.remove(&id);
+
+                        if let Some(key) = key {
+                            // this should only be removed when the settle_threshold was achieved
+                            // while processing a fulfill.
+                            timeouts.remove(&key);
+                            trace!("Cleared pending settlement timeout for account: {}", id);
+                        }
+                    }
+                    ManageTimeout::Set(id) => {
+                        let timeouts = &mut timeouts;
+                        in_queue.entry(id).or_insert_with(move || {
+                            let key = timeouts.insert(id, delay);
+
+                            trace!("Setting pending settlement timeout for account: {}", id);
+
+                            key
+                        });
+                    }
+                }
+            },
+            next = timeouts.next(), if !timeouts.is_empty() || cmds.is_terminated() => {
+                match next {
+                    Some(Ok(expired)) => {
+                        let id = expired.into_inner();
+                        in_queue.remove(&id); // unsure if this can ever be none
+
+                        trace!("Delayed settlement for account {} expired", id);
+
+                        let client = client.clone();
+                        let store = store.clone();
+
+                        tokio::spawn(async move {
+                            // TODO: this operation sounds like it ought to be implemented
+                            // elsewhere as well, couldn't find
+                            let to = match store.get_accounts(vec![id]).await {
+                                Ok(mut accounts) if accounts.len() == 1 => {
+                                    Ok(accounts.pop().unwrap())
+                                },
+                                Ok(accounts) => {
+                                    error!(
+                                        "Asked for account {} for delayed settlement got back {} accounts: {:?}",
+                                        id, accounts.len(), accounts
+                                    );
+                                    Err(())
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        "Failed to load account {} for time based settlement: {}",
+                                        id, e
+                                    );
+                                    Err(())
+                                }
+                            }?;
+
+                            let (balance, amount_to_settle) = store.update_balances_for_delayed_settlement(id).await
+                                .map_err(|e| warn!("Time based settlement failed for {}: {}", id, e))?;
+
+                            debug!(
+                                "Account {} balance at time based settlement: {}, Amount that needs to be settled: {}",
+                                to.id(), balance, amount_to_settle
+                            );
+
+                            settle_or_rollback(store, to, amount_to_settle, client).await
+                        });
+                    },
+                    Some(Err(e)) if e.is_shutdown() => {
+                        // we probably cant do much better than to exit here (and to drop the
+                        // stream)
+                        return ExitReason::Shutdown;
+                    },
+                    Some(Err(e)) if e.is_at_capacity() => {
+                        return ExitReason::Capacity;
+                    },
+                    Some(Err(e)) => {
+                        return ExitReason::Other(e);
+                    }
+                    None => {
+                        // no more timeouts currently
+                        assert!(cmds.is_terminated());
+                        // no more timeouts ever
+                        return ExitReason::InputClosed;
+                    }
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -235,7 +574,7 @@ mod tests {
             .build())
         });
         let store = TestStore::new(1);
-        let mut service = BalanceService::new(store.clone(), next);
+        let mut service = BalanceService::new(store.clone(), None, next);
         let fulfill = service.send_request(TEST_REQUEST.clone()).await.unwrap();
         assert_eq!(fulfill.data(), b"test data");
 
@@ -258,7 +597,7 @@ mod tests {
             .build())
         });
         let store = TestStore::new(0);
-        let mut service = BalanceService::new(store.clone(), next);
+        let mut service = BalanceService::new(store.clone(), None, next);
         let fulfill = service.send_request(TEST_REQUEST.clone()).await.unwrap();
         assert_eq!(fulfill.data(), b"test data");
 
@@ -281,7 +620,7 @@ mod tests {
             .build())
         });
         let store = TestStore::new(1);
-        let mut service = BalanceService::new(store.clone(), next);
+        let mut service = BalanceService::new(store.clone(), None, next);
         let fulfill = service.send_request(TEST_REQUEST.clone()).await.unwrap();
         assert_eq!(fulfill.data(), b"test data");
 
@@ -306,7 +645,7 @@ mod tests {
             .build())
         });
         let store = TestStore::new(1);
-        let mut service = BalanceService::new(store.clone(), next);
+        let mut service = BalanceService::new(store.clone(), None, next);
         let reject = service
             .send_request(TEST_REQUEST.clone())
             .await
@@ -419,6 +758,13 @@ mod tests {
         ) -> Result<(), BalanceStoreError> {
             *self.rejected_message.write() = true;
             Ok(())
+        }
+
+        async fn update_balances_for_delayed_settlement(
+            &self,
+            _: Uuid,
+        ) -> Result<(i64, u64), BalanceStoreError> {
+            Ok((0, self.amount_to_settle))
         }
     }
 

--- a/crates/interledger-service-util/src/balance_service.rs
+++ b/crates/interledger-service-util/src/balance_service.rs
@@ -270,6 +270,12 @@ where
         if balance > 0 {
             // so if we have the timeout configured, we should now make sure that there is a
             // timeout pending or new one is created right now.
+            //
+            // FIXME: when multiple nodes share a database and accounts, there is no coordination
+            // between the nodes and there can be multiple settlements when only one is expected.
+            // One way to avoid this would be to record a last_settled_at timestamp, making sure it
+            // is always older than our settlement period, and rescheduling a timeout whenever it
+            // would had been too early to settle.
             policy.settle_later(to.id(), channel_last_fail);
         }
         return Ok(());

--- a/crates/interledger-service-util/src/balance_service.rs
+++ b/crates/interledger-service-util/src/balance_service.rs
@@ -208,6 +208,7 @@ where
 }
 
 // See comments above in the BalanceStore::send_request why this is done in another task.
+#[allow(clippy::too_many_arguments)]
 fn settle_or_rollback_later<Acct, Store>(
     incoming_amount: u64,
     outgoing_amount: u64,
@@ -233,6 +234,7 @@ fn settle_or_rollback_later<Acct, Store>(
     ));
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn settle_or_rollback_now<Acct, Store>(
     incoming_amount: u64,
     outgoing_amount: u64,

--- a/crates/interledger-service-util/src/lib.rs
+++ b/crates/interledger-service-util/src/lib.rs
@@ -19,7 +19,7 @@ mod rate_limit_service;
 /// match the fulfillment inside the incoming fulfills
 mod validator_service;
 
-pub use self::balance_service::{BalanceService, BalanceStore};
+pub use self::balance_service::{start_delayed_settlement, BalanceService, BalanceStore};
 pub use self::echo_service::EchoService;
 pub use self::exchange_rates_service::ExchangeRateService;
 pub use self::expiry_shortener_service::{

--- a/crates/interledger-settlement/src/core/engines_api.rs
+++ b/crates/interledger-settlement/src/core/engines_api.rs
@@ -179,7 +179,7 @@ where
         .and(with_store.clone())
         .and_then(delete_engine_account);
 
-    // POST /accounts/:aVcount_id/settlements (optional idempotency-key header)
+    // POST /accounts/:account_id/settlements (optional idempotency-key header)
     // Body is a Quantity object
     let settlement_endpoint = account_id.and(warp::path("settlements"));
     let settlements = warp::post()

--- a/crates/interledger-store/src/redis/lua/process_settle.lua
+++ b/crates/interledger-store/src/redis/lua/process_settle.lua
@@ -1,0 +1,16 @@
+-- almost the same as process_fulfill.lua which is used to settle when balance is over the settlement threshold:
+-- returns similarly the balance and the amount to settle, but is called with only the account id as the only argument.
+--
+-- upon completion the `balance` is at the level of `settle_to`
+local to_account = 'accounts:' .. ARGV[1]
+
+local balance, prepaid_amount, settle_threshold, settle_to = unpack(redis.call('HMGET', to_account, 'balance', 'prepaid_amount', 'settle_threshold', 'settle_to'))
+local settle_amount = 0
+
+if (settle_threshold and settle_to) and (tonumber(settle_threshold) > tonumber(settle_to)) and tonumber(balance) >= tonumber(settle_to) then
+    settle_amount = tonumber(balance) - tonumber(settle_to)
+    balance = settle_to
+    redis.call('HSET', to_account, 'balance', balance)
+end
+
+return {balance + prepaid_amount, settle_amount}


### PR DESCRIPTION
Currently interledger-rs supports settling peer accounts whenever their balance goes over `settle_threshold`, settling for `balance - settle_to` and thus resetting the `balance` to `settle_to`. This PR adds a time-based method which works in addition to the existing threshold-based settlement. This feature allows driving the balance to `settle_to` later. The feature works with  `settle_threshold`: if the balance goes over the threshold, a settlement is still fired off right away and any existing time-based settlement is cancelled.

The feature works by adding a delay on each prepare for every peering account id which did not already have a delay. The delay duration is set through the `--settle_every` configuration option. When the delay expires, a path similar to threshold settlement is taken to settle the balances, but now the balance's relation to the threshold is ignored.

The hot path of the prepare/fulfill processing in balance service is changed by addition of a non-blocking non-awaiting call to [Sender::try_send](https://docs.rs/tokio/0.2.21/tokio/sync/mpsc/struct.Sender.html#method.try_send), and on failing the send there is protection against flooding the logging by a non-awaited try to lock the mutex to log at most every minute. This guarding is because we don't anticipate running into issues with processing of the queue – the situtation should only arise when the node is badly overloaded, and in that case the logging should try not to make the bad situtation worse.

In balance_service there's additionally minor refactoring to share the `settle_or_rollback` for threshold and time based approaches which involved a few lines moved.

Note: In a cluster configuration where multiple nodes share a single database and database accounts, using this can result in many settlements.