### PR TITLE
fix(packet): add precheck for timestamps in Prepares

### DIFF
--- a/crates/interledger-packet/src/packet.rs
+++ b/crates/interledger-packet/src/packet.rs
@@ -138,7 +138,11 @@ impl TryFrom<BytesMut> for Prepare {
         let mut expires_at = [0x00; 17];
         content.read_exact(&mut expires_at)?;
 
-        if !expires_at.iter().all(|e| (b'0'..=b'9').contains(e)) {
+        if !expires_at
+            .iter()
+            .map(|e| (b'0'..=b'9').contains(e))
+            .fold(true, |a, b| a & b)
+        {
             return Err(ParseError::InvalidPacket("DateTime must be numeric".into()));
         }
 

--- a/crates/interledger-packet/src/packet.rs
+++ b/crates/interledger-packet/src/packet.rs
@@ -146,9 +146,7 @@ impl TryFrom<BytesMut> for Prepare {
         let re = RE.get_or_init(|| Regex::new(r"[0-9]{17}").unwrap());
 
         if !re.is_match(&expires_at) {
-            return Err(ParseError::InvalidPacket(
-                "DateTime must be numerical".into(),
-            ));
+            return Err(ParseError::InvalidPacket("DateTime must be numeric".into()));
         }
 
         let expires_at = str::from_utf8(&expires_at[..])?;
@@ -759,28 +757,11 @@ mod test_prepare {
 
     #[test]
     fn test_invalid_ts() {
-        use std::convert::TryInto;
         for i in 12..(12 + 17) {
             let mut prep = BytesMut::from(PREPARE_BYTES);
             prep[i] = 9; // convert a byte from the address to a junk character
-            let x = match Prepare::try_from(prep) {
-                Ok(x) => x,
-                Err(_) => {
-                    continue;
-                }
-            };
-
-            let built = PrepareBuilder {
-                amount: x.amount(),
-                expires_at: x.expires_at(),
-                execution_condition: x.execution_condition().try_into().unwrap(),
-                destination: x.destination(),
-                data: x.data(),
-            }
-            .build();
-
-            assert_eq!(x, built);
-            assert_eq!(BytesMut::from(x), BytesMut::from(built));
+            let err = Prepare::try_from(prep).unwrap_err();
+            assert_eq!("Invalid Packet: DateTime must be numeric", &err.to_string());
         }
     }
 


### PR DESCRIPTION
Cc: #705 
Check if bytes are numerical values before handing to chrono