### PR TITLE
fix: adjust code for 1.44 clippies

### DIFF
--- a/crates/interledger-router/src/router.rs
+++ b/crates/interledger-router/src/router.rs
@@ -73,7 +73,7 @@ where
                 if (prefix.is_empty() || dest.starts_with(prefix.as_str()))
                     && prefix.len() >= matching_prefix.len()
                 {
-                    next_hop.replace(account.clone());
+                    next_hop.replace(*account);
                     matching_prefix = prefix.as_str();
                 }
             }

--- a/crates/interledger-settlement/src/core/settlement_client.rs
+++ b/crates/interledger-settlement/src/core/settlement_client.rs
@@ -35,7 +35,7 @@ impl SettlementClient {
     /// This is done by sending a POST to /accounts with the provided `id` as the request's body
     pub async fn create_engine_account(&self, id: Uuid, engine_url: Url) -> Response {
         FutureRetry::new(
-            move || self.create_engine_account_once(id.clone(), engine_url.clone()),
+            move || self.create_engine_account_once(id, engine_url.clone()),
             RequestErrorHandler::new(self.max_retries),
         )
         .await
@@ -46,7 +46,7 @@ impl SettlementClient {
     /// as the request's body
     pub async fn send_message(&self, id: Uuid, engine_url: Url, message: Vec<u8>) -> Response {
         FutureRetry::new(
-            move || self.send_message_once(id.clone(), engine_url.clone(), message.clone()),
+            move || self.send_message_once(id, engine_url.clone(), message.clone()),
             RequestErrorHandler::new(self.max_retries),
         )
         .await


### PR DESCRIPTION
It seems that CI pulls the most recent stable; fix the new clippies it introduces.

Unblocks #647, #649 and any other PR really :stuck_out_tongue:.