### PR TITLE
fix(docker): make .git available for the build image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,6 +65,7 @@ jobs:
         if: startsWith(steps.tags.outputs.tag, 'ilp-cli-') != true
         uses: docker/build-push-action@v2
         with:
+          context: .
           file: ./docker/Dockerfile
           push: true
           tags: interledgerrs/testnet-bundle:${{steps.tags.outputs.ilp_node_image_tag}}
@@ -74,6 +75,7 @@ jobs:
         if: startsWith(steps.tags.outputs.tag, 'ilp-node-') != true
         uses: docker/build-push-action@v2
         with:
+          context: .
           file: ./docker/ilp-cli.dockerfile
           push: true
           tags: interledgerrs/ilp-cli:${{steps.tags.outputs.ilp_node_cli_image_tag}}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /usr/src/interledger-rs
 COPY ./Cargo.toml /usr/src/interledger-rs/Cargo.toml
 COPY ./Cargo.lock /usr/src/interledger-rs/Cargo.lock
 COPY ./crates /usr/src/interledger-rs/crates
+COPY ./.git /usr/src/interledger-rs/
 
 # TODO: investigate using a method like https://whitfin.io/speeding-up-rust-docker-builds/
 # to ensure that the dependencies are cached so the build doesn't take as long

--- a/docker/ilp-cli.dockerfile
+++ b/docker/ilp-cli.dockerfile
@@ -5,6 +5,7 @@ WORKDIR /usr/src
 COPY ./Cargo.toml /usr/src/Cargo.toml
 COPY ./Cargo.lock /usr/src/Cargo.lock
 COPY ./crates /usr/src/crates
+COPY ./.git /usr/src/
 
 # TODO: investigate using a method like https://whitfin.io/speeding-up-rust-docker-builds/
 # to ensure that the dependencies are cached so the build doesn't take as long

--- a/docker/ilp-node.dockerfile
+++ b/docker/ilp-node.dockerfile
@@ -9,6 +9,7 @@ WORKDIR /usr/src
 COPY ./Cargo.toml /usr/src/Cargo.toml
 COPY ./Cargo.lock /usr/src/Cargo.lock
 COPY ./crates /usr/src/crates
+COPY ./.git /usr/src/
 
 RUN cargo build ${CARGO_BUILD_OPTION} --package ilp-node --bin ilp-node
 


### PR DESCRIPTION
When doing #680 I didn't notice the docker build failure and have been figuring out how to fix it since. Looking more closely to the dockerfile it already uses a two container construction so I was able to identify the issue being "only parts of the working copy are copied into the build container". The fix is obvious in hindsight.

Fixes #694 but we will not know until I merge this into master, we should have a third workflow which depends on both `build` and `test-md` and attempts to build the docker images.