### PR TITLE
CI and test-md enhancements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-# limit ci building to pushes to master not to get twice the notification email from github
+# limit ci building to pushes to master not to get twice the notification email
+# from github.
+#
+# if you want to test your branch on your fork, just replace the 'branches'
+# filter below for 'push' with the one for 'pull_request' temporarily and drop
+# the commit when creating the PR.
 on:
   push:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+# limit ci building to pushes to master not to get twice the notification email from github
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches: '*'
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
           scripts/run-md-test.sh '^.*$' 1
 
       - name: 'Store artifacts'
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
           name: run-md-test

--- a/scripts/parse-md.sh
+++ b/scripts/parse-md.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Just the awk md parser taken out so that it can be tested.
+
+set -eu
+
+# [ -t 0 ] is true when the stdin is terminal, sort of isatty
+if [[ $# -ne 0 ]] || [[ "${1:-}" == "--help" ]] || [[ "${1:-}" == "-h" ]] || [ -t 0 ]; then
+	echo "USAGE: ${0:-parse-md.sh} < input_file" 1>&2
+	echo "This program will strip the input out of markdown and output the executable script." 1>&2
+	echo "Example: scripts/parse-md.sh < examples/simple/README.md" 1>&2
+	exit 1
+fi
+
+# Based on mdlp.awk from https://gist.github.com/trauber/4955706
+# Originally written by @trauber Rich Traube
+
+# This script parses and executes code blocks found in Markdown files.
+# In addition to parsing code found between ```bash ... ```,
+# it also parses code from special HTML comments that start with <!--!
+# This allows us to hide certain commands from view in the rendered
+# Markdown file but run them when the whole file is executed.
+# This is largely intended for commands that make the output more readable
+
+awk 'BEGIN { one_line_comment="^<!--!(.*)-->$" }
+{
+  # cc = code block count
+  # hc = html comment count
+  # ps = print script
+  # codeblock starts only if the block is of bash, and ends if the line starts with ```
+  if (hc % 2 == 0 && /^```/) { if (/^```(bash)$/) { ps = 1; } else { ps = 0; } cc++; next }
+
+  # html comment starts if the line starts with <!--! and the line is not one line comment (<!--! foo -->)
+  else if (cc % 2 == 0 && /^<!--!/ && $0 !~ one_line_comment) { ps = 1; hc++; next }
+
+  # html comment ends if the line starts with --> and it is in html comment context
+  else if (cc % 2 == 0 && hc % 2 == 1 && /^-->/) { hc++; next }
+
+  # if the line is in either html comment section or code block section, print the line
+  else if ((hc % 2 == 1 || cc % 2 == 1) && ps == 1) { print }
+
+  # if the line matches one line comment (<!--! foo -->), just print it
+  else if ($0 ~ one_line_comment) { p = $0; sub("^<!--! *", "", p); sub(" *-->$", "", p); print p }
+}'

--- a/scripts/run-md-test.sh
+++ b/scripts/run-md-test.sh
@@ -35,7 +35,7 @@ function clear_redis_file() {
 }
 
 function clear_binaries() {
-    rm ~/.interledger/bin/*
+    rm -f ~/.interledger/bin/*
 }
 
 # $1 = target directory

--- a/scripts/run-md.sh
+++ b/scripts/run-md.sh
@@ -1,13 +1,4 @@
 #!/bin/bash
-# Based on mdlp.awk from https://gist.github.com/trauber/4955706
-# Originally written by @trauber Rich Traube
-
-# This script parses and executes code blocks found in Markdown files.
-# In addition to parsing code found between ```bash ... ```,
-# it also parses code from special HTML comments that start with <!--!
-# This allows us to hide certain commands from view in the rendered
-# Markdown file but run them when the whole file is executed.
-# This is largely intended for commands that make the output more readable
 
 TMP_SCRIPT=$(mktemp)
 export RUN_MD_LIB="$(dirname $0)/run-md-lib.sh"
@@ -24,26 +15,7 @@ else
   MD_FILE=-
 fi
 
-cat "$MD_FILE" | awk 'BEGIN { one_line_comment="^<!--!(.*)-->$" }
-{
-  # cc = code block count
-  # hc = html comment count
-  # ps = print script
-  # codeblock starts only if the block is of bash, and ends if the line starts with ```
-  if (hc % 2 == 0 && /^```/) { if (/^```(bash)$/) { ps = 1; } else { ps = 0; } cc++; next }
-
-  # html comment starts if the line starts with <!--! and the line is not one line comment (<!--! foo -->)
-  else if (cc % 2 == 0 && /^<!--!/ && $0 !~ one_line_comment) { ps = 1; hc++; next }
-
-  # html comment ends if the line starts with --> and it is in html comment context
-  else if (cc % 2 == 0 && hc % 2 == 1 && /^-->/) { hc++; next }
-
-  # if the line is in either html comment section or code block section, print the line
-  else if ((hc % 2 == 1 || cc % 2 == 1) && ps == 1) { print }
-
-  # if the line matches one line comment (<!--! foo -->), just print it
-  else if ($0 ~ one_line_comment) { p = $0; sub("^<!--! *", "", p); sub(" *-->$", "", p); print p }
-}' > "$TMP_SCRIPT"
+cat "$MD_FILE" | "$(dirname $0)/parse-md.sh" > "$TMP_SCRIPT"
 bash -O expand_aliases "$TMP_SCRIPT"
 
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
Separated from #693 which had a tough evening yesterday with multiple consecutive failures before starting to work again. This fixes:
 - the `test-md` logs (artifacts) are now only uploaded on failure (was only on success)
 - limiting the workflow execution to only pull requests and master branch (will allow anyone contributing with spam)
 - `rm` failure is from the bogus `~/.interledger` deletion which I do not know the reason for
   - it should probably be removed altogether
   - I have no idea what was the original point nor do I consider these scripts safe to run locally because of things like these
 - refactor the "mdlp" out to a simple to use awk wrapper with help, for the next time one needs to decipher the README.mds