### PR TITLE
Enhanced tracing setup

### DIFF
--- a/crates/ilp-node/Cargo.toml
+++ b/crates/ilp-node/Cargo.toml
@@ -23,6 +23,7 @@ monitoring = [
     "metrics-runtime",
     "tracing-futures",
     "tracing-subscriber",
+    "tracing-appender",
 ]
 
 [[test]]
@@ -65,6 +66,7 @@ yup-oauth2 = { version = "3.1.1", default-features = false, optional = true }
 # Tracing / metrics / prometheus for instrumentation
 tracing-futures = { version = "0.2", default-features = false, features = ["tokio", "futures-03"], optional = true }
 tracing-subscriber = { version = "0.2.0", default-features = false, features = ["tracing-log", "fmt", "env-filter", "chrono"], optional = true }
+tracing-appender = { version = "0.1", optional = true }
 metrics = { version = "0.12.0", default-features = false, features = ["std"], optional = true }
 metrics-core = { version = "0.5.1", default-features = false, optional = true }
 metrics-runtime = { version = "0.13.0", default-features = false, features = ["metrics-observer-prometheus"], optional = true }

--- a/crates/ilp-node/src/main.rs
+++ b/crates/ilp-node/src/main.rs
@@ -2,6 +2,18 @@
 mod instrumentation;
 pub mod node;
 
+use cfg_if::cfg_if;
+
+cfg_if! {
+    if #[cfg(feature = "monitoring")] {
+        use tracing_subscriber::{
+            filter::EnvFilter,
+            fmt::{time::ChronoUtc, Subscriber},
+        };
+        use node::LogWriter;
+    }
+}
+
 #[cfg(feature = "redis")]
 mod redis_store;
 
@@ -138,10 +150,32 @@ async fn main() {
     let matches = app.clone().get_matches();
     merge_args(&mut config, &matches);
 
+    cfg_if! {
+        if #[cfg(feature = "monitoring")] {
+            let mut log_writer = LogWriter::default();
+
+            let (nb_log_writer, _guard) = tracing_appender::non_blocking(log_writer.clone());
+
+            let tracing_builder = Subscriber::builder()
+                .with_timer(ChronoUtc::rfc3339())
+                .with_env_filter(EnvFilter::from_default_env())
+                .with_writer(nb_log_writer)
+                .with_filter_reloading();
+
+            log_writer.handle = Some(tracing_builder.reload_handle());
+
+            let _ = tracing_builder.try_init();
+
+            let log_writer = Some(log_writer);
+        } else {
+            let log_writer = None;
+        }
+    }
+
     let node = config
         .try_into::<InterledgerNode>()
         .expect("Could not parse provided configuration options into an Interledger Node config");
-    node.serve().await.unwrap();
+    node.serve(log_writer.clone()).await.unwrap();
 
     // Add a future which is always pending. This will ensure main does not exist
     // TODO: Is there a better way of doing this?

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -5,14 +5,16 @@ use crate::instrumentation::google_pubsub::{create_google_pubsub_wrapper, Pubsub
 
 cfg_if! {
     if #[cfg(feature = "monitoring")] {
-        use tracing_subscriber::{
-            filter::EnvFilter,
-            fmt::{time::ChronoUtc, Subscriber},
-        };
         use interledger::errors::ApiError;
         use secrecy::{ExposeSecret, SecretString};
-        use tracing_futures::Instrument;
         use tracing::debug_span;
+        use tracing_appender::non_blocking::NonBlocking;
+        use tracing_futures::Instrument;
+        use tracing_subscriber::{
+            filter::EnvFilter,
+            fmt::{format, time::ChronoUtc, Formatter},
+            reload::Handle,
+        };
         use crate::instrumentation::{
             metrics::{incoming_metrics, outgoing_metrics},
             prometheus::{serve_prometheus, PrometheusConfig},
@@ -20,6 +22,7 @@ cfg_if! {
         };
         use interledger::service::IncomingService;
         use futures::FutureExt;
+        use std::{io::{self, Stdout}, sync::Arc};
     }
 }
 
@@ -61,7 +64,12 @@ use interledger::{
 use num_bigint::BigUint;
 use once_cell::sync::Lazy;
 use serde::{de::Error as DeserializeError, Deserialize, Deserializer};
-use std::{convert::TryFrom, net::SocketAddr, str, str::FromStr, time::Duration};
+use std::{
+    convert::TryFrom,
+    net::SocketAddr,
+    str::{self, FromStr},
+    time::Duration,
+};
 use tokio::spawn;
 use tracing::{debug, error, info};
 use url::Url;
@@ -227,10 +235,10 @@ impl InterledgerNode {
     /// also run the Prometheus metrics server on the given address.
     // TODO when a BTP connection is made, insert a outgoing HTTP entry into the Store to tell other
     // connector instances to forward packets for that account to us
-    pub async fn serve(self) -> Result<(), ()> {
+    pub async fn serve(self, log_writer: Option<LogWriter>) -> Result<(), ()> {
         cfg_if! {
             if #[cfg(feature = "monitoring")] {
-                let f = futures::future::join(serve_prometheus(self.clone()), self.serve_node()).then(
+                let f = futures::future::join(serve_prometheus(self.clone()), self.serve_node(log_writer)).then(
                     |r| async move {
                         if r.0.is_ok() || r.1.is_ok() {
                             Ok(())
@@ -240,14 +248,14 @@ impl InterledgerNode {
                     },
                 );
             } else {
-                let f = self.serve_node();
+                let f = self.serve_node(log_writer);
             }
         }
 
         f.await
     }
 
-    async fn serve_node(self) -> Result<(), ()> {
+    async fn serve_node(self, log_writer: Option<LogWriter>) -> Result<(), ()> {
         let ilp_address = if let Some(address) = &self.ilp_address {
             address.clone()
         } else {
@@ -268,7 +276,7 @@ impl InterledgerNode {
 
         match database_url.scheme() {
             #[cfg(feature = "redis")]
-            "redis" | "redis+unix" => serve_redis_node(self, ilp_address).await,
+            "redis" | "redis+unix" => serve_redis_node(self, ilp_address, log_writer).await,
             other => {
                 error!("unsupported data source scheme: {}", other);
                 Err(())
@@ -277,7 +285,12 @@ impl InterledgerNode {
     }
 
     #[allow(clippy::cognitive_complexity)]
-    pub(crate) async fn chain_services<S>(self, store: S, ilp_address: Address) -> Result<(), ()>
+    pub(crate) async fn chain_services<S>(
+        self,
+        store: S,
+        ilp_address: Address,
+        _log_writer: Option<LogWriter>,
+    ) -> Result<(), ()>
     where
         S: NodeStore<Account = Account>
             + AddressStore
@@ -509,50 +522,58 @@ impl InterledgerNode {
         // changing the tracing level by administrators
         cfg_if! {
             if #[cfg(feature = "monitoring")] {
-                let builder = Subscriber::builder()
-                    .with_timer(ChronoUtc::rfc3339())
-                    .with_env_filter(EnvFilter::from_default_env())
-                    .with_filter_reloading();
-                let handle = builder.reload_handle();
-                builder.try_init().unwrap_or(());
+                let admin_only = warp::header::<SecretString>("authorization")
+                    .and_then(move |authorization: SecretString| {
+                        let admin_auth_header = format!("Bearer {}", self.admin_auth_token.clone());
+                        async move {
+                            if authorization.expose_secret() == &admin_auth_header {
+                                Ok::<(), warp::Rejection>(())
+                            } else {
+                                Err(warp::Rejection::from(ApiError::unauthorized()))
+                            }
+                        }
+                    })
+                    .untuple_one()
+                    .boxed();
 
-                let admin_auth_token = self.admin_auth_token.clone();
                 let api = {
+                    let tracing_handle = _log_writer.and_then(|al| al.handle);
+
                     let adjust_tracing = warp::put()
                         .and(warp::path("tracing-level"))
                         .and(warp::path::end())
-                        .and(warp::header::<SecretString>("authorization"))
+                        .and(admin_only)
                         .and(warp::body::bytes())
                         .and_then(
-                            move |auth_header: SecretString, new_level: bytes05::Bytes| {
-                                let handle = handle.clone();
-                                let admin_auth_header = format!("Bearer {}", admin_auth_token);
+                            move |new_level_input: bytes05::Bytes| {
+                                let handle = tracing_handle.clone().unwrap();
                                 async move {
-                                    if auth_header.expose_secret().as_str() != admin_auth_header {
-                                        return Err(ApiError::unauthorized()
-                                            .detail("invalid admin auth token")
-                                            .into());
-                                    }
-                                    let new_level = std::str::from_utf8(new_level.as_ref()).map_err(|_| {
+                                    let new_level_str = std::str::from_utf8(new_level_input.as_ref()).map_err(|_| {
                                         ApiError::bad_request().detail("invalid utf-8 body provided")
                                     })?;
-                                    let new_tracing_level = new_level
-                                        .parse::<tracing_subscriber::filter::EnvFilter>()
+
+                                    let new_level = new_level_str
+                                        .parse::<tracing_subscriber::filter::Directive>()
                                         .map_err(|_| {
                                             ApiError::bad_request().detail("could not parse body as log level")
                                         })?;
-                                    handle.reload(new_tracing_level).map_err(|err| {
+
+                                    let curr_env = handle.with_current(|env| env.to_string()).unwrap();
+                                    let new_env = curr_env.parse::<EnvFilter>().unwrap().add_directive(new_level);
+
+                                    handle.reload(new_env).map_err(|err| {
                                         ApiError::internal_server_error()
-                                            .detail(format!("could not apply new log level {}", err))
+                                            .detail(format!("could not apply new log level: {}", err))
                                     })?;
-                                    debug!(target: "interledger-node", "Logging level adjusted to {}", new_level);
+                                    debug!(target: "interledger-node", "Logging level adjusted to {}", new_level_str);
                                     Ok::<String, warp::Rejection>(format!(
                                         "Logging level changed to: {}",
-                                        new_level
+                                        new_level_str
                                     ))
                                 }
                             },
                         );
+
                     api.or(adjust_tracing)
                 };
             }
@@ -585,5 +606,40 @@ impl InterledgerNode {
         }
 
         Ok(())
+    }
+}
+
+cfg_if! {
+    if #[cfg(feature = "monitoring")] {
+        type TracingSubscriber =
+            Formatter<format::DefaultFields, format::Format<format::Full, ChronoUtc>, NonBlocking>;
+
+        #[derive(Clone)]
+        pub struct LogWriter {
+            stdout:     Arc<Stdout>,
+            pub handle: Option<Handle<EnvFilter, TracingSubscriber>>,
+        }
+
+        impl Default for LogWriter {
+            fn default() -> Self {
+                LogWriter {
+                    stdout: Arc::new(io::stdout()),
+                    handle: None,
+                }
+            }
+        }
+
+        impl std::io::Write for LogWriter {
+            fn flush(&mut self) -> std::io::Result<()> {
+                self.stdout.lock().flush()
+            }
+
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.stdout.lock().write(buf)
+            }
+        }
+    } else {
+        #[derive(Clone)]
+        pub struct LogWriter;
     }
 }

--- a/crates/ilp-node/tests/redis/btp.rs
+++ b/crates/ilp-node/tests/redis/btp.rs
@@ -79,7 +79,7 @@ async fn two_nodes_btp() {
     }))
     .expect("Error creating node_b.");
 
-    node_b.serve().await.unwrap();
+    node_b.serve(None).await.unwrap();
     create_account_on_node(node_b_http, a_on_b, "admin")
         .await
         .unwrap();
@@ -87,7 +87,7 @@ async fn two_nodes_btp() {
         .await
         .unwrap();
 
-    node_a.serve().await.unwrap();
+    node_a.serve(None).await.unwrap();
     create_account_on_node(node_a_http, alice_on_a, "admin")
         .await
         .unwrap();

--- a/crates/ilp-node/tests/redis/exchange_rates.rs
+++ b/crates/ilp-node/tests/redis/exchange_rates.rs
@@ -29,7 +29,7 @@ async fn coincap() {
         },
     }))
     .unwrap();
-    node.serve().await.unwrap();
+    node.serve(None).await.unwrap();
 
     // Wait a few seconds so our node can poll the API
     tokio::time::delay_for(Duration::from_millis(1000)).await;
@@ -85,7 +85,7 @@ async fn cryptocompare() {
         },
     }))
     .unwrap();
-    node.serve().await.unwrap();
+    node.serve(None).await.unwrap();
 
     // Wait a few seconds so our node can poll the API
     tokio::time::delay_for(Duration::from_millis(1000)).await;

--- a/crates/ilp-node/tests/redis/prometheus.rs
+++ b/crates/ilp-node/tests/redis/prometheus.rs
@@ -89,8 +89,8 @@ async fn prometheus() {
     }))
     .unwrap();
 
-    node_a.serve().await.unwrap();
-    node_b.serve().await.unwrap();
+    node_a.serve(None).await.unwrap();
+    node_b.serve(None).await.unwrap();
 
     create_account_on_node(node_b_http, a_on_b, "admin")
         .await

--- a/crates/ilp-node/tests/redis/three_nodes.rs
+++ b/crates/ilp-node/tests/redis/three_nodes.rs
@@ -125,7 +125,7 @@ async fn three_nodes() {
     }))
     .expect("Error creating node3.");
 
-    node1.serve().await.unwrap();
+    node1.serve(None).await.unwrap();
     create_account_on_node(node1_http, alice_on_alice, "admin")
         .await
         .unwrap();
@@ -141,7 +141,7 @@ async fn three_nodes() {
         .await
         .unwrap();
 
-    node2.serve().await.unwrap();
+    node2.serve(None).await.unwrap();
     create_account_on_node(node2_http, alice_on_bob, "admin")
         .await
         .unwrap();
@@ -156,7 +156,7 @@ async fn three_nodes() {
         .await
         .unwrap();
 
-    node3.serve().await.unwrap();
+    node3.serve(None).await.unwrap();
     create_account_on_node(node3_http, charlie_on_charlie, "admin")
         .await
         .unwrap();


### PR DESCRIPTION
This solution improves the current logging/tracing setup by setting it up earlier, fixing the runtime log level control (it no longer resets the non-default settings) and allowing for multiple log subscribers (currently just `stdout`).

This change can be later extended with additional log subscribers including channels, websockets, log files etc.