### PR TITLE
Custom (de)serialization code cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,7 +1305,6 @@ dependencies = [
  "bytes 0.5.6",
  "chrono",
  "criterion",
- "hex",
  "once_cell",
  "regex",
  "serde",

--- a/crates/interledger-btp/src/oer.rs
+++ b/crates/interledger-btp/src/oer.rs
@@ -7,7 +7,7 @@ use std::io::{self, Read, Result, Write};
 const HIGH_BIT: u8 = 0x80;
 const LOWER_SEVEN_BITS: u8 = 0x7f;
 
-// TODO test traits
+// FIXME: interledger-packet already has a fixed version of this trait, this is extra
 pub trait ReadOerExt: Read + ReadBytesExt + Debug {
     #[inline]
     fn read_var_octet_string(&mut self) -> Result<Vec<u8>> {

--- a/crates/interledger-btp/src/oer.rs
+++ b/crates/interledger-btp/src/oer.rs
@@ -46,7 +46,7 @@ pub trait WriteOerExt: Write + WriteBytesExt + Debug {
     fn write_var_octet_string(&mut self, string: &[u8]) -> Result<()> {
         let length = string.len();
 
-        if length < 127 {
+        if length < 128 {
             self.write_u8(length as u8)?;
         } else {
             let bit_length_of_length = format!("{:b}", length).chars().count();

--- a/crates/interledger-packet/Cargo.toml
+++ b/crates/interledger-packet/Cargo.toml
@@ -12,7 +12,6 @@ byteorder = { version = "1.3.2", default-features = false }
 bytes05 = { package = "bytes", version = "0.5", default-features = false, features = ["serde"] }
 bytes = { version = "0.4.12", default-features = false, features = ["serde"] }
 chrono = { version = "0.4.9", default-features = false, features = ["std"] }
-hex = { version = "0.4.0", default-features = false }
 thiserror = { version = "1.0.10", default-features = false }
 serde = { version = "1.0.101", default-features = false, features = ["derive"], optional = true }
 regex = { version ="1.3.1", default-features = false, features = ["std"] }

--- a/crates/interledger-packet/src/oer.rs
+++ b/crates/interledger-packet/src/oer.rs
@@ -111,6 +111,11 @@ impl<'a> BufOerExt<'a> for &'a [u8] {
                     ErrorKind::InvalidData,
                     "length prefix too large",
                 ))
+            } else if length_prefix_length == 0 {
+                Err(Error::new(
+                    ErrorKind::InvalidData,
+                    "0x80 as length prefix is not supported",
+                ))
             } else {
                 Ok(self.read_uint::<BigEndian>(length_prefix_length)? as usize)
             }

--- a/crates/interledger-packet/src/oer.rs
+++ b/crates/interledger-packet/src/oer.rs
@@ -22,7 +22,9 @@ pub fn predict_var_octet_string(length: usize) -> usize {
 
 /// Returns the minimum number of bytes needed to encode the value.
 /// Returns an error of the value requires more than 8 bytes.
-fn predict_var_uint_size(value: u64) -> usize {
+pub fn predict_var_uint_size(value: u64) -> usize {
+    // FIXME: when renaming/retouching this fn shouldn't return more than u8
+
     // avoid branching on zero by always orring one; it will not have any effect on other inputs
     let value = value | 1;
 

--- a/crates/interledger-packet/src/packet.rs
+++ b/crates/interledger-packet/src/packet.rs
@@ -235,7 +235,7 @@ impl fmt::Debug for Prepare {
             )
             .field(
                 "execution_condition",
-                &hex::encode(self.execution_condition()),
+                &HexString(&self.execution_condition()),
             )
             .field("data_length", &self.data().len())
             .finish()
@@ -349,7 +349,7 @@ impl fmt::Debug for Fulfill {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter
             .debug_struct("Fulfill")
-            .field("fulfillment", &hex::encode(self.fulfillment()))
+            .field("fulfillment", &HexString(self.fulfillment()))
             .field("data_length", &self.data().len())
             .finish()
     }
@@ -963,5 +963,16 @@ mod test_max_packet_amount_details {
     #[test]
     fn test_max_amount() {
         assert_eq!(DETAILS.max_amount(), 0x0006_0504);
+    }
+}
+
+struct HexString<'a>(&'a [u8]);
+
+impl<'a> fmt::Debug for HexString<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in self.0 {
+            write!(fmt, "{:02x}", b)?;
+        }
+        Ok(())
     }
 }

--- a/crates/interledger-packet/src/packet.rs
+++ b/crates/interledger-packet/src/packet.rs
@@ -34,15 +34,11 @@ impl TryFrom<&[u8]> for PacketType {
     type Error = ParseError;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        match bytes.first() {
-            Some(&12) => Ok(PacketType::Prepare),
-            Some(&13) => Ok(PacketType::Fulfill),
-            Some(&14) => Ok(PacketType::Reject),
-            _ => Err(ParseError::InvalidPacket(format!(
-                "Unknown packet type: {:?}",
-                bytes,
-            ))),
-        }
+        let first = bytes
+            .first()
+            .ok_or_else(|| ParseError::InvalidPacket("Unknown packet type: []".into()))?;
+
+        PacketType::try_from(*first)
     }
 }
 
@@ -658,6 +654,14 @@ mod test_packet_type {
         assert_eq!(PacketType::try_from(13).unwrap(), PacketType::Fulfill);
         assert_eq!(PacketType::try_from(14).unwrap(), PacketType::Reject);
         assert!(PacketType::try_from(15).is_err());
+    }
+
+    #[test]
+    fn try_from_empty() {
+        assert_eq!(
+            "Invalid Packet: Unknown packet type: []",
+            format!("{}", PacketType::try_from(&[][..]).unwrap_err())
+        );
     }
 }
 

--- a/crates/interledger-packet/src/packet.rs
+++ b/crates/interledger-packet/src/packet.rs
@@ -69,14 +69,10 @@ impl TryFrom<BytesMut> for Packet {
     type Error = ParseError;
 
     fn try_from(buffer: BytesMut) -> Result<Self, Self::Error> {
-        match buffer.first() {
-            Some(&12) => Ok(Packet::Prepare(Prepare::try_from(buffer)?)),
-            Some(&13) => Ok(Packet::Fulfill(Fulfill::try_from(buffer)?)),
-            Some(&14) => Ok(Packet::Reject(Reject::try_from(buffer)?)),
-            _ => Err(ParseError::InvalidPacket(format!(
-                "Unknown packet type: {:?}",
-                buffer.first(),
-            ))),
+        match PacketType::try_from(buffer.as_ref())? {
+            PacketType::Prepare => Prepare::try_from(buffer).map(Packet::from),
+            PacketType::Fulfill => Fulfill::try_from(buffer).map(Packet::from),
+            PacketType::Reject => Reject::try_from(buffer).map(Packet::from),
         }
     }
 }


### PR DESCRIPTION
Assorted cleanup commits while looking into the bytes04, bytes05 issues. This is mostly idle work while thinking for the path forwards towards tokio-1.0 but publishing the PR for review. 

Among fixes is the 0x80 case is currently a panic on the packet/btp as the `0` is forwarded to `byteorder::ReadBytesExt::read_uint` which requires `1 <= n <= 8`. This was found while fuzzing which I didn't include at least yet, as for some reason the longer length cases weren't found with the naive fuzz target.