### PR TITLE
add Apache license badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ![rustc](https://img.shields.io/badge/rustc-1.39+-red.svg)
 ![Rust](https://img.shields.io/badge/rust-stable-Success)
 [![Docker Image](https://img.shields.io/docker/pulls/interledgerrs/ilp-node.svg?maxAge=2592000)](https://hub.docker.com/r/interledgerrs/ilp-node/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## Requirements
 


### PR DESCRIPTION
Add Apache 2.0 License badge in README.MD. #158 

