### PR TITLE
Add fields to WebSocket notifications

### DIFF
--- a/crates/ilp-node/tests/redis/payments_incoming.rs
+++ b/crates/ilp-node/tests/redis/payments_incoming.rs
@@ -5,14 +5,9 @@ use serde::Deserialize;
 use serde_json::{self, json};
 use tungstenite::{client, handshake::client::Request};
 
-use std::{
-    sync::{Arc, Mutex},
-    thread,
-    time::Duration,
-};
-
 #[tokio::test]
 async fn payments_incoming() {
+    use tokio::stream::StreamExt;
     let context = TestContext::new();
 
     let mut connection_info1 = context.get_client_connection_info();
@@ -137,13 +132,8 @@ async fn payments_incoming() {
     }
 
     // create a cross-thread collection of payment notifications
-    let pmt_notifications = Arc::new(Mutex::new(
-        Vec::<(PmtNotification, PmtNotification)>::with_capacity(3),
-    ));
-
-    // spawn a thread that listens in on node-wide payment notifications for node b
-    let notifications = pmt_notifications.clone();
-    std::thread::spawn(move || {
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let handle = std::thread::spawn(move || {
         let ws_request = Request::builder()
             .uri(format!("ws://localhost:{}/payments/incoming", node_b_http))
             .header("Authorization", "Bearer admin")
@@ -160,7 +150,9 @@ async fn payments_incoming() {
             let msg = payments_ws.read_message().unwrap();
             let close: PmtNotificationWrapper =
                 serde_json::from_str(&msg.into_text().unwrap()).unwrap();
-            notifications.lock().unwrap().push((payment.Ok, close.Ok));
+            tx.send((payment.Ok, close.Ok))
+                .map_err(|_| ())
+                .expect("send failed");
         }
 
         payments_ws.close(None).unwrap();
@@ -202,11 +194,22 @@ async fn payments_incoming() {
     .await
     .unwrap();
 
-    // a small delay to make sure the notifications are intercepted in the other thread
-    thread::sleep(Duration::from_secs(1));
+    // FIXME: this should be doable with rx.collect::<????>().await.unwrap()
+    let mut messages = vec![];
+    loop {
+        let next = rx.next().await;
+        if let Some(next) = next {
+            messages.push(next);
+        } else {
+            break;
+        }
+    }
+
+    handle
+        .join()
+        .expect("as the messages stopped the thread should have exited as well");
 
     // check if all the payment notifications were received as expected
-    let messages = pmt_notifications.lock().unwrap();
     assert_eq!(messages.len(), 3);
 
     assert_eq!(messages[0].0.to_username, "bob_on_b");

--- a/crates/interledger-stream/src/server.rs
+++ b/crates/interledger-stream/src/server.rs
@@ -309,6 +309,9 @@ fn receive_money(
             }));
         }
 
+        // The last packet contains the ConnectionClose frame;
+        // if this is the case, return this information to the caller
+        // to be included in the payment notification
         if let Frame::ConnectionClose(_) = frame {
             connection_closed = true;
         }

--- a/crates/interledger-stream/src/server.rs
+++ b/crates/interledger-stream/src/server.rs
@@ -96,6 +96,26 @@ pub struct PaymentNotification {
     pub amount: u64,
     /// The time this payment notification was fired in RFC3339 format
     pub timestamp: String,
+    /// The sequence number of the packet
+    pub sequence: u64,
+    /// Whether or not a packet signifying closing the connection was received.
+    /// In that case, the PaymentNotification will have `amount: 0`
+    /// and `connection_closed: true`.
+    pub connection_closed: bool,
+}
+
+/// The Ok(ReceiveOk) variant of receive_money(...) return result
+struct ReceiveOk {
+    fulfill: Fulfill,
+    sequence: u64,
+}
+
+#[derive(Debug)]
+/// The Err(ReceiveErr) variant of receive_money(...) return result
+struct ReceiveErr {
+    reject: Reject,
+    sequence: u64,
+    connection_closed: bool,
 }
 
 /// A trait representing the Publish side of a pub/sub store
@@ -177,7 +197,7 @@ where
                 &request.prepare,
             );
             match response {
-                Ok(ref _fulfill) => self
+                Ok(ref ok) => self
                     .store
                     .publish_payment_notification(PaymentNotification {
                         to_username,
@@ -185,9 +205,23 @@ where
                         amount,
                         destination,
                         timestamp: DateTime::<Utc>::from(SystemTime::now()).to_rfc3339(),
+                        sequence: ok.sequence,
+                        connection_closed: false,
                     }),
-                Err(ref reject) => {
-                    if reject.code() == ErrorCode::F06_UNEXPECTED_PAYMENT {
+                Err(ref err) => {
+                    if err.connection_closed {
+                        self.store
+                            .publish_payment_notification(PaymentNotification {
+                                to_username,
+                                from_username,
+                                amount: 0,
+                                destination,
+                                timestamp: DateTime::<Utc>::from(SystemTime::now()).to_rfc3339(),
+                                sequence: err.sequence,
+                                connection_closed: true,
+                            });
+                    }
+                    if err.reject.code() == ErrorCode::F06_UNEXPECTED_PAYMENT {
                         // Assume the packet isn't for us if the decryption step fails.
                         // Note this means that if the packet data is modified in any way,
                         // the sender will likely see an error like F02: Unavailable (this is
@@ -197,7 +231,7 @@ where
                     }
                 }
             };
-            return response;
+            return response.map(|x| x.fulfill).map_err(|x| x.reject);
         }
         self.next.send_request(request).await
     }
@@ -213,7 +247,7 @@ fn receive_money(
     asset_code: &str,
     asset_scale: u8,
     prepare: &Prepare,
-) -> Result<Fulfill, Reject> {
+) -> Result<ReceiveOk, ReceiveErr> {
     // Generate fulfillment
     let fulfillment = generate_fulfillment(&shared_secret[..], prepare.data());
     let condition = hash_sha256(&fulfillment);
@@ -235,16 +269,21 @@ fn receive_money(
 
     let stream_packet = StreamPacket::from_encrypted(shared_secret, copied_data).map_err(|_| {
         debug!("Unable to parse data, rejecting Prepare packet");
-        RejectBuilder {
-            code: ErrorCode::F06_UNEXPECTED_PAYMENT,
-            message: b"Could not decrypt data",
-            triggered_by: Some(ilp_address),
-            data: &[],
+        ReceiveErr {
+            reject: RejectBuilder {
+                code: ErrorCode::F06_UNEXPECTED_PAYMENT,
+                message: b"Could not decrypt data",
+                triggered_by: Some(ilp_address),
+                data: &[],
+            }
+            .build(),
+            sequence: 0,
+            connection_closed: false,
         }
-        .build()
     })?;
 
     let mut response_frames: Vec<Frame> = Vec::new();
+    let mut connection_closed = false;
 
     // Handle STREAM frames
     // TODO reject if they send data?
@@ -269,6 +308,10 @@ fn receive_money(
                 source_asset_scale: asset_scale,
             }));
         }
+
+        if let Frame::ConnectionClose(_) = frame {
+            connection_closed = true;
+        }
     }
 
     // Return Fulfill or Reject Packet
@@ -292,7 +335,10 @@ fn receive_money(
             data: &encrypted_response[..],
         }
         .build();
-        Ok(fulfill)
+        Ok(ReceiveOk {
+            fulfill,
+            sequence: stream_packet.sequence(),
+        })
     } else {
         let response_packet = StreamPacketBuilder {
             sequence: stream_packet.sequence(),
@@ -322,7 +368,11 @@ fn receive_money(
             data: &encrypted_response[..],
         }
         .build();
-        Err(reject)
+        Err(ReceiveErr {
+            reject,
+            sequence: stream_packet.sequence(),
+            connection_closed,
+        })
     }
 }
 
@@ -501,7 +551,8 @@ mod receiving_money {
             "did not regenerate the same shared secret",
         );
         let fulfill = receive_money(&shared_secret, &ilp_address, "ABC", 9, &prepare)
-            .expect("Receiver should be able to generate the fulfillment");
+            .expect("Receiver should be able to generate the fulfillment")
+            .fulfill;
         assert_eq!(
             &hash_sha256(fulfill.fulfillment())[..],
             &condition[..],

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,7 +27,7 @@ Admin or account-holder only.
 
 #### Message
 
-In the format of text message of WebSocket, the endpoint will send the following JSON when receiving payments:
+In the format of text message of WebSocket, the endpoint will send the following JSON as a payment notification when receiving payments:
 
 ```json
 {
@@ -35,11 +35,17 @@ In the format of text message of WebSocket, the endpoint will send the following
     "from_username": "Sending account username",
     "destination": "Destination ILP address",
     "amount": 1000,
-    "timestamp": "Receiving time in RFC3339 format"
+    "timestamp": "Receiving time in RFC3339 format",
+    "sequence": 2,
+    "connection_closed": false
 }
 ```
 
 Note that the `from_username` corresponds to the account that received the packet _on this node_, not the original sender.
+
+The `sequence` field reports the sequence number of each received packet carrying a payment amount.
+
+A payment notification with `amount: 0` and `connection_closed: true` will be sent when the last packet (which has a `ConnectionClose` frame) has been received. All other payment notifications report an actual payment amount and `connection_closed: false`.
 
 
 ### `/accounts/:username/ilp/btp` - Bilateral Transfer Protocol (BTP)


### PR DESCRIPTION
For improved payment tracking and debugging, we'd like to add two additional fields to the WebSocket payment notifications: the Boolean value `connection_closed` and the packet sequence number `sequence`.

The `connection_closed` field will be `true` only when the last packet, which contains the `ConnectionClose` frame, has been received. As a result, in addition to the normal payment notifications reported in the WebSocket, an extra notification will be sent at the end, containing `{ "amount": 0, "connection_closed": true, ... }`.

The `sequence` field reports the sequence number of each received payment-carrying packet.