### PR TITLE
Bump futures version to please the audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,9 +576,9 @@ checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
 name = "futures"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+checksum = "95314d38584ffbfda215621d723e0a3906f032e03ae5551e650058dac83d4797"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -591,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
+checksum = "0448174b01148032eed37ac4aed28963aaaa8cfa93569a08e5b479bbc6c2c151"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+checksum = "18eaa56102984bed2c88ea39026cff3ce3b4c7f508ca970cedf2450ea10d4e46"
 
 [[package]]
 name = "futures-cpupool"
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "futures-executor"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
+checksum = "f5f8e0c9258abaea85e78ebdda17ef9666d390e987f006be6080dfe354b708cb"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -628,15 +628,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
+checksum = "6e1798854a4727ff944a7b12aa999f58ce7aa81db80d2dfaaf2ba06f065ddd2b"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
+checksum = "e36fccf3fc58563b4a14d265027c627c3b665d7fed489427e88e7cc929559efe"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -650,31 +650,31 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc9a95ec273db7b9d07559e25f9cd75074fee2f437f1e502b0c3b610d129d554"
 dependencies = [
- "futures 0.3.5",
- "pin-project",
+ "futures 0.3.7",
+ "pin-project 0.4.24",
  "tokio 0.2.22",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
+checksum = "0e3ca3f17d6e8804ae5d3df7a7d35b2b3a6fe89dac84b31872720fc3060a0b11"
 
 [[package]]
 name = "futures-task"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+checksum = "96d502af37186c4fef99453df03e374683f8a1eec9dcc1e66b3b82dc8278ce3c"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
+checksum = "abcb44342f62e6f3e8ac427b8aa815f724fd705dfad060b18ac7866c15bb8e34"
 dependencies = [
  "futures 0.1.29",
  "futures-channel",
@@ -684,7 +684,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project",
+ "pin-project 1.0.1",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -922,7 +922,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
+ "pin-project 0.4.24",
  "socket2",
  "tokio 0.2.22",
  "tower-service",
@@ -1008,7 +1008,7 @@ dependencies = [
  "chrono",
  "clap",
  "config",
- "futures 0.3.5",
+ "futures 0.3.7",
  "hex",
  "interledger",
  "libc",
@@ -1099,7 +1099,7 @@ version = "1.0.0"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures-retry",
  "http 0.2.1",
  "interledger-btp",
@@ -1135,7 +1135,7 @@ dependencies = [
  "byteorder",
  "bytes 0.4.12",
  "chrono",
- "futures 0.3.5",
+ "futures 0.3.7",
  "hex",
  "interledger-errors",
  "interledger-packet",
@@ -1143,7 +1143,7 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "parking_lot 0.10.2",
- "pin-project",
+ "pin-project 0.4.24",
  "rand 0.7.3",
  "secrecy",
  "socket2",
@@ -1165,7 +1165,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "bytes 0.4.12",
- "futures 0.3.5",
+ "futures 0.3.7",
  "hex",
  "interledger-errors",
  "interledger-packet",
@@ -1203,7 +1203,7 @@ version = "1.0.0"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
- "futures 0.3.5",
+ "futures 0.3.7",
  "http 0.2.1",
  "interledger-errors",
  "interledger-packet",
@@ -1229,7 +1229,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "bytes 0.4.12",
- "futures 0.3.5",
+ "futures 0.3.7",
  "interledger-packet",
  "interledger-service",
  "once_cell",
@@ -1260,7 +1260,7 @@ name = "interledger-rates"
 version = "1.0.0"
 dependencies = [
  "async-trait",
- "futures 0.3.5",
+ "futures 0.3.7",
  "interledger-errors",
  "once_cell",
  "reqwest",
@@ -1290,7 +1290,7 @@ name = "interledger-service"
 version = "1.0.0"
 dependencies = [
  "async-trait",
- "futures 0.3.5",
+ "futures 0.3.7",
  "interledger-errors",
  "interledger-packet",
  "once_cell",
@@ -1312,7 +1312,7 @@ dependencies = [
  "bytes 0.4.12",
  "bytes 0.5.6",
  "chrono",
- "futures 0.3.5",
+ "futures 0.3.7",
  "hex",
  "interledger-errors",
  "interledger-packet",
@@ -1339,7 +1339,7 @@ dependencies = [
  "async-trait",
  "bytes 0.5.6",
  "env_logger",
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures-retry",
  "http 0.2.1",
  "hyper 0.13.8",
@@ -1373,7 +1373,7 @@ dependencies = [
  "base64 0.11.0",
  "bytes 0.4.12",
  "bytes 0.5.6",
- "futures 0.3.5",
+ "futures 0.3.7",
  "hyper 0.13.8",
  "interledger-packet",
  "interledger-rates",
@@ -1394,7 +1394,7 @@ dependencies = [
  "async-trait",
  "bytes 0.5.6",
  "env_logger",
- "futures 0.3.5",
+ "futures 0.3.7",
  "http 0.2.1",
  "interledger-api",
  "interledger-btp",
@@ -1437,7 +1437,7 @@ dependencies = [
  "bytes 0.4.12",
  "chrono",
  "csv",
- "futures 0.3.5",
+ "futures 0.3.7",
  "hex",
  "interledger-errors",
  "interledger-packet",
@@ -1448,7 +1448,7 @@ dependencies = [
  "num",
  "once_cell",
  "parking_lot 0.10.2",
- "pin-project",
+ "pin-project 0.4.24",
  "ring",
  "serde",
  "thiserror",
@@ -1999,7 +1999,16 @@ version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f48fad7cfbff853437be7cf54d7b993af21f53be7f0988cbfe4a51535aa77205"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 0.4.24",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
+dependencies = [
+ "pin-project-internal 1.0.1",
 ]
 
 [[package]]
@@ -2007,6 +2016,17 @@ name = "pin-project-internal"
 version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24c6d293bdd3ca5a1697997854c6cf7855e43fb6a0ba1c47af57a5bcafd158ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2633,7 +2653,7 @@ checksum = "15c2f5be039aed0d08b3596461637480d35858ca4360c905b0e802b934fa8e48"
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project",
+ "pin-project 0.4.24",
  "tokio 0.2.22",
 ]
 
@@ -2648,9 +2668,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.42"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
+checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2969,10 +2989,10 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8b8fe88007ebc363512449868d7da4389c9400072a3f666f212c7280082882a"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
  "log 0.4.11",
  "native-tls",
- "pin-project",
+ "pin-project 0.4.24",
  "tokio 0.2.22",
  "tokio-tls",
  "tungstenite 0.10.1",
@@ -2986,7 +3006,7 @@ checksum = "6d9e878ad426ca286e4dcae09cbd4e1973a7f8987d97570e2469703dd7f5720c"
 dependencies = [
  "futures-util",
  "log 0.4.11",
- "pin-project",
+ "pin-project 0.4.24",
  "tokio 0.2.22",
  "tungstenite 0.11.1",
 ]
@@ -3105,9 +3125,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
 dependencies = [
- "futures 0.3.5",
+ "futures 0.3.7",
  "futures-task",
- "pin-project",
+ "pin-project 0.4.24",
  "tokio 0.1.22",
  "tracing",
 ]
@@ -3346,14 +3366,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f41be6df54c97904af01aa23e613d4521eed7ab23537cede692d4058f6449407"
 dependencies = [
  "bytes 0.5.6",
- "futures 0.3.5",
+ "futures 0.3.7",
  "headers",
  "http 0.2.1",
  "hyper 0.13.8",
  "log 0.4.11",
  "mime",
  "mime_guess",
- "pin-project",
+ "pin-project 0.4.24",
  "scoped-tls",
  "serde",
  "serde_json",

--- a/crates/ilp-node/Cargo.toml
+++ b/crates/ilp-node/Cargo.toml
@@ -40,7 +40,7 @@ bytes05 = { package = "bytes", version = "0.5", default-features = false }
 cfg-if = { version = "0.1.10", default-features = false }
 clap = { version = "2.33.0", default-features = false }
 config = { version = "0.10.1", default-features = false, features = ["json", "toml", "yaml"] }
-futures = { version = "0.3.1", default-features = false, features = ["compat"] }
+futures = { version = "0.3.7", default-features = false, features = ["compat"] }
 hex = { version = "0.4.0", default-features = false }
 once_cell = { version = "1.3.1", default-features = false }
 num-bigint = { version = "0.2.3", default-features = false, features = ["std"] }

--- a/crates/interledger-api/Cargo.toml
+++ b/crates/interledger-api/Cargo.toml
@@ -23,7 +23,7 @@ interledger-btp = { path = "../interledger-btp", version = "1.0.0", default-feat
 interledger-errors = { path = "../interledger-errors", version = "1.0.0", default-features = false, features = ["warp_errors"] }
 
 bytes = { version = "0.5", default-features = false }
-futures = { version = "0.3.1", default-features = false }
+futures = { version = "0.3.7", default-features = false }
 futures-retry = { version = "0.4", default-features = false }
 http = { version = "0.2", default-features = false }
 tracing = { version = "0.1.12", default-features = false, features = ["log"] }

--- a/crates/interledger-btp/Cargo.toml
+++ b/crates/interledger-btp/Cargo.toml
@@ -15,7 +15,7 @@ interledger-service = { path = "../interledger-service", version = "1.0.0", defa
 bytes = { version = "0.4.12", default-features = false }
 byteorder = { version = "1.3.2", default-features = false }
 chrono = { version = "0.4.9", default-features = false }
-futures = { version = "0.3.1", default-features = false }
+futures = { version = "0.3.7", default-features = false }
 tracing = { version = "0.1.12", default-features = false, features = ["log"] }
 num-bigint = { version = "0.2.3", default-features = false, features = ["std"] }
 parking_lot = { version = "0.10.0", default-features = false }

--- a/crates/interledger-ccp/Cargo.toml
+++ b/crates/interledger-ccp/Cargo.toml
@@ -14,7 +14,7 @@ interledger-service = { path = "../interledger-service", version = "1.0.0", defa
 
 bytes = { version = "0.4.12", default-features = false }
 byteorder = { version = "1.3.2", default-features = false }
-futures = { version = "0.3", default-features = false }
+futures = { version = "0.3.7", default-features = false }
 hex = { version = "0.4.0", default-features = false }
 once_cell = { version = "1.3.1", default-features = false }
 tracing = { version = "0.1.12", default-features = false, features = ["log"] }

--- a/crates/interledger-http/Cargo.toml
+++ b/crates/interledger-http/Cargo.toml
@@ -13,7 +13,7 @@ interledger-packet = { path = "../interledger-packet", version = "1.0.0", defaul
 interledger-service = { path = "../interledger-service", version = "1.0.0", default-features = false }
 
 bytes = { version = "0.5", default-features = false }
-futures = { version = "0.3", default-features = false }
+futures = { version = "0.3.7", default-features = false }
 tracing = { version = "0.1.12", default-features = false, features = ["log"] }
 reqwest = { version = "0.10.0", default-features = false, features = ["default-tls"] }
 url = { version = "2.1.1", default-features = false }

--- a/crates/interledger-ildcp/Cargo.toml
+++ b/crates/interledger-ildcp/Cargo.toml
@@ -13,7 +13,7 @@ interledger-service = { path = "../interledger-service", version = "1.0.0", defa
 
 bytes = { version = "0.4.12", default-features = false }
 byteorder = { version = "1.3.2", default-features = false }
-futures = { version = "0.3", default-features = false }
+futures = { version = "0.3.7", default-features = false }
 once_cell = { version = "1.3.1", default-features = false }
 tracing = { version = "0.1.12", default-features = false, features = ["log"] }
 async-trait = { version = "0.1.22", default-features = false }

--- a/crates/interledger-rates/Cargo.toml
+++ b/crates/interledger-rates/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 interledger-errors = { path = "../interledger-errors", version = "1.0.0" }
 
 async-trait = "0.1.22"
-futures = { version = "0.3.1", default-features = false }
+futures = { version = "0.3.7", default-features = false }
 tracing = { version = "0.1.12", default-features = false, features = ["log"] }
 once_cell = { version = "1.3.1", default-features = false }
 reqwest = { version = "0.10.0", default-features = false, features = ["default-tls", "json"] }

--- a/crates/interledger-service-util/Cargo.toml
+++ b/crates/interledger-service-util/Cargo.toml
@@ -17,7 +17,7 @@ interledger-settlement = { path = "../interledger-settlement", version = "1.0.0"
 bytes = { version = "0.5", default-features = false }
 byteorder = { version = "1.3.2", default-features = false }
 chrono = { version = "0.4.9", default-features = false, features = ["clock"] }
-futures = { version = "0.3.1", default-features = false }
+futures = { version = "0.3.7", default-features = false }
 hex = { version = "0.4.0", default-features = false }
 once_cell = { version = "1.3.1", default-features = false, features = ["std"] }
 tracing = { version = "0.1.12", default-features = false, features = ["log"] }

--- a/crates/interledger-service/Cargo.toml
+++ b/crates/interledger-service/Cargo.toml
@@ -15,7 +15,7 @@ trace = ["tracing-futures"]
 interledger-errors = { path = "../interledger-errors", version = "1.0.0", default-features = false }
 interledger-packet = { path = "../interledger-packet", version = "1.0.0", default-features = false }
 
-futures = { version = "0.3.1", default-features = false }
+futures = { version = "0.3.7", default-features = false }
 serde = { version = "1.0.101", default-features = false, features = ["derive"] }
 regex = { version = "1.3.1", default-features = false, features = ["std", "unicode-perl"] }
 once_cell = { version = "1.3.1", default-features = false, features = ["std"] }

--- a/crates/interledger-settlement/Cargo.toml
+++ b/crates/interledger-settlement/Cargo.toml
@@ -14,7 +14,7 @@ interledger-packet = { path = "../interledger-packet", version = "1.0.0", defaul
 interledger-service = { path = "../interledger-service", version = "1.0.0", default-features = false }
 
 bytes = { version = "0.5", default-features = false }
-futures = { version = "0.3.1", default-features = false }
+futures = { version = "0.3.7", default-features = false }
 hyper = { version = "0.13.1", default-features = false }
 tracing = { version = "0.1.12", default-features = false, features = ["log"] }
 reqwest = { version = "0.10", default-features = false, features = ["default-tls", "json"] }

--- a/crates/interledger-spsp/Cargo.toml
+++ b/crates/interledger-spsp/Cargo.toml
@@ -16,7 +16,7 @@ interledger-stream = { path = "../interledger-stream", version = "1.0.0", defaul
 base64 = { version = "0.11.0", default-features = false }
 bytes = { version = "0.5", default-features = false }
 bytes04 = { package = "bytes", version = "0.4.12", default-features = false }
-futures = { version = "0.3.1", default-features = false }
+futures = { version = "0.3.7", default-features = false }
 hyper = { version = "0.13.1", default-features = false }
 tracing = { version = "0.1.12", default-features = false, features = ["log"] }
 reqwest = { version = "0.10", default-features = false, features = ["default-tls", "json"] }

--- a/crates/interledger-store/Cargo.toml
+++ b/crates/interledger-store/Cargo.toml
@@ -35,7 +35,7 @@ interledger-stream = { path = "../interledger-stream", version = "1.0.0", defaul
 interledger-errors = { path = "../interledger-errors", version = "1.0.0", default-features = false, features = ["redis_errors"] }
 
 bytes = { version = "0.5", default-features = false }
-futures = { version = "0.3", default-features = false }
+futures = { version = "0.3.7", default-features = false }
 once_cell = { version = "1.3.1", default-features = false }
 tracing = { version = "0.1.12", default-features = false, features = ["log"] }
 parking_lot = { version = "0.10.0", default-features = false }

--- a/crates/interledger-stream/Cargo.toml
+++ b/crates/interledger-stream/Cargo.toml
@@ -20,7 +20,7 @@ base64 = { version = "0.11.0", default-features = false }
 bytes = { version = "0.4.12", default-features = false }
 byteorder = { version = "1.3.2", default-features = false }
 chrono = { version = "0.4.9", default-features = false, features = ["clock"] }
-futures = { version = "0.3.1", default-features = false, features = ["std"] }
+futures = { version = "0.3.7", default-features = false, features = ["std"] }
 hex = { version = "0.4.0", default-features = false }
 tracing = { version = "0.1.12", default-features = false, features = ["log"] }
 num = { version = "0.2.1" }


### PR DESCRIPTION
CircleCI audit check fails: `cargo audit --ignore RUSTSEC-2019-0031 --ignore RUSTSEC-2020-0041 --ignore RUSTSEC-2020-0016`.
Fix is to bump `futures` version to `0.3.7`