### PR TITLE
Docker releases on gh actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,9 +37,14 @@ jobs:
           ILP_NODE_CLI_IMAGE_TAG=$(./.circleci/release/get_docker_image_tag.sh ilp-cli ${TAG})
           echo ::set-output name=ilp_node_cli_image_tag::${ILP_NODE_CLI_IMAGE_TAG}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
 #   Build and push ilp-node in the case of push to master or tag with 'ilp-node-*'
 #   todo: this is a dry-run now, change to push = true when tested
-#   todo: change to appropriate repo
       - name: Build ilp-node
         if: startsWith(steps.get_tag.outputs.tag, 'ilp-cli-') != true
         uses: docker/build-push-action@v2
@@ -47,30 +52,28 @@ jobs:
           context: .
           file: ./docker/ilp-node.dockerfile
           push: false
-          tags: papadoubi/ilp-node:${{steps.tags.outputs.ilp_node_image_tag}}
+          tags: interledgerrs/ilp-node:${{steps.tags.outputs.ilp_node_image_tag}}
           build-args: |
             CARGO_BUILD_OPTION=--release
             RUST_BIN_DIR_NAME=release
 
 #   Build and push together with ilp-node in the case of push to master or tag with 'ilp-node-*'
 #   todo: this is a dry-run now, change to push = true when tested
-#   todo: change to appropriate repo
-        - name: Build ilp-tesnet
-          if: startsWith(steps.get_tag.outputs.tag, 'ilp-cli-') != true
-          uses: docker/build-push-action@v2
-          with:
-            file: ./docker/Dockerfile
-            push: false
-            tags: papadoubi/testnet-bundle:${{steps.tags.outputs.ilp_node_image_tag}}
+      - name: Build ilp-tesnet
+        if: startsWith(steps.get_tag.outputs.tag, 'ilp-cli-') != true
+        uses: docker/build-push-action@v2
+        with:
+          file: ./docker/Dockerfile
+          push: false
+          tags: interledgerrs/testnet-bundle:${{steps.tags.outputs.ilp_node_image_tag}}
 
 #  Build and push in the case of push to master or tag with `ilp-cli-*`
 #   todo: this is a dry-run now, change to push = true when tested
-#   todo: change to appropriate repo
-        - name: Build ilp-cli
-          if: startsWith(steps.get_tag.outputs.tag, 'ilp-node-') != true
-          uses: docker/build-push-action@v2
-          with:
-            file: ./docker/ilp-cli.dockerfile
-            push: false
-            tags: papadoubi/ilp-cli:${{steps.tags.outputs.ilp_node_image_tag}}
+      - name: Build ilp-cli
+        if: startsWith(steps.get_tag.outputs.tag, 'ilp-node-') != true
+        uses: docker/build-push-action@v2
+        with:
+          file: ./docker/ilp-cli.dockerfile
+          push: false
+          tags: interledgerrs/ilp-cli:${{steps.tags.outputs.ilp_node_image_tag}}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,76 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - 'ilp-node-*'
+      - 'ilp-cli-*'
+
+jobs:
+  update-docker-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y redis-server redis-tools libssl-dev
+
+      - name: Install node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 'v12.18.4'
+
+      - name: Get tags
+        id: tags
+        run: |
+          TAG=${GITHUB_REF/refs\/tags\//}
+          echo ::set-output name=tag::${TAG}
+          ILP_NODE_IMAGE_TAG=$(./.circleci/release/get_docker_image_tag.sh ilp-node ${TAG})
+          echo ::set-output name=ilp_node_image_tag::${ILP_NODE_IMAGE_TAG}
+          echo "ilp node image tag: ${ILP_NODE_IMAGE_TAG}"
+
+          ILP_NODE_CLI_IMAGE_TAG=$(./.circleci/release/get_docker_image_tag.sh ilp-cli ${TAG})
+          echo ::set-output name=ilp_node_cli_image_tag::${ILP_NODE_CLI_IMAGE_TAG}
+
+#   Build and push ilp-node in the case of push to master or tag with 'ilp-node-*'
+#   todo: this is a dry-run now, change to push = true when tested
+#   todo: change to appropriate repo
+      - name: Build ilp-node
+        if: startsWith(steps.get_tag.outputs.tag, 'ilp-cli-') != true
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./docker/ilp-node.dockerfile
+          push: false
+          tags: papadoubi/ilp-node:${{steps.tags.outputs.ilp_node_image_tag}}
+          build-args: |
+            CARGO_BUILD_OPTION=--release
+            RUST_BIN_DIR_NAME=release
+
+#   Build and push together with ilp-node in the case of push to master or tag with 'ilp-node-*'
+#   todo: this is a dry-run now, change to push = true when tested
+#   todo: change to appropriate repo
+        - name: Build ilp-tesnet
+          if: startsWith(steps.get_tag.outputs.tag, 'ilp-cli-') != true
+          uses: docker/build-push-action@v2
+          with:
+            file: ./docker/Dockerfile
+            push: false
+            tags: papadoubi/testnet-bundle:${{steps.tags.outputs.ilp_node_image_tag}}
+
+#  Build and push in the case of push to master or tag with `ilp-cli-*`
+#   todo: this is a dry-run now, change to push = true when tested
+#   todo: change to appropriate repo
+        - name: Build ilp-cli
+          if: startsWith(steps.get_tag.outputs.tag, 'ilp-node-') != true
+          uses: docker/build-push-action@v2
+          with:
+            file: ./docker/ilp-cli.dockerfile
+            push: false
+            tags: papadoubi/ilp-cli:${{steps.tags.outputs.ilp_node_image_tag}}
+


### PR DESCRIPTION
Docker releases that mimic the same behavior as before. Docker releases are triggered on:
- push to master
- tag on any branch with `ilp-node-|ilp-cli-` prefix

Tag is derived same as before, using the same scripts.
This is only the dry-run and will not push images to dockerhub.