### PR TITLE
Fix interledger-stream build and test in isolation

### DIFF
--- a/crates/interledger-stream/Cargo.toml
+++ b/crates/interledger-stream/Cargo.toml
@@ -16,7 +16,7 @@ interledger-packet = { path = "../interledger-packet", version = "1.0.0", defaul
 interledger-rates = { path = "../interledger-rates", version = "1.0.0", default-features = false }
 interledger-service = { path = "../interledger-service", version = "1.0.0", default-features = false }
 
-base64 = { version = "0.11.0", default-features = false }
+base64 = { version = "0.11.0", default-features = false, features = ["std"] }
 bytes = { version = "0.4.12", default-features = false }
 byteorder = { version = "1.3.2", default-features = false }
 chrono = { version = "0.4.9", default-features = false, features = ["clock"] }


### PR DESCRIPTION
Cargo.toml in the `interledger-stream` package was missing the feature `"std"` for `base64`. This caused it to report an error when building or testing the package in isolation. This pull request introduces the minor fix to the problem.