### PR TITLE
Fix test flakyness

### DIFF
--- a/crates/interledger-store/tests/redis/notifications.rs
+++ b/crates/interledger-store/tests/redis/notifications.rs
@@ -72,7 +72,12 @@ async fn notifications_on_multitenant_config() {
     // even though the subscription to all exists. this tests uses the all_payment_subscription()
     // and that should be ok, since the trigger still comes through PSUBSCRIBE.
 
-    let (msg1, msg2) = futures::future::join(rx1.next(), rx2.next()).await;
+    let (msg1, msg2) = tokio::time::timeout(
+        std::time::Duration::from_millis(1000),
+        futures::future::join(rx1.next(), rx2.next()),
+    )
+    .await
+    .expect("timed out");
     assert_eq!(msg1.unwrap().expect("cannot lag yet").sequence, 2);
     assert_eq!(msg2.unwrap().expect("cannot lag yet").sequence, 1);
 

--- a/crates/interledger-store/tests/redis/notifications.rs
+++ b/crates/interledger-store/tests/redis/notifications.rs
@@ -23,13 +23,11 @@ async fn notifications_on_multitenant_config() {
         .await
         .unwrap();
 
-    let mut rx1 = first.all_payment_subscription();
-    let mut rx2 = second.all_payment_subscription();
-
     let firstuser = first
         .insert_account(ACCOUNT_DETAILS_0.clone())
         .await
         .unwrap();
+
     let seconduser = second
         .insert_account({
             let mut details = ACCOUNT_DETAILS_1.clone();
@@ -39,7 +37,7 @@ async fn notifications_on_multitenant_config() {
         .await
         .unwrap();
 
-    first.publish_payment_notification(PaymentNotification {
+    let first_pmt = PaymentNotification {
         from_username: seconduser.username().to_owned(),
         to_username: firstuser.username().to_owned(),
         destination: firstuser.ilp_address().to_owned(),
@@ -47,9 +45,9 @@ async fn notifications_on_multitenant_config() {
         timestamp: String::from("2021-04-04T12:11:11.987+00:00"),
         sequence: 2,
         connection_closed: false,
-    });
+    };
 
-    second.publish_payment_notification(PaymentNotification {
+    let second_pmt = PaymentNotification {
         from_username: firstuser.username().to_owned(),
         to_username: seconduser.username().to_owned(),
         destination: seconduser.ilp_address().to_owned(),
@@ -57,31 +55,50 @@ async fn notifications_on_multitenant_config() {
         timestamp: String::from("2021-04-04T12:11:10.987+00:00"),
         sequence: 1,
         connection_closed: false,
-    });
+    };
 
-    // these used to only log before #700:
-    //
-    // WARN interledger_store::redis: Ignoring unexpected message from Redis subscription for channel: first:stream_notifications:...
-    // WARN interledger_store::redis: Ignoring unexpected message from Redis subscription for channel: second:stream_notifications:...
-    //
-    // after fixing this, there will still be:
-    //
-    // TRACE interledger_store::redis: Ignoring message for account ... because there were no open subscriptions
-    // TRACE interledger_store::redis: Ignoring message for account ... because there were no open subscriptions
-    //
-    // even though the subscription to all exists. this tests uses the all_payment_subscription()
-    // and that should be ok, since the trigger still comes through PSUBSCRIBE.
+    // do the test in a loop since sometimes the psubscribe functionality just isn't ready
+    for _ in 0..10 {
+        // we recreate these on the start of every attempt in order to get a fresh start; the
+        // channel will not forward us messages which have come before.
+        let mut rx1 = first.all_payment_subscription();
+        let mut rx2 = second.all_payment_subscription();
 
-    let (msg1, msg2) = tokio::time::timeout(
-        std::time::Duration::from_millis(1000),
-        futures::future::join(rx1.next(), rx2.next()),
-    )
-    .await
-    .expect("timed out");
-    assert_eq!(msg1.unwrap().expect("cannot lag yet").sequence, 2);
-    assert_eq!(msg2.unwrap().expect("cannot lag yet").sequence, 1);
+        first.publish_payment_notification(first_pmt.clone());
+        second.publish_payment_notification(second_pmt.clone());
 
-    let (msg1, msg2) = (rx1.next().now_or_never(), rx2.next().now_or_never());
-    assert!(msg1.is_none(), "{:?}", msg1);
-    assert!(msg2.is_none(), "{:?}", msg2);
+        // these used to only log before #700:
+        //
+        // WARN interledger_store::redis: Ignoring unexpected message from Redis subscription for channel: first:stream_notifications:...
+        // WARN interledger_store::redis: Ignoring unexpected message from Redis subscription for channel: second:stream_notifications:...
+        //
+        // after fixing this, there will still be:
+        //
+        // TRACE interledger_store::redis: Ignoring message for account ... because there were no open subscriptions
+        // TRACE interledger_store::redis: Ignoring message for account ... because there were no open subscriptions
+        //
+        // even though the subscription to all exists. this tests uses the all_payment_subscription()
+        // and that should be ok, since the trigger still comes through PSUBSCRIBE.
+        //
+        let deadline = std::time::Duration::from_millis(1000);
+        let read_both = futures::future::join(rx1.next(), rx2.next());
+
+        let (msg1, msg2) = match tokio::time::timeout(deadline, read_both).await {
+            Ok(messages) => messages,
+            Err(tokio::time::Elapsed { .. }) => {
+                // failure is most likely because of redis, or publishing to it
+                // see issue #711.
+                continue;
+            }
+        };
+        assert_eq!(msg1.unwrap().expect("cannot lag yet").sequence, 2);
+        assert_eq!(msg2.unwrap().expect("cannot lag yet").sequence, 1);
+
+        let (msg1, msg2) = (rx1.next().now_or_never(), rx2.next().now_or_never());
+        assert!(msg1.is_none(), "{:?}", msg1);
+        assert!(msg2.is_none(), "{:?}", msg2);
+        return;
+    }
+
+    unreachable!("did not complete with retries");
 }


### PR DESCRIPTION
Fixes #711. Adds synchronization for the launched thread, and retry for the test case.