### PR TITLE
Enable multiple nodes to use same redis db

### DIFF
--- a/crates/ilp-node/src/main.rs
+++ b/crates/ilp-node/src/main.rs
@@ -79,6 +79,11 @@ async fn main() {
             .takes_value(true)
             .default_value("redis://127.0.0.1:6379")
             .help("Redis URI (for example, \"redis://127.0.0.1:6379\" or \"unix:/tmp/redis.sock\")"),
+        Arg::with_name("database_prefix")
+            .long("database_prefix")
+            .takes_value(true)
+            .default_value("")
+            .help("Unique prefix that can be used to identify part of the db that this node will use. This can be used to enable multiple nodes to share the same database instance"),
         Arg::with_name("http_bind_address")
             .long("http_bind_address")
             .takes_value(true)

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -92,9 +92,6 @@ fn default_settlement_api_bind_address() -> SocketAddr {
 fn default_http_bind_address() -> SocketAddr {
     SocketAddr::from(([127, 0, 0, 1], 7770))
 }
-fn default_database_prefix() -> String {
-    "".to_string()
-}
 // We allow unreachable code on the below function because there must always be exactly one default
 // regardless of how many data sources the crate is compiled to support,
 // but we don't know which will be enabled or in which quantities or configurations.
@@ -204,7 +201,7 @@ pub struct InterledgerNode {
     )]
     pub database_url: String,
     /// Database prefix which can be used in case a db instance is shared by multiple nodes
-    #[serde(default = "default_database_prefix")]
+    #[serde(default)]
     pub database_prefix: String,
     /// IP address and port to listen for HTTP connections
     /// This is used for both the API and ILP over HTTP packets

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -92,6 +92,7 @@ fn default_settlement_api_bind_address() -> SocketAddr {
 fn default_http_bind_address() -> SocketAddr {
     SocketAddr::from(([127, 0, 0, 1], 7770))
 }
+fn default_database_prefix() -> String { "".to_string() }
 // We allow unreachable code on the below function because there must always be exactly one default
 // regardless of how many data sources the crate is compiled to support,
 // but we don't know which will be enabled or in which quantities or configurations.
@@ -200,6 +201,9 @@ pub struct InterledgerNode {
         alias = "redis_url"
     )]
     pub database_url: String,
+    /// Database prefix which can be used in case a db instance is shared by multiple nodes
+    #[serde(default = "default_database_prefix")]
+    pub database_prefix: String,
     /// IP address and port to listen for HTTP connections
     /// This is used for both the API and ILP over HTTP packets
     #[serde(default = "default_http_bind_address")]

--- a/crates/ilp-node/src/node.rs
+++ b/crates/ilp-node/src/node.rs
@@ -92,7 +92,9 @@ fn default_settlement_api_bind_address() -> SocketAddr {
 fn default_http_bind_address() -> SocketAddr {
     SocketAddr::from(([127, 0, 0, 1], 7770))
 }
-fn default_database_prefix() -> String { "".to_string() }
+fn default_database_prefix() -> String {
+    "".to_string()
+}
 // We allow unreachable code on the below function because there must always be exactly one default
 // regardless of how many data sources the crate is compiled to support,
 // but we don't know which will be enabled or in which quantities or configurations.

--- a/crates/ilp-node/src/redis_store.rs
+++ b/crates/ilp-node/src/redis_store.rs
@@ -30,6 +30,7 @@ pub async fn serve_redis_node(
     let redis_addr = redis_connection_info.addr.clone();
     let redis_secret = generate_redis_secret(&node.secret_seed);
     let store = RedisStoreBuilder::new(redis_connection_info, redis_secret)
+        .with_db_prefix(node.database_prefix.as_str())
         .node_ilp_address(ilp_address.clone())
         .connect()
         .map_err(move |err| error!(target: "interledger-node", "Error connecting to Redis: {:?} {:?}", redis_addr, err))

--- a/crates/ilp-node/tests/redis/payments_incoming.rs
+++ b/crates/ilp-node/tests/redis/payments_incoming.rs
@@ -17,8 +17,6 @@ async fn payments_incoming() {
 
     let mut connection_info1 = context.get_client_connection_info();
     connection_info1.db = 1;
-    let mut connection_info2 = context.get_client_connection_info();
-    connection_info2.db = 2;
 
     // test ports
     let node_a_http = get_open_port(None);
@@ -72,7 +70,8 @@ async fn payments_incoming() {
     // node a config
     let node_a: InterledgerNode = serde_json::from_value(json!({
         "admin_auth_token": "admin",
-        "database_url": connection_info_to_string(connection_info1),
+        "database_url": connection_info_to_string(connection_info1.clone()),
+        "database_prefix": "testnodea",
         "http_bind_address": format!("127.0.0.1:{}", node_a_http),
         "settlement_api_bind_address": format!("127.0.0.1:{}", node_a_settlement),
         "secret_seed": random_secret(),
@@ -88,7 +87,8 @@ async fn payments_incoming() {
         "ilp_address": "example.parent",
         "default_spsp_account": "bob_on_b",
         "admin_auth_token": "admin",
-        "database_url": connection_info_to_string(connection_info2),
+        "database_url": connection_info_to_string(connection_info1),
+        "database_prefix": "testnodeb",
         "http_bind_address": format!("127.0.0.1:{}", node_b_http),
         "settlement_api_bind_address": format!("127.0.0.1:{}", node_b_settlement),
         "secret_seed": random_secret(),

--- a/crates/interledger-store/src/redis/lua/account_from_username.lua
+++ b/crates/interledger-store/src/redis/lua/account_from_username.lua
@@ -1,7 +1,9 @@
-local username = ARGV[1]
-local id_from_username = redis.call('HGET', 'usernames', username)
+local usernames_key = ARGV[1]
+local accounts_key = ARGV[2]
+local username = ARGV[3]
+local id_from_username = redis.call('HGET', usernames_key, username)
 if id_from_username then
-    return redis.call('HGETALL', 'accounts:' .. id_from_username)
+    return redis.call('HGETALL', accounts_key .. ':' .. id_from_username)
 else
     return nil
 end

--- a/crates/interledger-store/src/redis/lua/process_fulfill.lua
+++ b/crates/interledger-store/src/redis/lua/process_fulfill.lua
@@ -1,5 +1,6 @@
-local to_account = 'accounts:' .. ARGV[1]
-local to_amount = tonumber(ARGV[2])
+local accounts_key = ARGV[1]
+local to_account = accounts_key .. ':' .. ARGV[2]
+local to_amount = tonumber(ARGV[3])
 
 local balance = redis.call('HINCRBY', to_account, 'balance', to_amount)
 local prepaid_amount, settle_threshold, settle_to = unpack(redis.call('HMGET', to_account, 'prepaid_amount', 'settle_threshold', 'settle_to'))

--- a/crates/interledger-store/src/redis/lua/process_incoming_settlement.lua
+++ b/crates/interledger-store/src/redis/lua/process_incoming_settlement.lua
@@ -1,6 +1,7 @@
-local account = 'accounts:' .. ARGV[1]
-local amount = tonumber(ARGV[2])
-local idempotency_key = ARGV[3]
+local accounts_key = ARGV[1]
+local account = accounts_key .. ':' .. ARGV[2]
+local amount = tonumber(ARGV[3])
+local idempotency_key = ARGV[4]
 
 local balance, prepaid_amount = unpack(redis.call('HMGET', account, 'balance', 'prepaid_amount'))
 

--- a/crates/interledger-store/src/redis/lua/process_prepare.lua
+++ b/crates/interledger-store/src/redis/lua/process_prepare.lua
@@ -1,6 +1,7 @@
-local from_id = ARGV[1]
-local from_account = 'accounts:' .. ARGV[1]
-local from_amount = tonumber(ARGV[2])
+local accounts_key = ARGV[1]
+local from_id = ARGV[2]
+local from_account = accounts_key .. ':' .. from_id
+local from_amount = tonumber(ARGV[3])
 local min_balance, balance, prepaid_amount = unpack(redis.call('HMGET', from_account, 'min_balance', 'balance', 'prepaid_amount'))
 balance = tonumber(balance)
 prepaid_amount = tonumber(prepaid_amount)

--- a/crates/interledger-store/src/redis/lua/process_reject.lua
+++ b/crates/interledger-store/src/redis/lua/process_reject.lua
@@ -1,5 +1,6 @@
-local from_account = 'accounts:' .. ARGV[1]
-local from_amount = tonumber(ARGV[2])
+local accounts_key = ARGV[1]
+local from_account = accounts_key .. ':' .. ARGV[2]
+local from_amount = tonumber(ARGV[3])
 
 local prepaid_amount = redis.call('HGET', from_account, 'prepaid_amount')
 local balance = redis.call('HINCRBY', from_account, 'balance', from_amount)

--- a/crates/interledger-store/src/redis/lua/process_settle.lua
+++ b/crates/interledger-store/src/redis/lua/process_settle.lua
@@ -2,8 +2,8 @@
 -- returns similarly the balance and the amount to settle, but is called with only the account id as the only argument.
 --
 -- upon completion the `balance` is at the level of `settle_to`
-local to_account = 'accounts:' .. ARGV[1]
-
+local accounts_key = ARGV[1]
+local to_account = accounts_key .. ':' .. ARGV[2]
 local balance, prepaid_amount, settle_threshold, settle_to = unpack(redis.call('HMGET', to_account, 'balance', 'prepaid_amount', 'settle_threshold', 'settle_to'))
 local settle_amount = 0
 

--- a/crates/interledger-store/src/redis/lua/refund_settlement.lua
+++ b/crates/interledger-store/src/redis/lua/refund_settlement.lua
@@ -1,5 +1,6 @@
-local account = 'accounts:' .. ARGV[1]
-local settle_amount = tonumber(ARGV[2])
+local accounts_key = ARGV[1]
+local account = accounts_key .. ':' .. ARGV[2]
+local settle_amount = tonumber(ARGV[3])
 
 local balance = redis.call('HINCRBY', account, 'balance', settle_amount)
 return balance

--- a/crates/interledger-store/src/redis/mod.rs
+++ b/crates/interledger-store/src/redis/mod.rs
@@ -6,6 +6,8 @@
 //   routes:current         hash        dynamic routing table
 //   routes:static          hash        static routing table
 //   accounts:<id>          hash        information for each account
+//   accounts               set
+//   usernames              hash
 //   btp_outgoing
 // For interactive exploration of the store,
 // use the redis-cli tool included with your redis install.
@@ -61,6 +63,7 @@ use std::{
     str::FromStr,
     sync::Arc,
     time::Duration,
+    borrow::Cow,
 };
 use tokio::sync::broadcast;
 use tracing::{debug, error, trace, warn};
@@ -70,6 +73,7 @@ use zeroize::Zeroize;
 
 const DEFAULT_POLL_INTERVAL: u64 = 30000; // 30 seconds
 const ACCOUNT_DETAILS_FIELDS: usize = 21;
+const DEFAULT_DB_PREFIX: &str = "";
 
 static PARENT_ILP_KEY: &str = "parent_node_account_address";
 static ROUTES_KEY: &str = "routes:current";
@@ -77,20 +81,33 @@ static STATIC_ROUTES_KEY: &str = "routes:static";
 static DEFAULT_ROUTE_KEY: &str = "routes:default";
 static STREAM_NOTIFICATIONS_PREFIX: &str = "stream_notifications:";
 static SETTLEMENT_ENGINES_KEY: &str = "settlement_engines";
+static USERNAMES_KEY: &str = "usernames";
+static ACCOUNTS_KEY: &str = "accounts";
+static SEND_ROUTES_KEY: &str = "send_routes_to";
+static RECEIVE_ROUTES_FROM_KEY: &str = "receive_routes_from";
+static BPT_OUTGOING: &str = "btp_outgoing";
 
 /// Domain separator for leftover amounts
-fn uncredited_amount_key(account_id: impl ToString) -> String {
-    format!("uncredited-amount:{}", account_id.to_string())
+fn uncredited_amount_key(prefix: &str, account_id: impl ToString) -> String {
+    prefixed_key(prefix, &format!("uncredited-amount:{}", account_id.to_string())).into_owned()
 }
 
 /// Domain separator for idempotency keys
-fn prefixed_idempotency_key(idempotency_key: &str) -> String {
-    format!("idempotency-key:{}", idempotency_key)
+fn prefixed_idempotency_key(prefix: &str, idempotency_key: &str) -> String {
+    prefixed_key(prefix, format!("idempotency-key:{}", idempotency_key).as_str()).into_owned()
+}
+
+fn prefixed_key<'a>(prefix: &str, key: &'a str) -> Cow<'a, str> {
+    if prefix.is_empty() {
+        Cow::Borrowed(key)
+    } else {
+        Cow::Owned(format!("{}:{}", prefix, key))
+    }
 }
 
 /// Domain separator for accounts
-fn accounts_key(account_id: Uuid) -> String {
-    format!("accounts:{}", account_id)
+fn accounts_key(prefix: &str, account_id: Uuid) -> String {
+    prefixed_key(prefix, &format!("accounts:{}", account_id)).into_owned()
 }
 
 // TODO: Add descriptive errors inside the lua scripts!
@@ -143,6 +160,7 @@ pub struct RedisStoreBuilder {
     poll_interval: u64,
     /// Connector's ILP Address. Used to insert `Child` accounts as
     node_ilp_address: Address,
+    db_prefix: String,
 }
 
 impl RedisStoreBuilder {
@@ -153,6 +171,7 @@ impl RedisStoreBuilder {
             secret,
             poll_interval: DEFAULT_POLL_INTERVAL,
             node_ilp_address: DEFAULT_ILP_ADDRESS.clone(),
+            db_prefix: DEFAULT_DB_PREFIX.to_string(),
         }
     }
 
@@ -167,6 +186,14 @@ impl RedisStoreBuilder {
         self.poll_interval = poll_interval;
         self
     }
+
+    /// Sets the redis db prefix that will be used for top level keys for this node
+   /// It can be used if there is a need for the same redis db to be shared by multiple nodes
+    pub fn with_db_prefix(&mut self, prefix: &str) -> &mut Self {
+        self.db_prefix = prefix.to_string();
+        self
+    }
+
 
     /// Connects to the Redis Store
     ///
@@ -197,7 +224,7 @@ impl RedisStoreBuilder {
         // found, use the builder's provided address (local.host) or the
         // one we decided to override it with
         let address: Option<String> = connection
-            .get(PARENT_ILP_KEY)
+            .get(&*prefixed_key(&self.db_prefix, PARENT_ILP_KEY))
             .map_err(|err| {
                 error!(
                     "Error checking whether we have a parent configured: {:?}",
@@ -222,6 +249,7 @@ impl RedisStoreBuilder {
             routes: Arc::new(RwLock::new(Arc::new(HashMap::new()))),
             encryption_key: Arc::new(encryption_key),
             decryption_key: Arc::new(decryption_key),
+            db_prefix: self.db_prefix.clone(),
         };
 
         // Poll for routing table updates
@@ -230,6 +258,7 @@ impl RedisStoreBuilder {
         let redis_info = store.connection.redis_info.clone();
         let routing_table = store.routes.clone();
 
+        let db_prefix  = self.db_prefix.clone();
         let poll_routes = async move {
             let mut interval = tokio::time::interval(Duration::from_millis(poll_interval));
             // Irrefutable while pattern, can we do something here?
@@ -242,6 +271,7 @@ impl RedisStoreBuilder {
                             redis_info: redis_info.clone(),
                         },
                         routing_table.clone(),
+                        &db_prefix,
                     )
                     .map_err(|err| error!("{}", err))
                     .await;
@@ -260,12 +290,13 @@ impl RedisStoreBuilder {
         // not yet supporting asynchronous subscriptions (see https://github.com/mitsuhiko/redis-rs/issues/183).
         let subscriptions_clone = store.subscriptions.clone();
         let payment_publisher = store.payment_publisher.clone();
+        let db_prefix  = prefixed_key(&self.db_prefix, STREAM_NOTIFICATIONS_PREFIX).into_owned();
         std::thread::spawn(move || {
             #[allow(clippy::cognitive_complexity)]
             let sub_status =
                 sub_connection.psubscribe::<_, _, Vec<String>>(&["*"], move |msg| {
                     let channel_name = msg.get_channel_name();
-                    if let Some(suffix) = channel_name.strip_prefix(STREAM_NOTIFICATIONS_PREFIX) {
+                    if let Some(suffix) = channel_name.strip_prefix(&db_prefix) {
                         if let Ok(account_id) = Uuid::from_str(&suffix) {
                             let message: PaymentNotification = match serde_json::from_slice(msg.get_payload_bytes()) {
                                 Ok(s) => s,
@@ -339,13 +370,15 @@ pub struct RedisStore {
     encryption_key: Arc<Secret<EncryptionKey>>,
     /// Decryption Key to provide cleartext data to users
     decryption_key: Arc<Secret<DecryptionKey>>,
+    /// Prefix for all top level keys. This enables multiple nodes to use the same db instance.
+    db_prefix: String,
 }
 
 impl RedisStore {
     /// Gets all the account ids from Redis
     async fn get_all_accounts_ids(&self) -> Result<Vec<Uuid>, NodeStoreError> {
         let mut connection = self.connection.clone();
-        let account_ids: Vec<RedisAccountId> = connection.smembers("accounts").await?;
+        let account_ids: Vec<RedisAccountId> = connection.smembers(&*prefixed_key(&self.db_prefix, ACCOUNTS_KEY)).await?;
         Ok(account_ids.iter().map(|rid| rid.0).collect())
     }
 
@@ -356,15 +389,15 @@ impl RedisStore {
         encrypted: &AccountWithEncryptedTokens,
     ) -> Result<(), NodeStoreError> {
         let account = &encrypted.account;
-        let id = accounts_key(account.id);
+        let id = accounts_key(&self.db_prefix, account.id);
         let mut connection = self.connection.clone();
         let routing_table = self.routes.clone();
         // Check that there isn't already an account with values that MUST be unique
         let mut pipe = redis_crate::pipe();
-        pipe.exists(accounts_key(account.id));
-        pipe.hexists("usernames", account.username().as_ref());
+        pipe.exists(&id);
+        pipe.hexists(&*prefixed_key(&self.db_prefix, USERNAMES_KEY), account.username().as_ref());
         if account.routing_relation == RoutingRelation::Parent {
-            pipe.exists(PARENT_ILP_KEY);
+            pipe.exists(&*prefixed_key(&self.db_prefix, PARENT_ILP_KEY));
         }
 
         let results: Vec<bool> = pipe.query_async(&mut connection).await?;
@@ -380,11 +413,11 @@ impl RedisStore {
         pipe.atomic();
 
         // Add the account key to the list of accounts
-        pipe.sadd("accounts", RedisAccountId(account.id)).ignore();
+        pipe.sadd(&*prefixed_key(&self.db_prefix, ACCOUNTS_KEY), RedisAccountId(account.id)).ignore();
 
         // Save map for Username -> Account ID
         pipe.hset(
-            "usernames",
+            &*prefixed_key(&self.db_prefix, USERNAMES_KEY),
             account.username().as_ref(),
             RedisAccountId(account.id),
         )
@@ -395,23 +428,23 @@ impl RedisStore {
             .ignore();
 
         if account.should_send_routes() {
-            pipe.sadd("send_routes_to", RedisAccountId(account.id))
+            pipe.sadd(&*prefixed_key(&self.db_prefix, SEND_ROUTES_KEY), RedisAccountId(account.id))
                 .ignore();
         }
 
         if account.should_receive_routes() {
-            pipe.sadd("receive_routes_from", RedisAccountId(account.id))
+            pipe.sadd(&*prefixed_key(&self.db_prefix, RECEIVE_ROUTES_FROM_KEY), RedisAccountId(account.id))
                 .ignore();
         }
 
         if account.ilp_over_btp_url.is_some() {
-            pipe.sadd("btp_outgoing", RedisAccountId(account.id))
+            pipe.sadd(&*prefixed_key(&self.db_prefix, BPT_OUTGOING), RedisAccountId(account.id))
                 .ignore();
         }
 
         // Add route to routing table
         pipe.hset(
-            ROUTES_KEY,
+            &*prefixed_key(&self.db_prefix, ROUTES_KEY),
             account.ilp_address.as_bytes(),
             RedisAccountId(account.id),
         )
@@ -424,7 +457,7 @@ impl RedisStore {
         // had to check for the existence of a parent
         pipe.query_async(&mut connection).await?;
 
-        update_routes(connection, routing_table).await?;
+        update_routes(connection, routing_table,  &self.db_prefix).await?;
         debug!(
             "Inserted account {} (ILP address: {})",
             account.id, account.ilp_address
@@ -448,7 +481,7 @@ impl RedisStore {
         // TODO: Do not allow this update to happen if
         // AccountDetails.RoutingRelation == Parent and parent is
         // already set
-        let exists: bool = connection.exists(accounts_key(account.id)).await?;
+        let exists: bool = connection.exists(accounts_key(&self.db_prefix, account.id)).await?;
 
         if !exists {
             warn!(
@@ -461,39 +494,39 @@ impl RedisStore {
         pipe.atomic();
 
         // Add the account key to the list of accounts
-        pipe.sadd("accounts", RedisAccountId(account.id)).ignore();
+        pipe.sadd(&*prefixed_key(&self.db_prefix, ACCOUNTS_KEY), RedisAccountId(account.id)).ignore();
 
         // Set account details
         pipe.cmd("HMSET")
-            .arg(accounts_key(account.id))
+            .arg(accounts_key(&self.db_prefix, account.id))
             .arg(encrypted)
             .ignore();
 
         if account.should_send_routes() {
-            pipe.sadd("send_routes_to", RedisAccountId(account.id))
+            pipe.sadd(&*prefixed_key(&self.db_prefix, SEND_ROUTES_KEY), RedisAccountId(account.id))
                 .ignore();
         }
 
         if account.should_receive_routes() {
-            pipe.sadd("receive_routes_from", RedisAccountId(account.id))
+            pipe.sadd(&*prefixed_key(&self.db_prefix, RECEIVE_ROUTES_FROM_KEY), RedisAccountId(account.id))
                 .ignore();
         }
 
         if account.ilp_over_btp_url.is_some() {
-            pipe.sadd("btp_outgoing", RedisAccountId(account.id))
+            pipe.sadd(&*prefixed_key(&self.db_prefix, BPT_OUTGOING), RedisAccountId(account.id))
                 .ignore();
         }
 
         // Add route to routing table
         pipe.hset(
-            ROUTES_KEY,
+            &*prefixed_key(&self.db_prefix, ROUTES_KEY),
             account.ilp_address.to_bytes().to_vec(),
             RedisAccountId(account.id),
         )
         .ignore();
 
         pipe.query_async(&mut connection).await?;
-        update_routes(connection, routing_table).await?;
+        update_routes(connection, routing_table, &self.db_prefix).await?;
         debug!(
             "Inserted account {} (id: {}, ILP address: {})",
             account.username, account.id, account.ilp_address
@@ -511,17 +544,18 @@ impl RedisStore {
         let mut pipe = redis_crate::pipe();
         pipe.atomic();
 
+        let accounts_key = accounts_key(&self.db_prefix, id);
         if let Some(ref endpoint) = settings.ilp_over_btp_url {
-            pipe.hset(accounts_key(id), "ilp_over_btp_url", endpoint);
+            pipe.hset(&accounts_key, "ilp_over_btp_url", endpoint);
         }
 
         if let Some(ref endpoint) = settings.ilp_over_http_url {
-            pipe.hset(accounts_key(id), "ilp_over_http_url", endpoint);
+            pipe.hset(&accounts_key, "ilp_over_http_url", endpoint);
         }
 
         if let Some(ref token) = settings.ilp_over_btp_outgoing_token {
             pipe.hset(
-                accounts_key(id),
+                &accounts_key,
                 "ilp_over_btp_outgoing_token",
                 token.as_ref(),
             );
@@ -529,7 +563,7 @@ impl RedisStore {
 
         if let Some(ref token) = settings.ilp_over_http_outgoing_token {
             pipe.hset(
-                accounts_key(id),
+                &accounts_key,
                 "ilp_over_http_outgoing_token",
                 token.as_ref(),
             );
@@ -537,7 +571,7 @@ impl RedisStore {
 
         if let Some(ref token) = settings.ilp_over_btp_incoming_token {
             pipe.hset(
-                accounts_key(id),
+                &accounts_key,
                 "ilp_over_btp_incoming_token",
                 token.as_ref(),
             );
@@ -545,14 +579,14 @@ impl RedisStore {
 
         if let Some(ref token) = settings.ilp_over_http_incoming_token {
             pipe.hset(
-                accounts_key(id),
+                &accounts_key,
                 "ilp_over_http_incoming_token",
                 token.as_ref(),
             );
         }
 
         if let Some(settle_threshold) = settings.settle_threshold {
-            pipe.hset(accounts_key(id), "settle_threshold", settle_threshold);
+            pipe.hset(&accounts_key, "settle_threshold", settle_threshold);
         }
 
         if let Some(settle_to) = settings.settle_to {
@@ -562,7 +596,7 @@ impl RedisStore {
                     CreateAccountError::ParamTooLarge("settle_to".to_owned()),
                 ));
             }
-            pipe.hset(accounts_key(id), "settle_to", settle_to);
+            pipe.hset(&accounts_key, "settle_to", settle_to);
         }
 
         pipe.query_async(&mut self.connection.clone()).await?;
@@ -577,6 +611,8 @@ impl RedisStore {
         id: Uuid,
     ) -> Result<AccountWithEncryptedTokens, NodeStoreError> {
         let mut accounts: Vec<AccountWithEncryptedTokens> = LOAD_ACCOUNTS
+            .arg(&*prefixed_key(&self.db_prefix, ACCOUNTS_KEY))
+            .arg(&*prefixed_key(&self.db_prefix, SETTLEMENT_ENGINES_KEY))
             .arg(RedisAccountId(id))
             .invoke_async(&mut self.connection.clone())
             .await?;
@@ -596,34 +632,33 @@ impl RedisStore {
         let mut pipe = redis_crate::pipe();
         pipe.atomic();
 
-        pipe.srem("accounts", RedisAccountId(account.id)).ignore();
-
-        pipe.del(accounts_key(account.id)).ignore();
-        pipe.hdel("usernames", account.username().as_ref()).ignore();
+        pipe.srem(&*prefixed_key(&self.db_prefix, ACCOUNTS_KEY), RedisAccountId(account.id)).ignore();
+        pipe.del(&*accounts_key(&self.db_prefix, account.id)).ignore();
+        pipe.hdel(&*prefixed_key(&self.db_prefix, USERNAMES_KEY), account.username().as_ref()).ignore();
 
         if account.should_send_routes() {
-            pipe.srem("send_routes_to", RedisAccountId(account.id))
+            pipe.srem(&*prefixed_key(&self.db_prefix, SEND_ROUTES_KEY), RedisAccountId(account.id))
                 .ignore();
         }
 
         if account.should_receive_routes() {
-            pipe.srem("receive_routes_from", RedisAccountId(account.id))
+            pipe.srem(&*prefixed_key(&self.db_prefix, RECEIVE_ROUTES_FROM_KEY), RedisAccountId(account.id))
                 .ignore();
         }
 
         if account.ilp_over_btp_url.is_some() {
-            pipe.srem("btp_outgoing", RedisAccountId(account.id))
+            pipe.srem(&*prefixed_key(&self.db_prefix, BPT_OUTGOING), RedisAccountId(account.id))
                 .ignore();
         }
 
-        pipe.hdel(ROUTES_KEY, account.ilp_address.to_bytes().to_vec())
+        pipe.hdel(&*prefixed_key(&self.db_prefix, ROUTES_KEY), account.ilp_address.to_bytes().to_vec())
             .ignore();
 
-        pipe.del(uncredited_amount_key(id));
+        pipe.del(uncredited_amount_key(&self.db_prefix, id));
 
         let mut connection = self.connection.clone();
         pipe.query_async(&mut connection).await?;
-        update_routes(connection, self.routes.clone()).await?;
+        update_routes(connection, self.routes.clone(), &self.db_prefix).await?;
         debug!("Deleted account {}", account.id);
         Ok(encrypted)
     }
@@ -640,6 +675,9 @@ impl AccountStore for RedisStore {
     ) -> Result<Vec<Account>, AccountStoreError> {
         let num_accounts = account_ids.len();
         let mut script = LOAD_ACCOUNTS.prepare_invoke();
+        script.arg(&*prefixed_key(&self.db_prefix, ACCOUNTS_KEY));
+        script.arg(&*prefixed_key(&self.db_prefix, SETTLEMENT_ENGINES_KEY));
+
         for id in account_ids.iter() {
             script.arg(id.to_string());
         }
@@ -672,7 +710,7 @@ impl AccountStore for RedisStore {
         let id: Option<RedisAccountId> = self
             .connection
             .clone()
-            .hget("usernames", username.as_ref())
+            .hget(&*prefixed_key(&self.db_prefix, USERNAMES_KEY), username.as_ref())
             .await?;
         match id {
             Some(rid) => Ok(rid.0),
@@ -721,7 +759,7 @@ impl StreamNotificationsStore for RedisStore {
                 message, account_id
             );
             // https://github.com/rust-lang/rust/issues/64960#issuecomment-544219926
-            let published_args = format!("{}{}", STREAM_NOTIFICATIONS_PREFIX, account_id.clone());
+            let published_args = format!("{}{}", prefixed_key(&self_clone.db_prefix, STREAM_NOTIFICATIONS_PREFIX), account_id.clone());
             redis_crate::cmd("PUBLISH")
                 .arg(published_args)
                 .arg(message)
@@ -746,7 +784,7 @@ impl BalanceStore for RedisStore {
         let values: Vec<i64> = self
             .connection
             .clone()
-            .hget(accounts_key(account_id), &["balance", "prepaid_amount"])
+            .hget(accounts_key(&self.db_prefix, account_id), &["balance", "prepaid_amount"])
             .await?;
 
         let balance = values[0];
@@ -765,6 +803,7 @@ impl BalanceStore for RedisStore {
         }
 
         let balance: i64 = PROCESS_PREPARE
+            .arg(&*prefixed_key(&self.db_prefix, ACCOUNTS_KEY))
             .arg(RedisAccountId(from_account_id))
             .arg(incoming_amount)
             .invoke_async(&mut self.connection.clone())
@@ -783,6 +822,7 @@ impl BalanceStore for RedisStore {
         outgoing_amount: u64,
     ) -> Result<(i64, u64), BalanceStoreError> {
         let (balance, amount_to_settle): (i64, u64) = PROCESS_FULFILL
+            .arg(&*prefixed_key(&self.db_prefix, ACCOUNTS_KEY))
             .arg(RedisAccountId(to_account_id))
             .arg(outgoing_amount)
             .invoke_async(&mut self.connection.clone())
@@ -808,6 +848,7 @@ impl BalanceStore for RedisStore {
         }
 
         let balance: i64 = PROCESS_REJECT
+            .arg(&*prefixed_key(&self.db_prefix, ACCOUNTS_KEY))
             .arg(RedisAccountId(from_account_id))
             .arg(incoming_amount)
             .invoke_async(&mut self.connection.clone())
@@ -866,6 +907,8 @@ impl BtpStore for RedisStore {
         // TODO cache the result so we don't hit redis for every packet (is that
         // necessary if redis is often used as a cache?)
         let account: Option<AccountWithEncryptedTokens> = ACCOUNT_FROM_USERNAME
+            .arg(&*prefixed_key(&self.db_prefix, USERNAMES_KEY))
+            .arg(&*prefixed_key(&self.db_prefix, ACCOUNTS_KEY))
             .arg(username.as_ref())
             .invoke_async(&mut self.connection.clone())
             .await?;
@@ -898,7 +941,7 @@ impl BtpStore for RedisStore {
 
     async fn get_btp_outgoing_accounts(&self) -> Result<Vec<Self::Account>, BtpStoreError> {
         let account_ids: Vec<RedisAccountId> =
-            self.connection.clone().smembers("btp_outgoing").await?;
+            self.connection.clone().smembers(&*prefixed_key(&self.db_prefix, BPT_OUTGOING)).await?;
         let account_ids: Vec<Uuid> = account_ids.into_iter().map(|id| id.0).collect();
 
         if account_ids.is_empty() {
@@ -923,6 +966,8 @@ impl HttpStore for RedisStore {
     ) -> Result<Self::Account, HttpStoreError> {
         // TODO make sure it can't do script injection!
         let account: Option<AccountWithEncryptedTokens> = ACCOUNT_FROM_USERNAME
+            .arg(&*prefixed_key(&self.db_prefix, USERNAMES_KEY))
+            .arg(&*prefixed_key(&self.db_prefix, ACCOUNTS_KEY))
             .arg(username.as_ref())
             .invoke_async(&mut self.connection.clone())
             .await?;
@@ -1051,6 +1096,8 @@ impl NodeStore for RedisStore {
         let account_ids = self.get_all_accounts_ids().await?;
 
         let mut script = LOAD_ACCOUNTS.prepare_invoke();
+        script.arg(&*prefixed_key(&self.db_prefix, ACCOUNTS_KEY));
+        script.arg(&*prefixed_key(&self.db_prefix, SETTLEMENT_ENGINES_KEY));
         for id in account_ids.iter() {
             script.arg(id.to_string());
         }
@@ -1080,7 +1127,7 @@ impl NodeStore for RedisStore {
             HashSet::from_iter(routes.iter().map(|(_prefix, account_id)| account_id));
         let mut pipe = redis_crate::pipe();
         for account_id in accounts {
-            pipe.exists(accounts_key((*account_id).0));
+            pipe.exists(accounts_key(&self.db_prefix, (*account_id).0));
         }
 
         let routing_table = self.routes.clone();
@@ -1095,14 +1142,14 @@ impl NodeStore for RedisStore {
 
         let mut pipe = redis_crate::pipe();
         pipe.atomic()
-            .del(STATIC_ROUTES_KEY)
+            .del(&*prefixed_key(&self.db_prefix, STATIC_ROUTES_KEY))
             .ignore()
-            .hset_multiple(STATIC_ROUTES_KEY, &routes)
+            .hset_multiple(&*prefixed_key(&self.db_prefix, STATIC_ROUTES_KEY), &routes)
             .ignore();
 
         pipe.query_async(&mut connection).await?;
 
-        update_routes(connection, routing_table).await?;
+        update_routes(connection, routing_table, &self.db_prefix).await?;
         Ok(())
     }
 
@@ -1114,7 +1161,7 @@ impl NodeStore for RedisStore {
         let routing_table = self.routes.clone();
         let mut connection = self.connection.clone();
 
-        let exists: bool = connection.exists(accounts_key(account_id)).await?;
+        let exists: bool = connection.exists(accounts_key(&self.db_prefix, account_id)).await?;
         if !exists {
             error!(
                 "Cannot set static route for prefix: {} because account {} does not exist",
@@ -1124,10 +1171,10 @@ impl NodeStore for RedisStore {
         }
 
         connection
-            .hset(STATIC_ROUTES_KEY, prefix, RedisAccountId(account_id))
+            .hset(&*prefixed_key(&self.db_prefix, STATIC_ROUTES_KEY), prefix, RedisAccountId(account_id))
             .await?;
 
-        update_routes(connection, routing_table).await?;
+        update_routes(connection, routing_table, &self.db_prefix).await?;
 
         Ok(())
     }
@@ -1136,7 +1183,7 @@ impl NodeStore for RedisStore {
         let routing_table = self.routes.clone();
         // TODO replace this with a lua script to do both calls at once
         let mut connection = self.connection.clone();
-        let exists: bool = connection.exists(accounts_key(account_id)).await?;
+        let exists: bool = connection.exists(accounts_key(&self.db_prefix, account_id)).await?;
         if !exists {
             error!(
                 "Cannot set default route because account {} does not exist",
@@ -1146,10 +1193,10 @@ impl NodeStore for RedisStore {
         }
 
         connection
-            .set(DEFAULT_ROUTE_KEY, RedisAccountId(account_id))
+            .set(&*prefixed_key(&self.db_prefix, DEFAULT_ROUTE_KEY), RedisAccountId(account_id))
             .await?;
         debug!("Set default route to account id: {}", account_id);
-        update_routes(connection, routing_table).await?;
+        update_routes(connection, routing_table, &self.db_prefix).await?;
         Ok(())
     }
 
@@ -1164,7 +1211,7 @@ impl NodeStore for RedisStore {
             .collect();
         debug!("Setting settlement engines to {:?}", asset_to_url_map);
         connection
-            .hset_multiple(SETTLEMENT_ENGINES_KEY, &asset_to_url_map)
+            .hset_multiple(&*prefixed_key(&self.db_prefix, SETTLEMENT_ENGINES_KEY), &asset_to_url_map)
             .await?;
         Ok(())
     }
@@ -1176,7 +1223,7 @@ impl NodeStore for RedisStore {
         let url: Option<String> = self
             .connection
             .clone()
-            .hget(SETTLEMENT_ENGINES_KEY, asset_code)
+            .hget(&*prefixed_key(&self.db_prefix, SETTLEMENT_ENGINES_KEY), asset_code)
             .await?;
         if let Some(url) = url {
             match Url::parse(url.as_str()) {
@@ -1209,7 +1256,7 @@ impl AddressStore for RedisStore {
 
         // Save it to Redis
         connection
-            .set(PARENT_ILP_KEY, ilp_address.as_bytes())
+            .set(&*prefixed_key(&self.db_prefix, PARENT_ILP_KEY), ilp_address.as_bytes())
             .await?;
 
         let accounts = self.get_all_accounts().await?;
@@ -1233,7 +1280,7 @@ impl AddressStore for RedisStore {
                 && account.routing_relation() != RoutingRelation::Peer
             {
                 // remove the old route
-                pipe.hdel(ROUTES_KEY, account.ilp_address.as_bytes())
+                pipe.hdel(&*prefixed_key(&self.db_prefix, ROUTES_KEY), account.ilp_address.as_bytes())
                     .ignore();
 
                 // if the username of the account ends with the
@@ -1247,30 +1294,30 @@ impl AddressStore for RedisStore {
                         .unwrap()
                 };
                 pipe.hset(
-                    accounts_key(account.id()),
+                    accounts_key(&self.db_prefix, account.id()),
                     "ilp_address",
                     new_ilp_address.as_bytes(),
                 )
-                .ignore();
+                    .ignore();
 
                 pipe.hset(
-                    ROUTES_KEY,
+                    &*prefixed_key(&self.db_prefix, ROUTES_KEY),
                     new_ilp_address.as_bytes(),
                     RedisAccountId(account.id()),
                 )
-                .ignore();
+                    .ignore();
             }
         }
 
         pipe.query_async(&mut connection.clone()).await?;
-        update_routes(connection, routing_table).await?;
+        update_routes(connection, routing_table, &self.db_prefix).await?;
         Ok(())
     }
 
     async fn clear_ilp_address(&self) -> Result<(), AddressStoreError> {
         self.connection
             .clone()
-            .del(PARENT_ILP_KEY)
+            .del(&*prefixed_key(&self.db_prefix, PARENT_ILP_KEY))
             .map_err(|err| AddressStoreError::Other(Box::new(err)))
             .await?;
 
@@ -1296,7 +1343,7 @@ impl CcpRoutingStore for RedisStore {
         ignore_accounts: Vec<Uuid>,
     ) -> Result<Vec<Account>, CcpRoutingStoreError> {
         let account_ids: Vec<RedisAccountId> =
-            self.connection.clone().smembers("send_routes_to").await?;
+            self.connection.clone().smembers(&*prefixed_key(&self.db_prefix, SEND_ROUTES_KEY)).await?;
         let account_ids: Vec<Uuid> = account_ids
             .into_iter()
             .map(|id| id.0)
@@ -1316,7 +1363,7 @@ impl CcpRoutingStore for RedisStore {
         let account_ids: Vec<RedisAccountId> = self
             .connection
             .clone()
-            .smembers("receive_routes_from")
+            .smembers(&*prefixed_key(&self.db_prefix, RECEIVE_ROUTES_FROM_KEY))
             .await?;
         let account_ids: Vec<Uuid> = account_ids.into_iter().map(|id| id.0).collect();
 
@@ -1332,7 +1379,7 @@ impl CcpRoutingStore for RedisStore {
         &self,
     ) -> Result<(RoutingTable<Account>, RoutingTable<Account>), CcpRoutingStoreError> {
         let static_routes: Vec<(String, RedisAccountId)> =
-            self.connection.clone().hgetall(STATIC_ROUTES_KEY).await?;
+            self.connection.clone().hgetall(&*prefixed_key(&self.db_prefix, STATIC_ROUTES_KEY)).await?;
 
         let accounts = self.get_all_accounts().await?;
 
@@ -1377,15 +1424,15 @@ impl CcpRoutingStore for RedisStore {
         // Save routes to Redis
         let mut pipe = redis_crate::pipe();
         pipe.atomic()
-            .del(ROUTES_KEY)
+            .del(&*prefixed_key(&self.db_prefix, ROUTES_KEY))
             .ignore()
-            .hset_multiple(ROUTES_KEY, &routes)
+            .hset_multiple(&*prefixed_key(&self.db_prefix, ROUTES_KEY), &routes)
             .ignore();
 
         pipe.query_async(&mut connection).await?;
         trace!("Saved {} routes to Redis", num_routes);
 
-        update_routes(connection, self.routes.clone()).await?;
+        update_routes(connection, self.routes.clone(), &self.db_prefix).await?;
         Ok(())
     }
 }
@@ -1409,9 +1456,9 @@ impl RateLimitStore for RedisStore {
 
             if let Some(limit) = account.packets_per_minute_limit {
                 let limit = limit - 1;
-                let packets_limit = format!("limit:packets:{}", account.id);
+                let packets_limit = prefixed_key(&self.db_prefix, &format!("limit:packets:{}", account.id)).into_owned();
                 pipe.cmd("CL.THROTTLE")
-                    .arg(packets_limit)
+                    .arg(&packets_limit)
                     .arg(limit)
                     .arg(limit)
                     .arg(60)
@@ -1420,9 +1467,9 @@ impl RateLimitStore for RedisStore {
 
             if let Some(limit) = account.amount_per_minute_limit {
                 let limit = limit - 1;
-                let throughput_limit = format!("limit:throughput:{}", account.id);
+                let throughput_limit = prefixed_key(&self.db_prefix, &format!("limit:throughput:{}", account.id)).into_owned();
                 pipe.cmd("CL.THROTTLE")
-                    .arg(throughput_limit)
+                    .arg(&throughput_limit)
                     // TODO allow separate configuration for burst limit
                     .arg(limit)
                     .arg(limit)
@@ -1465,9 +1512,9 @@ impl RateLimitStore for RedisStore {
     ) -> Result<(), RateLimitError> {
         if let Some(limit) = account.amount_per_minute_limit {
             let limit = limit - 1;
-            let throughput_limit = format!("limit:throughput:{}", account.id);
+            let throughput_limit = prefixed_key(&self.db_prefix, &format!("limit:throughput:{}", account.id)).into_owned();
             cmd("CL.THROTTLE")
-                .arg(throughput_limit)
+                .arg(&throughput_limit)
                 .arg(limit)
                 .arg(limit)
                 .arg(60)
@@ -1490,7 +1537,7 @@ impl IdempotentStore for RedisStore {
     ) -> Result<Option<IdempotentData>, IdempotentStoreError> {
         let mut connection = self.connection.clone();
         let ret: HashMap<String, String> = connection
-            .hgetall(prefixed_idempotency_key(&idempotency_key))
+            .hgetall(prefixed_idempotency_key(&self.db_prefix, &idempotency_key))
             .await?;
 
         if let (Some(status_code), Some(data), Some(input_hash_slice)) = (
@@ -1522,7 +1569,7 @@ impl IdempotentStore for RedisStore {
         let mut connection = self.connection.clone();
         pipe.atomic()
             .cmd("HMSET") // cannot use hset_multiple since data and status_code have different types
-            .arg(&prefixed_idempotency_key(&idempotency_key))
+            .arg(&prefixed_idempotency_key(&self.db_prefix, &idempotency_key))
             .arg("status_code")
             .arg(status_code.as_u16())
             .arg("data")
@@ -1530,7 +1577,7 @@ impl IdempotentStore for RedisStore {
             .arg("input_hash")
             .arg(&input_hash)
             .ignore()
-            .expire(&prefixed_idempotency_key(&idempotency_key), 86400)
+            .expire(&prefixed_idempotency_key(&self.db_prefix, &idempotency_key), 86400)
             .ignore();
         pipe.query_async(&mut connection).await?;
 
@@ -1556,9 +1603,10 @@ impl SettlementStore for RedisStore {
     ) -> Result<(), SettlementStoreError> {
         let idempotency_key = idempotency_key.unwrap();
         let balance: i64 = PROCESS_INCOMING_SETTLEMENT
+            .arg(&*prefixed_key(&self.db_prefix, ACCOUNTS_KEY))
             .arg(RedisAccountId(account_id))
             .arg(amount)
-            .arg(idempotency_key)
+            .arg(&*prefixed_key(&self.db_prefix, idempotency_key.as_str()))
             .invoke_async(&mut self.connection.clone())
             .await?;
         trace!(
@@ -1581,6 +1629,7 @@ impl SettlementStore for RedisStore {
             settle_amount
         );
         let balance: i64 = REFUND_SETTLEMENT
+            .arg(&*prefixed_key(&self.db_prefix, ACCOUNTS_KEY))
             .arg(RedisAccountId(account_id))
             .arg(settle_amount)
             .invoke_async(&mut self.connection.clone())
@@ -1697,8 +1746,8 @@ impl LeftoversStore for RedisStore {
         let mut pipe = redis_crate::pipe();
         pipe.atomic();
         // get the amounts and instantly delete them
-        pipe.lrange(uncredited_amount_key(account_id.to_string()), 0, -1);
-        pipe.del(uncredited_amount_key(account_id.to_string()))
+        pipe.lrange(uncredited_amount_key(&self.db_prefix, account_id.to_string()), 0, -1);
+        pipe.del(uncredited_amount_key(&self.db_prefix, account_id.to_string()))
             .ignore();
 
         let amounts: Vec<AmountWithScale> = pipe.query_async(&mut self.connection.clone()).await?;
@@ -1725,7 +1774,7 @@ impl LeftoversStore for RedisStore {
         let mut connection = self.connection.clone();
         connection
             .rpush(
-                uncredited_amount_key(account_id),
+                uncredited_amount_key(&self.db_prefix, account_id),
                 AmountWithScale {
                     num: uncredited_settlement_amount.0,
                     scale: uncredited_settlement_amount.1,
@@ -1752,7 +1801,7 @@ impl LeftoversStore for RedisStore {
             self.connection
                 .clone()
                 .rpush(
-                    uncredited_amount_key(account_id),
+                    uncredited_amount_key(&self.db_prefix, account_id),
                     AmountWithScale {
                         num: precision_loss,
                         scale: std::cmp::max(local_scale, amount.1),
@@ -1771,7 +1820,7 @@ impl LeftoversStore for RedisStore {
         trace!("Clearing uncredited_settlement_amount {:?}", account_id);
         self.connection
             .clone()
-            .del(uncredited_amount_key(account_id))
+            .del(uncredited_amount_key(&self.db_prefix, account_id))
             .await?;
         Ok(())
     }
@@ -1785,11 +1834,12 @@ use futures::future::TryFutureExt;
 async fn update_routes(
     mut connection: RedisReconnect,
     routing_table: Arc<RwLock<Arc<HashMap<String, Uuid>>>>,
+    db_prefix: &str,
 ) -> Result<(), RedisError> {
     let mut pipe = redis_crate::pipe();
-    pipe.hgetall(ROUTES_KEY)
-        .hgetall(STATIC_ROUTES_KEY)
-        .get(DEFAULT_ROUTE_KEY);
+    pipe.hgetall(&*prefixed_key(db_prefix, ROUTES_KEY))
+        .hgetall(&*prefixed_key(db_prefix, STATIC_ROUTES_KEY))
+        .get(&*prefixed_key(db_prefix, DEFAULT_ROUTE_KEY));
     let (routes, static_routes, default_route): (RouteVec, RouteVec, Option<RedisAccountId>) =
         pipe.query_async(&mut connection).await?;
     trace!(

--- a/crates/interledger-store/src/redis/mod.rs
+++ b/crates/interledger-store/src/redis/mod.rs
@@ -933,6 +933,7 @@ impl BalanceStore for RedisStore {
         to_account_id: Uuid,
     ) -> Result<(i64, u64), BalanceStoreError> {
         let (balance, amount_to_settle): (i64, u64) = PROCESS_DELAYED_SETTLEMENT
+            .arg(&*prefixed_key(&self.db_prefix, ACCOUNTS_KEY))
             .arg(RedisAccountId(to_account_id))
             .invoke_async(&mut self.connection.clone())
             .await?;


### PR DESCRIPTION
The main use case to cover was to enable nodes to share the same redis db instance without braking the existing functionality. The proposed solution was to use different prefix for each node that want to share the db instance. This PR is enabling use of prefix, if provided, for redis in all db calls so that this functionality can be achieved. 

I have tested the functionality by running the examples from the `/examples` folder, and by  subscribing to various nodes with ws client to check the redis pub/sub as well.
With 2 nodes started, 1st one (node_a) without a prefix and a second one (node_b) with `test` prefix like: 
```
cargo run --bin ilp-node -- --ilp_address example.node_b \                                                                
  --secret_seed 1604966725982139900555208458637022875563691455429373719368053354 \
  --admin_auth_token admin-b \
  --redis_url redis://127.0.0.1:6379/ \
  --http_bind_address 127.0.0.1:8770 \
  --settlement_api_bind_address 127.0.0.1:8771 \
  --database_prefix test
```

I get expected functionality and the db looks like this:
```
127.0.0.1:6379> keys *
 1) "test:accounts:ad2e87ba-323a-42f2-8b5a-178550366f49"
 2) "routes:current"
 3) "usernames"
 4) "test:usernames"
 5) "test:accounts:7c9ad66e-80cd-4f0c-9cfd-d0584dfd832c"
 6) "accounts:41884c6c-a63e-4c85-8dd3-df04f36cee9e"
 7) "accounts"
 8) "test:routes:current"
 9) "accounts:ae910fb7-b31a-4e8b-97ab-d2d6d81af0d4"
```

So, in order to spin up different nodes that share the same db redis instance, they should be run with a `--database_prefix` argument provided, similar to how the node_b was spawn in the example. Each node should use a unique prefix for itself in order not to intervene with a data from other nodes.

We had this use case and we tried it on our fork, seems to work fine. Thought it would be useful for the main implementation as well. Let us know what you think :)