### PR TITLE
Remove error decrypting unspecified

### DIFF
--- a/crates/interledger-stream/src/crypto.rs
+++ b/crates/interledger-stream/src/crypto.rs
@@ -157,10 +157,7 @@ pub fn decrypt(shared_secret: &[u8], mut ciphertext: BytesMut) -> Result<BytesMu
             aead::Aad::from(additional_data),
             &mut ciphertext,
         )
-        .map_err(|err| {
-            // FIXME: many of the tests see this if you have logging on.
-            error!("Error decrypting {:?}", err);
-        })?
+        .map_err(|_| ())?
         .len();
     ciphertext.truncate(length);
     Ok(ciphertext)

--- a/crates/interledger-stream/src/packet.rs
+++ b/crates/interledger-stream/src/packet.rs
@@ -141,7 +141,7 @@ impl StreamPacket {
     pub fn from_encrypted(shared_secret: &[u8], ciphertext: BytesMut) -> Result<Self, ParseError> {
         // TODO handle decryption failure
         let decrypted = decrypt(shared_secret, ciphertext)
-            .map_err(|_err| ParseError::InvalidPacket(String::from("Unable to decrypt packet")))?;
+            .map_err(|_| ParseError::InvalidPacket(String::from("Unable to decrypt packet")))?;
         StreamPacket::from_bytes_unencrypted(decrypted)
     }
 

--- a/crates/interledger-stream/src/server.rs
+++ b/crates/interledger-stream/src/server.rs
@@ -207,7 +207,7 @@ where
                 request.to.asset_scale(),
                 &request.prepare,
             );
-            return match response {
+            match response {
                 Ok(ReceiveOk { fulfill, sequence }) => {
                     self.store
                         .publish_payment_notification(PaymentNotification {
@@ -253,9 +253,10 @@ where
 
                     Err(reject)
                 }
-            };
+            }
+        } else {
+            self.next.send_request(request).await
         }
-        self.next.send_request(request).await
     }
 }
 

--- a/crates/interledger-stream/src/server.rs
+++ b/crates/interledger-stream/src/server.rs
@@ -276,18 +276,10 @@ fn receive_money(
     let condition = hash_sha256(&fulfillment);
     let is_fulfillable = condition == prepare.execution_condition();
 
-    // Parse STREAM packet
-    // TODO avoid copying data
     let prepare_amount = prepare.amount();
 
-    // Note that we are copying the Prepare packet data. This is a bad idea
-    // in cases where STREAM is used to send a significant amount of data.
-    // This implementation doesn't currently support handling the STREAM data
-    // so copying the bytes of the other STREAM frames shouldn't be a big
-    // performance hit in practice.
-    // The data is copied so that we can take the Prepare packet by
-    // reference in the case that the decryption fails and we want to pass
-    // the request on to the next service.
+    // Creating a copy for the prepare.data() cannot be avoided, as the decryption happens in place
+    // while the outer Prepare needs to remain unchanged.
     let copied_data = BytesMut::from(prepare.data());
 
     let stream_packet = StreamPacket::from_encrypted(shared_secret, copied_data)

--- a/crates/interledger-stream/src/server.rs
+++ b/crates/interledger-stream/src/server.rs
@@ -111,12 +111,22 @@ struct ReceiveOk {
     sequence: u64,
 }
 
-#[derive(Debug)]
 /// The Err(ReceiveErr) variant of receive_money(...) return result
-struct ReceiveErr {
-    reject: Reject,
-    sequence: u64,
-    connection_closed: bool,
+#[derive(Debug)]
+enum ReceiveErr {
+    /// When decrypting fails, it means that the packet was definitely not for this service running
+    /// on this node. It should be handled by forwarding it to another handler.
+    ///
+    /// This variant is used to describe decryption failure in addition to all kinds of parsing
+    /// failures.
+    InvalidPacket,
+
+    /// We definitely reject and terminate processing of this transaction.
+    Rejection {
+        reject: Reject,
+        sequence: u64,
+        connection_closed: bool,
+    },
 }
 
 /// A trait representing the Publish side of a pub/sub store
@@ -197,20 +207,38 @@ where
                 request.to.asset_scale(),
                 &request.prepare,
             );
-            match response {
-                Ok(ref ok) => self
-                    .store
-                    .publish_payment_notification(PaymentNotification {
-                        to_username,
-                        from_username,
-                        amount,
-                        destination,
-                        timestamp: DateTime::<Utc>::from(SystemTime::now()).to_rfc3339(),
-                        sequence: ok.sequence,
-                        connection_closed: false,
-                    }),
-                Err(ref err) => {
-                    if err.connection_closed {
+            return match response {
+                Ok(ReceiveOk { fulfill, sequence }) => {
+                    self.store
+                        .publish_payment_notification(PaymentNotification {
+                            to_username,
+                            from_username,
+                            amount,
+                            destination,
+                            timestamp: DateTime::<Utc>::from(SystemTime::now()).to_rfc3339(),
+                            sequence,
+                            connection_closed: false,
+                        });
+                    Ok(fulfill)
+                }
+                Err(ReceiveErr::InvalidPacket) => {
+                    // Additional context for the spared comment; the decryption or parsing fails
+                    // path used to be handled by signalling an F06 from the receive_money step:
+                    //
+                    // <historical_comment>
+                    // Assume the packet isn't for us if the decryption step fails. Note this means
+                    // that if the packet data is modified in any way, the sender will likely see
+                    // an error like F02: Unavailable (this is a bit confusing but the packet data
+                    // should not be modified at all under normal circumstances).
+                    // </historical_comment>
+                    self.next.send_request(request).await
+                }
+                Err(ReceiveErr::Rejection {
+                    reject,
+                    sequence,
+                    connection_closed,
+                }) => {
+                    if connection_closed {
                         self.store
                             .publish_payment_notification(PaymentNotification {
                                 to_username,
@@ -218,21 +246,14 @@ where
                                 amount: 0,
                                 destination,
                                 timestamp: DateTime::<Utc>::from(SystemTime::now()).to_rfc3339(),
-                                sequence: err.sequence,
+                                sequence,
                                 connection_closed: true,
                             });
                     }
-                    if err.reject.code() == ErrorCode::F06_UNEXPECTED_PAYMENT {
-                        // Assume the packet isn't for us if the decryption step fails.
-                        // Note this means that if the packet data is modified in any way,
-                        // the sender will likely see an error like F02: Unavailable (this is
-                        // a bit confusing but the packet data should not be modified at all
-                        // under normal circumstances).
-                        return self.next.send_request(request).await;
-                    }
+
+                    Err(reject)
                 }
             };
-            return response.map(|x| x.fulfill).map_err(|x| x.reject);
         }
         self.next.send_request(request).await
     }
@@ -268,20 +289,8 @@ fn receive_money(
     // the request on to the next service.
     let copied_data = BytesMut::from(prepare.data());
 
-    let stream_packet = StreamPacket::from_encrypted(shared_secret, copied_data).map_err(|_| {
-        debug!("Unable to parse data, rejecting Prepare packet");
-        ReceiveErr {
-            reject: RejectBuilder {
-                code: ErrorCode::F06_UNEXPECTED_PAYMENT,
-                message: b"Could not decrypt data",
-                triggered_by: Some(ilp_address),
-                data: &[],
-            }
-            .build(),
-            sequence: 0,
-            connection_closed: false,
-        }
-    })?;
+    let stream_packet = StreamPacket::from_encrypted(shared_secret, copied_data)
+        .map_err(|_| ReceiveErr::InvalidPacket)?;
 
     let mut response_frames: Vec<Frame> = Vec::new();
     let mut connection_closed = false;
@@ -372,7 +381,7 @@ fn receive_money(
             data: &encrypted_response[..],
         }
         .build();
-        Err(ReceiveErr {
+        Err(ReceiveErr::Rejection {
             reject,
             sequence: stream_packet.sequence(),
             connection_closed,


### PR DESCRIPTION
First commit has more of a "drive-by" refactoring, but the rest are related to the case. It turns out that the "Error decrypting Unspecified" is totally worthless `error!` level message, because:

 * when separating the F06 path and the F99 paths in 842268f it becomes apparent that the error message is only related to F06
 * so it can be removed in c709c94 
 * and the `send_request` impl can be simplified not to have any fallthrough in 5e98c4d

Specifically this removes two log messages:

 1. ["Error decrypting Unspecified"](https://github.com/interledger-rs/interledger-rs/blob/33055529c888f64a08fdbf12addcd23ea1bac7d3/crates/interledger-stream/src/crypto.rs#L172) (always formatted but same  string)
 2. ["Unable to parse data, rejecting Prepare packet"](https://github.com/interledger-rs/interledger-rs/blob/33055529c888f64a08fdbf12addcd23ea1bac7d3/crates/interledger-stream/src/server.rs#L272) (static string)
 
This makes handling of invalid interledger STREAM packets silent, whereas previously they had the second log message without any details. Details were probably not added in the first place, because they are a result of decrypting. However the logic of handling such invalid but decryptable STREAM packets are not changed; they will be forwarded to other layers as previously. This does sound like the wrong thing to do so perhaps this needs to be revisited.