### PR TITLE
disallow extra trailing bytes in Fulfillment packet

### DIFF
--- a/crates/interledger-packet/fuzz/Cargo.toml
+++ b/crates/interledger-packet/fuzz/Cargo.toml
@@ -15,6 +15,7 @@ bytes = "0.5"
 
 [dependencies.interledger-packet]
 path = ".."
+features = ["strict"]
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/crates/interledger-packet/src/packet.rs
+++ b/crates/interledger-packet/src/packet.rs
@@ -970,7 +970,7 @@ mod test_reject {
         #[cfg(not(feature = "strict"))]
         {
             let with_junk_data = with_junk_data.unwrap();
-            assert_eq!(with_junk_data.unwrap().code(), REJECT_BUILDER.code);
+            assert_eq!(with_junk_data.code(), REJECT_BUILDER.code);
             assert_eq!(with_junk_data.message(), REJECT_BUILDER.message);
             assert_eq!(
                 with_junk_data.triggered_by().as_ref(),


### PR DESCRIPTION
cc: #705 

Trailing bytes with length included in the varlen octet string that do not contribute to the data field should not be allowed. 