### PR TITLE
perf: removing unneccesary clones and muts

### DIFF
--- a/crates/ilp-node/src/instrumentation/google_pubsub.rs
+++ b/crates/ilp-node/src/instrumentation/google_pubsub.rs
@@ -92,7 +92,7 @@ pub fn create_google_pubsub_wrapper<A: Account + 'static>(
           mut next: Box<dyn OutgoingService<A> + Send>|
           -> Pin<BoxedIlpFuture> {
         let (client, api_endpoint, token_fetcher) = if let Some(ref utilities) = utilities {
-            utilities.clone()
+            utilities
         } else {
             return Box::pin(async move { next.send_request(request).await });
         };

--- a/crates/interledger-http/src/server.rs
+++ b/crates/interledger-http/src/server.rs
@@ -65,12 +65,13 @@ async fn ilp_over_http<S, I>(
     password: SecretString,
     body: Bytes,
     store: S,
-    mut incoming: I,
+    incoming: I,
 ) -> Result<impl warp::Reply, warp::Rejection>
 where
     S: HttpStore,
     I: IncomingService<S::Account> + Clone,
 {
+    let mut incoming = incoming.clone();
     let account = get_account(store, &path_username, &password).await?;
 
     let buffer = bytes::BytesMut::from(body.as_ref());

--- a/crates/interledger-stream/src/packet.rs
+++ b/crates/interledger-stream/src/packet.rs
@@ -371,7 +371,7 @@ impl<'a> fmt::Debug for Frame<'a> {
 }
 
 /// The Stream Frame types [as defined in the RFC](https://interledger.org/rfcs/0029-stream/#53-frames)
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone)]
 #[repr(u8)]
 pub enum FrameType {
     ConnectionClose = 0x01,
@@ -414,7 +414,7 @@ impl From<u8> for FrameType {
 }
 
 /// The STREAM Error Codes [as defined in the RFC](https://interledger.org/rfcs/0029-stream/#54-error-codes)
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone)]
 #[repr(u8)]
 pub enum ErrorCode {
     NoError = 0x01,
@@ -472,7 +472,7 @@ impl<'a> SerializableFrame<'a> for ConnectionCloseFrame<'a> {
     }
 
     fn put_contents(&self, buf: &mut impl MutBufOerExt) {
-        buf.put_u8(self.code as u8);
+        buf.put_u8(self.code.clone() as u8);
         buf.put_var_octet_string(self.message.as_bytes());
     }
 }
@@ -640,7 +640,7 @@ impl<'a> SerializableFrame<'a> for StreamCloseFrame<'a> {
 
     fn put_contents(&self, buf: &mut impl MutBufOerExt) {
         buf.put_var_uint(self.stream_id);
-        buf.put_u8(self.code as u8);
+        buf.put_u8(self.code.clone() as u8);
         buf.put_var_octet_string(self.message.as_bytes());
     }
 }

--- a/crates/interledger-stream/src/server.rs
+++ b/crates/interledger-stream/src/server.rs
@@ -162,6 +162,7 @@ where
         let to_username = request.to.username().clone();
         let from_username = request.from.username().clone();
         let amount = request.prepare.amount();
+        let store = self.store.clone();
 
         let destination = request.prepare.destination();
         let to_address = request.to.ilp_address();
@@ -178,16 +179,13 @@ where
                     &request.prepare,
                 );
                 match response {
-                    Ok(ref _fulfill) => {
-                        self.store
-                            .publish_payment_notification(PaymentNotification {
-                                to_username,
-                                from_username,
-                                amount,
-                                destination,
-                                timestamp: DateTime::<Utc>::from(SystemTime::now()).to_rfc3339(),
-                            })
-                    }
+                    Ok(ref _fulfill) => store.publish_payment_notification(PaymentNotification {
+                        to_username,
+                        from_username,
+                        amount,
+                        destination: destination.clone(),
+                        timestamp: DateTime::<Utc>::from(SystemTime::now()).to_rfc3339(),
+                    }),
                     Err(ref reject) => {
                         if reject.code() == ErrorCode::F06_UNEXPECTED_PAYMENT {
                             // Assume the packet isn't for us if the decryption step fails.


### PR DESCRIPTION
This PR is part of reconciling our `interledger-rs` fork with the upstream. It contains the `clone()` and `mut` removal that @ljedrz performed.

Note: Clippy may fail and I or somebody will likely introduce another PR to fix those as well.