### PR TITLE
Update config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/rust
-    resource_class: large
+      - image: circleci/rust:1.49
+    resource_class: medium
     environment:
       CARGO_HOME: /home/circleci/.cargo
     steps:


### PR DESCRIPTION
This PR:

1. Pins a specific Rust version of the CircleCI image (1.49 which is the stable at the time of this PR)
2. Reduces the resource class to medium to get rid of the warning on the CircleCI UI.

![image](https://user-images.githubusercontent.com/106148/104047732-1eeeea00-51b0-11eb-8e95-4af1aa67b063.png)
