### PR TITLE
Multiple payments benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,6 +1016,7 @@ dependencies = [
  "chrono",
  "clap",
  "config",
+ "criterion",
  "futures 0.3.12",
  "hex",
  "interledger",

--- a/crates/ilp-node/Cargo.toml
+++ b/crates/ilp-node/Cargo.toml
@@ -80,7 +80,10 @@ reqwest = { version = "0.10.0", default-features = false, features = ["default-t
 serde_json = { version = "1.0.41", default-features = false }
 tokio-retry = { version = "0.2.0", default-features = false }
 tungstenite = {version = "0.10", default-features = false }
-
+criterion = { version = "0.3", default-features = false , features = ["cargo_bench_support", 'html_reports']}
 [badges]
 circle-ci = { repository = "interledger-rs/interledger-rs" }
 codecov = { repository = "interledger-rs/interledger-rs" }
+[[bench]]
+name = "multiple_payments"
+harness = false

--- a/crates/ilp-node/README.md
+++ b/crates/ilp-node/README.md
@@ -2,3 +2,10 @@
 
 The Interledger.rs node bundles all the functionality necessary to send, receive, and forward
 Interledger packets. See the examples for how to configure and use the `ilp-node`.
+
+#### Benchmark
+
+```bash #
+# This runs the process payment benchmark
+cargo bench -- process_payment
+```

--- a/crates/ilp-node/benches/multiple_payments.rs
+++ b/crates/ilp-node/benches/multiple_payments.rs
@@ -1,0 +1,388 @@
+//! Multiple payments benchmark
+//! Adds four bench functions which tracks, how long it takes for an ilp-node to receive payment through websocket, process it and respond back.
+//! Half of the benchmarks are with http and half are with btp.
+//! Half of the benchmarks are with high packet count (100) and half are with single packets.
+//! Sometimes it might take a while to start the benchmarks as the route propagation start up is sometimes slow.
+//! When a request is sent it will receive message for every packet + one connection closed packet.
+//! This is why 101 and 2 are used instead of 100 and 1 for [`RECEIVED_MESSAGE_COUNT_HIGH`] and [`RECEIVED_MESSAGE_COUNT_LOW`].
+use criterion::{criterion_group, criterion_main, Criterion};
+use ilp_node::InterledgerNode;
+use serde_json::{self, json};
+use tokio::runtime::Runtime;
+use tokio::sync::mpsc::channel;
+use tungstenite::{client, handshake::client::Request};
+
+mod redis_helpers;
+mod test_helpers;
+
+use redis_helpers::*;
+use test_helpers::*;
+
+const RECEIVED_MESSAGE_COUNT_HIGH: usize = 101;
+const RECEIVED_MESSAGE_COUNT_LOW: usize = 2;
+
+/// There will be executions where routes seem to be propagated right away during init, but on most
+/// runs they require this propagation delay. It will create additional noise to results.
+/// FIXME: this is a workaround to difficult startup
+const ROUTE_BROADCAST_INTERVAL: u64 = 500;
+
+fn multiple_payments_btp(c: &mut Criterion) {
+    let mut rt = Runtime::new().unwrap();
+
+    let node_a_http = get_open_port(None);
+    let node_a_settlement = get_open_port(None);
+    let node_b_http = get_open_port(None);
+    let node_b_settlement = get_open_port(None);
+    let context = TestContext::new();
+
+    let mut connection_info1 = context.get_client_connection_info();
+    connection_info1.db = 1;
+    let mut connection_info2 = context.get_client_connection_info();
+    connection_info2.db = 2;
+
+    // accounts to be created on node a
+    let alice_on_a = json!({
+        "username": "alice_on_a",
+        "asset_code": "XYZ",
+        "asset_scale": 9,
+        "ilp_over_http_incoming_token" : "default account holder",
+        "max_packet_amount": 100,
+    });
+    let b_on_a = json!({
+        "username": "b_on_a",
+        "asset_code": "XYZ",
+        "asset_scale": 9,
+        "ilp_over_btp_url": format!("ws://localhost:{}/accounts/{}/ilp/btp", node_b_http, "a_on_b"),
+        "ilp_over_btp_outgoing_token" : "token",
+        "routing_relation": "Parent",
+    });
+
+    // accounts to be created on node b
+    let a_on_b = json!({
+        "username": "a_on_b",
+        "asset_code": "XYZ",
+        "asset_scale": 9,
+        "ilp_over_btp_incoming_token" : "token",
+        "routing_relation": "Child",
+    });
+    let bob_on_b = json!({
+        "username": "bob_on_b",
+        "asset_code": "XYZ",
+        "asset_scale": 9,
+        "ilp_over_http_incoming_token" : "default account holder",
+    });
+
+    // node a config
+    let node_a: InterledgerNode = serde_json::from_value(json!({
+        "admin_auth_token": "admin",
+        "database_url": connection_info_to_string(connection_info1),
+        "http_bind_address": format!("127.0.0.1:{}", node_a_http),
+        "settlement_api_bind_address": format!("127.0.0.1:{}", node_a_settlement),
+        "secret_seed": random_secret(),
+        "route_broadcast_interval": ROUTE_BROADCAST_INTERVAL,
+        "exchange_rate": {
+            "poll_interval": 60000
+        },
+    }))
+    .expect("Error creating node_a.");
+
+    // node b config
+    let node_b: InterledgerNode = serde_json::from_value(json!({
+        "ilp_address": "example.parent",
+        "default_spsp_account": "bob_on_b",
+        "admin_auth_token": "admin",
+        "database_url": connection_info_to_string(connection_info2),
+        "http_bind_address": format!("127.0.0.1:{}", node_b_http),
+        "settlement_api_bind_address": format!("127.0.0.1:{}", node_b_settlement),
+        "secret_seed": random_secret(),
+        "route_broadcast_interval": ROUTE_BROADCAST_INTERVAL,
+        "exchange_rate": {
+            "poll_interval": 60000
+        },
+    }))
+    .expect("Error creating node_b.");
+
+    rt.block_on(
+        // start node b and open its accounts
+        async {
+            node_b.serve(None).await.unwrap();
+            create_account_on_node(node_b_http, a_on_b, "admin")
+                .await
+                .unwrap();
+            create_account_on_node(node_b_http, bob_on_b, "admin")
+                .await
+                .unwrap();
+
+            // start node a and open its accounts
+            node_a.serve(None).await.unwrap();
+            create_account_on_node(node_a_http, alice_on_a, "admin")
+                .await
+                .unwrap();
+            create_account_on_node(node_a_http, b_on_a, "admin")
+                .await
+                .unwrap();
+        },
+    );
+
+    let ws_request = Request::builder()
+        .uri(format!("ws://localhost:{}/payments/incoming", node_b_http))
+        .header("Authorization", "Bearer admin")
+        .body(())
+        .unwrap();
+    let (sender, mut receiver) = channel(RECEIVED_MESSAGE_COUNT_HIGH);
+    let client = reqwest::Client::new();
+    let req_low = client
+        .post(&format!(
+            "http://localhost:{}/accounts/{}/payments",
+            node_a_http, "alice_on_a"
+        ))
+        .header(
+            "Authorization",
+            format!("Bearer {}", "default account holder"),
+        )
+        .json(&json!({
+            "receiver": format!("http://localhost:{}/accounts/{}/spsp", node_b_http,"bob_on_b"),
+            "source_amount": 100,
+            "slippage": 0.025 // allow up to 2.5% slippage
+        }));
+    let req_high = client
+        .post(&format!(
+            "http://localhost:{}/accounts/{}/payments",
+            node_a_http, "alice_on_a"
+        ))
+        .header(
+            "Authorization",
+            format!("Bearer {}", "default account holder"),
+        )
+        .json(&json!({
+            "receiver": format!("http://localhost:{}/accounts/{}/spsp", node_b_http,"bob_on_b"),
+            "source_amount": 10000,
+            "slippage": 0.025 // allow up to 2.5% slippage
+        }));
+    let handle = std::thread::spawn(move || forward_payment_notifications(ws_request, sender));
+
+    wait_for_propagation(&mut rt, &req_low, RECEIVED_MESSAGE_COUNT_LOW, &mut receiver);
+    c.bench_function("process_payment_btp_single_packet", |b| {
+        b.iter(|| bench_fn(&mut rt, &req_low, RECEIVED_MESSAGE_COUNT_LOW, &mut receiver));
+    });
+    c.bench_function("process_payment_btp_hundred_packets", |b| {
+        b.iter(|| {
+            bench_fn(
+                &mut rt,
+                &req_high,
+                RECEIVED_MESSAGE_COUNT_HIGH,
+                &mut receiver,
+            )
+        });
+    });
+
+    drop(rt);
+    handle.join().unwrap().unwrap();
+}
+fn multiple_payments_http(c: &mut Criterion) {
+    let mut rt = Runtime::new().unwrap();
+    let node_a_http = get_open_port(None);
+    let node_a_settlement = get_open_port(None);
+    let node_b_http = get_open_port(None);
+    let node_b_settlement = get_open_port(None);
+    let context = TestContext::new();
+
+    let mut connection_info1 = context.get_client_connection_info();
+    connection_info1.db = 1;
+    let mut connection_info2 = context.get_client_connection_info();
+    connection_info2.db = 2;
+
+    // accounts to be created on node a
+    let alice_on_a = json!({
+        "username": "alice_on_a",
+        "asset_code": "XYZ",
+        "asset_scale": 9,
+        "ilp_over_http_incoming_token" : "admin",
+        "max_packet_amount": 100,
+    });
+    let b_on_a = json!({
+        "username": "b_on_a",
+        "asset_code": "XYZ",
+        "asset_scale": 9,
+        "ilp_over_http_url": format!("http://localhost:{}/accounts/{}/ilp", node_b_http, "a_on_b"),
+        "ilp_over_http_incoming_token" : "admin",
+        "ilp_over_http_outgoing_token" : "admin",
+        "ilp_address": "example.node_b",
+    });
+
+    // accounts to be created on node b
+    let a_on_b = json!({
+        "username": "a_on_b",
+        "ilp_over_http_url": format!("http://localhost:{}/accounts/{}/ilp", node_a_http, "b_on_a"),
+        "asset_code": "XYZ",
+        "asset_scale": 9,
+        "ilp_over_http_incoming_token" : "admin",
+        "ilp_over_http_outgoing_token" : "admin",
+    });
+    let bob_on_b = json!({
+        "username": "bob_on_b",
+        "asset_code": "XYZ",
+        "asset_scale": 9,
+        "ilp_over_http_incoming_token" : "admin",
+    });
+
+    let node_a: InterledgerNode = serde_json::from_value(json!({
+        "ilp_address": "example.node_a",
+        "secret_seed" : random_secret(),
+        "admin_auth_token": "admin",
+        "database_url": connection_info_to_string(connection_info1),
+        "http_bind_address": format!("127.0.0.1:{}", node_a_http),
+        "settlement_api_bind_address": format!("127.0.0.1:{}", node_a_settlement),
+        "route_broadcast_interval": ROUTE_BROADCAST_INTERVAL,
+        "exchange_rate": {
+            "poll_interval": 60000
+        },
+    }))
+    .expect("Error creating node_a.");
+
+    let node_b: InterledgerNode = serde_json::from_value(json!({
+        "ilp_address": "example.node_b",
+        "secret_seed" : random_secret(),
+        "admin_auth_token": "admin",
+        "database_url": connection_info_to_string(connection_info2),
+        "http_bind_address": format!("127.0.0.1:{}", node_b_http),
+        "settlement_api_bind_address": format!("127.0.0.1:{}", node_b_settlement),
+        "default_spsp_account": "bob_on_b",
+        "route_broadcast_interval": ROUTE_BROADCAST_INTERVAL,
+        "exchange_rate": {
+            "poll_interval": 60000
+        },
+    }))
+    .expect("Error creating node_b.");
+    rt.block_on(
+        // start node b and open its accounts
+        async {
+            node_b.serve(None).await.unwrap();
+            create_account_on_node(node_b_http, a_on_b, "admin")
+                .await
+                .unwrap();
+            create_account_on_node(node_b_http, bob_on_b, "admin")
+                .await
+                .unwrap();
+
+            // start node a and open its accounts
+            node_a.serve(None).await.unwrap();
+            create_account_on_node(node_a_http, alice_on_a, "admin")
+                .await
+                .unwrap();
+            create_account_on_node(node_a_http, b_on_a, "admin")
+                .await
+                .unwrap();
+        },
+    );
+
+    let ws_request = Request::builder()
+        .uri(format!("ws://localhost:{}/payments/incoming", node_b_http))
+        .header("Authorization", "Bearer admin")
+        .body(())
+        .unwrap();
+    let (sender, mut receiver) = channel(RECEIVED_MESSAGE_COUNT_HIGH);
+    let client = reqwest::Client::new();
+    let req_low = client
+        .post(&format!(
+            "http://localhost:{}/accounts/{}/payments",
+            node_a_http, "alice_on_a"
+        ))
+        .header("Authorization", format!("Bearer {}", "admin"))
+        .json(&json!({
+            "receiver": format!("http://localhost:{}/accounts/{}/spsp", node_b_http,"bob_on_b"),
+            "source_amount": 100,
+            "slippage": 0.025 // allow up to 2.5% slippage
+        }));
+    let req_high = client
+        .post(&format!(
+            "http://localhost:{}/accounts/{}/payments",
+            node_a_http, "alice_on_a"
+        ))
+        .header("Authorization", format!("Bearer {}", "admin"))
+        .json(&json!({
+            "receiver": format!("http://localhost:{}/accounts/{}/spsp", node_b_http,"bob_on_b"),
+            "source_amount": 10000,
+            "slippage": 0.025 // allow up to 2.5% slippage
+        }));
+    let handle = std::thread::spawn(move || forward_payment_notifications(ws_request, sender));
+    wait_for_propagation(&mut rt, &req_low, RECEIVED_MESSAGE_COUNT_LOW, &mut receiver);
+    c.bench_function("process_payment_http_single_packet", |b| {
+        b.iter(|| bench_fn(&mut rt, &req_low, RECEIVED_MESSAGE_COUNT_LOW, &mut receiver));
+    });
+    c.bench_function("process_payment_http_hundred_packets", |b| {
+        b.iter(|| {
+            bench_fn(
+                &mut rt,
+                &req_high,
+                RECEIVED_MESSAGE_COUNT_HIGH,
+                &mut receiver,
+            )
+        });
+    });
+
+    drop(rt);
+    handle.join().unwrap().unwrap();
+}
+
+/// Forwards the payment notifications from the websocket into the channel
+/// When runtime (rt) is dropped, error will happen ending the loop and then the websocket
+fn forward_payment_notifications(
+    ws_request: tungstenite::http::Request<()>,
+    mut sender: tokio::sync::mpsc::Sender<tungstenite::Message>,
+) -> Result<(), tungstenite::Error> {
+    let mut payments_ws = client::connect(ws_request)?.0;
+    while let Ok(message) = payments_ws.read_message() {
+        sender.try_send(message).unwrap();
+    }
+    payments_ws.close(None)
+}
+
+/// Route propagation has a slow startup sometimes.
+/// Loops until route propagation is on.
+fn wait_for_propagation(
+    rt: &mut tokio::runtime::Runtime,
+    request: &reqwest::RequestBuilder,
+    received_message_count: usize,
+    receiver: &mut tokio::sync::mpsc::Receiver<tungstenite::Message>,
+) {
+    let delay_ms = 100;
+    let timeout_ms = 40000;
+    let tries_until_timeout = timeout_ms / delay_ms;
+    rt.block_on(async {
+        for i in 0..tries_until_timeout {
+            let response = request.try_clone().unwrap().send().await.unwrap();
+            if response.status().is_success() {
+                break;
+            }
+            if i == tries_until_timeout - 1 {
+                panic!("Timeout: Responses keep on failing: {:?}", response);
+            }
+            tokio::time::delay_for(std::time::Duration::from_millis(delay_ms)).await;
+        }
+        for _ in 0..received_message_count {
+            // TODO check if received data is correct
+            receiver.recv().await.unwrap();
+        }
+    });
+}
+
+fn bench_fn(
+    rt: &mut tokio::runtime::Runtime,
+    request: &reqwest::RequestBuilder,
+    received_message_count: usize,
+    receiver: &mut tokio::sync::mpsc::Receiver<tungstenite::Message>,
+) {
+    rt.block_on(async {
+        let response = request.try_clone().unwrap().send().await.unwrap();
+        if !&response.status().is_success() {
+            panic!("Error receiving response: {:?}", response)
+        }
+        for _ in 0..received_message_count {
+            // TODO check if received data is correct
+            receiver.recv().await.unwrap();
+        }
+    });
+}
+criterion_group!(benches, multiple_payments_http, multiple_payments_btp);
+criterion_main!(benches);

--- a/crates/ilp-node/benches/redis_helpers.rs
+++ b/crates/ilp-node/benches/redis_helpers.rs
@@ -1,0 +1,231 @@
+// Copied from https://github.com/mitsuhiko/redis-rs/blob/9a1777e8a90c82c315a481cdf66beb7d69e681a2/tests/support/mod.rs
+#![allow(dead_code)]
+
+use futures::TryFutureExt;
+use redis_crate::{self as redis, ConnectionAddr, ConnectionInfo, RedisError};
+use socket2::{Domain, Socket, Type};
+use std::env;
+use std::fs;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::process;
+use std::thread::sleep;
+use std::time::Duration;
+
+#[allow(unused)]
+pub fn connection_info_to_string(info: ConnectionInfo) -> String {
+    match info.addr.as_ref() {
+        ConnectionAddr::Tcp(url, port) => format!("redis://{}:{}/{}", url, port, info.db),
+        ConnectionAddr::Unix(path) => {
+            format!("redis+unix:{}?db={}", path.to_str().unwrap(), info.db)
+        }
+    }
+}
+
+pub fn get_open_port(try_port: Option<u16>) -> u16 {
+    if let Some(port) = try_port {
+        let socket = Socket::new(Domain::ipv4(), Type::stream(), None).unwrap();
+        socket.reuse_address().unwrap();
+        if socket
+            .bind(
+                &format!("127.0.0.1:{}", port)
+                    .parse::<SocketAddr>()
+                    .unwrap()
+                    .into(),
+            )
+            .is_ok()
+        {
+            socket.listen(1).unwrap();
+            let listener = socket.into_tcp_listener();
+            return listener.local_addr().unwrap().port();
+        }
+    }
+
+    for _i in 0..1000 {
+        let socket = Socket::new(Domain::ipv4(), Type::stream(), None).unwrap();
+        socket.reuse_address().unwrap();
+        if socket
+            .bind(&"127.0.0.1:0".parse::<SocketAddr>().unwrap().into())
+            .is_ok()
+        {
+            socket.listen(1).unwrap();
+            let listener = socket.into_tcp_listener();
+            return listener.local_addr().unwrap().port();
+        }
+    }
+
+    panic!("Cannot find open port!");
+}
+
+pub async fn delay(ms: u64) {
+    tokio::time::delay_for(Duration::from_millis(ms)).await;
+}
+
+#[derive(PartialEq)]
+enum ServerType {
+    Tcp,
+    Unix,
+}
+
+pub struct RedisServer {
+    pub process: process::Child,
+    addr: redis::ConnectionAddr,
+}
+
+impl ServerType {
+    fn get_intended() -> ServerType {
+        match env::var("REDISRS_SERVER_TYPE")
+            .ok()
+            .as_ref()
+            .map(|x| &x[..])
+        {
+            // Default to unix socket unlike original version
+            Some("tcp") => ServerType::Tcp,
+            _ => ServerType::Unix,
+        }
+    }
+}
+
+impl RedisServer {
+    pub fn new() -> RedisServer {
+        let server_type = ServerType::get_intended();
+        let mut cmd = process::Command::new("redis-server");
+        cmd.stdout(process::Stdio::null())
+            .stderr(process::Stdio::null());
+
+        let addr = match server_type {
+            ServerType::Tcp => {
+                // this is technically a race but we can't do better with
+                // the tools that redis gives us :(
+                let socket = Socket::new(Domain::ipv4(), Type::stream(), None).unwrap();
+                socket.reuse_address().unwrap();
+                socket
+                    .bind(&"127.0.0.1:0".parse::<SocketAddr>().unwrap().into())
+                    .unwrap();
+                socket.listen(1).unwrap();
+                let listener = socket.into_tcp_listener();
+                let server_port = listener.local_addr().unwrap().port();
+                cmd.arg("--port")
+                    .arg(server_port.to_string())
+                    .arg("--bind")
+                    .arg("127.0.0.1");
+                redis::ConnectionAddr::Tcp("127.0.0.1".to_string(), server_port)
+            }
+            ServerType::Unix => {
+                let (a, b) = rand::random::<(u64, u64)>();
+                let path = format!("/tmp/redis-rs-test-{}-{}.sock", a, b);
+                cmd.arg("--port").arg("0").arg("--unixsocket").arg(&path);
+                redis::ConnectionAddr::Unix(PathBuf::from(&path))
+            }
+        };
+
+        let process = cmd.spawn().expect(
+            "Could not spawn redis-server process, please ensure \
+             that all redis components are installed",
+        );
+        RedisServer { process, addr }
+    }
+
+    pub fn wait(&mut self) {
+        self.process.wait().unwrap();
+    }
+
+    pub fn get_client_addr(&self) -> &redis::ConnectionAddr {
+        &self.addr
+    }
+
+    pub fn stop(&mut self) {
+        let _ = self.process.kill();
+        let _ = self.process.wait();
+        if let redis::ConnectionAddr::Unix(ref path) = *self.get_client_addr() {
+            fs::remove_file(&path).ok();
+        }
+    }
+}
+
+impl Default for RedisServer {
+    fn default() -> Self {
+        RedisServer::new()
+    }
+}
+
+impl Drop for RedisServer {
+    fn drop(&mut self) {
+        self.stop()
+    }
+}
+
+pub struct TestContext {
+    pub server: RedisServer,
+    pub client: redis::Client,
+}
+
+impl TestContext {
+    pub fn new() -> TestContext {
+        let server = RedisServer::new();
+
+        let client = redis::Client::open(redis::ConnectionInfo {
+            addr: Box::new(server.get_client_addr().clone()),
+            db: 0,
+            passwd: None,
+        })
+        .unwrap();
+        let mut con;
+
+        let millisecond = Duration::from_millis(1);
+        loop {
+            match client.get_connection() {
+                Err(err) => {
+                    if err.is_connection_refusal() {
+                        sleep(millisecond);
+                    } else {
+                        panic!("Could not connect: {}", err);
+                    }
+                }
+                Ok(x) => {
+                    con = x;
+                    break;
+                }
+            }
+        }
+        redis::cmd("FLUSHALL").execute(&mut con);
+
+        TestContext { server, client }
+    }
+
+    // This one was added and not in the original file
+    pub fn get_client_connection_info(&self) -> redis::ConnectionInfo {
+        redis::ConnectionInfo {
+            addr: Box::new(self.server.get_client_addr().clone()),
+            db: 0,
+            passwd: None,
+        }
+    }
+
+    pub fn connection(&self) -> redis::Connection {
+        self.client.get_connection().unwrap()
+    }
+
+    pub async fn async_connection(&self) -> Result<redis::aio::Connection, ()> {
+        self.client
+            .get_async_connection()
+            .map_err(|err| panic!(err))
+            .await
+    }
+
+    pub fn stop_server(&mut self) {
+        self.server.stop();
+    }
+
+    pub async fn shared_async_connection(
+        &self,
+    ) -> Result<redis::aio::MultiplexedConnection, RedisError> {
+        self.client.get_multiplexed_tokio_connection().await
+    }
+}
+
+impl Default for TestContext {
+    fn default() -> Self {
+        TestContext::new()
+    }
+}

--- a/crates/ilp-node/benches/test_helpers.rs
+++ b/crates/ilp-node/benches/test_helpers.rs
@@ -1,0 +1,144 @@
+use futures::TryFutureExt;
+use interledger::stream::StreamDelivery;
+use interledger::{packet::Address, service::Account as AccountTrait, store::account::Account};
+use ring::rand::{SecureRandom, SystemRandom};
+use serde::Serialize;
+use serde_json::json;
+use std::collections::HashMap;
+use std::fmt::{Debug, Display};
+use std::str;
+// use tracing_subscriber;
+use uuid::Uuid;
+
+#[allow(unused)]
+pub fn random_secret() -> String {
+    let mut bytes: [u8; 32] = [0; 32];
+    SystemRandom::new().fill(&mut bytes).unwrap();
+    hex::encode(bytes)
+}
+
+#[derive(serde::Deserialize, Debug, PartialEq)]
+pub struct BalanceData {
+    pub balance: f64,
+    pub asset_code: String,
+}
+
+#[allow(unused)]
+pub async fn create_account_on_node<T: Serialize>(
+    api_port: u16,
+    data: T,
+    auth: &str,
+) -> Result<Account, ()> {
+    let client = reqwest::Client::new();
+    let res = client
+        .post(&format!("http://localhost:{}/accounts", api_port))
+        .header("Content-Type", "application/json")
+        .header("Authorization", format!("Bearer {}", auth))
+        .json(&data)
+        .send()
+        .map_err(|_| ())
+        .await?;
+
+    let res = res.error_for_status().map_err(|_| ())?;
+
+    Ok(res.json::<Account>().map_err(|_| ()).await.unwrap())
+}
+
+#[allow(unused)]
+pub async fn create_account_on_engine<T: Serialize>(
+    engine_port: u16,
+    account_id: T,
+) -> Result<String, ()> {
+    let client = reqwest::Client::new();
+    let res = client
+        .post(&format!("http://localhost:{}/accounts", engine_port))
+        .header("Content-Type", "application/json")
+        .json(&json!({ "id": account_id }))
+        .send()
+        .map_err(|_| ())
+        .await?;
+
+    let res = res.error_for_status().map_err(|_| ())?;
+
+    let data: bytes05::Bytes = res.bytes().map_err(|_| ()).await?;
+
+    Ok(str::from_utf8(&data).unwrap().to_string())
+}
+
+#[allow(unused)]
+pub async fn send_money_to_username<T: Display + Debug>(
+    from_port: u16,
+    to_port: u16,
+    amount: u64,
+    to_username: T,
+    from_username: &str,
+    from_auth: &str,
+) -> Result<StreamDelivery, ()> {
+    let client = reqwest::Client::new();
+    let res = client
+        .post(&format!(
+            "http://localhost:{}/accounts/{}/payments",
+            from_port, from_username
+        ))
+        .header("Authorization", format!("Bearer {}", from_auth))
+        .json(&json!({
+            "receiver": format!("http://localhost:{}/accounts/{}/spsp", to_port, to_username),
+            "source_amount": amount,
+            "slippage": 0.025 // allow up to 2.5% slippage
+        }))
+        .send()
+        .map_err(|_| ())
+        .await?;
+
+    let res = res.error_for_status().map_err(|_| ())?;
+    Ok(res.json::<StreamDelivery>().await.unwrap())
+}
+
+#[allow(unused)]
+pub async fn get_all_accounts(node_port: u16, admin_token: &str) -> Result<Vec<Account>, ()> {
+    let client = reqwest::Client::new();
+    let res = client
+        .get(&format!("http://localhost:{}/accounts", node_port))
+        .header("Authorization", format!("Bearer {}", admin_token))
+        .send()
+        .map_err(|_| ())
+        .await?;
+
+    let res = res.error_for_status().map_err(|_| ())?;
+    let body: bytes05::Bytes = res.bytes().map_err(|_| ()).await?;
+    let ret: Vec<Account> = serde_json::from_slice(&body).unwrap();
+    Ok(ret)
+}
+
+#[allow(unused)]
+#[allow(clippy::mutable_key_type)]
+pub fn accounts_to_ids(accounts: Vec<Account>) -> HashMap<Address, Uuid> {
+    let mut map = HashMap::new();
+    for a in accounts {
+        map.insert(a.ilp_address().clone(), a.id());
+    }
+    map
+}
+
+#[allow(unused)]
+pub async fn get_balance<T: Display>(
+    account_id: T,
+    node_port: u16,
+    admin_token: &str,
+) -> Result<BalanceData, ()> {
+    let client = reqwest::Client::new();
+    let res = client
+        .get(&format!(
+            "http://localhost:{}/accounts/{}/balance",
+            node_port, account_id
+        ))
+        .header("Authorization", format!("Bearer {}", admin_token))
+        .send()
+        .map_err(|_| ())
+        .await?;
+
+    let res = res.error_for_status().map_err(|_| ())?;
+    let body: bytes05::Bytes = res.bytes().map_err(|_| ()).await?;
+    let ret: BalanceData = serde_json::from_slice(&body).unwrap();
+    Ok(ret)
+}


### PR DESCRIPTION
Adds two benchmarks which tracks, how long it takes for an ilp-node to receive payment through websocket, process it and respond back. One benchmark with high packet count and one benchmark with lower packet count.

```bash #
# This runs the process payment benchmarks
cargo bench -- process_payment
```
