### PR TITLE
Limit csv output in ci logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,7 +1472,6 @@ dependencies = [
  "byteorder",
  "bytes 0.5.6",
  "chrono",
- "csv",
  "futures 0.3.13",
  "hex-literal",
  "interledger-errors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,7 +1298,6 @@ dependencies = [
 name = "interledger-rates"
 version = "1.0.0"
 dependencies = [
- "async-trait",
  "futures 0.3.13",
  "interledger-errors",
  "once_cell",

--- a/crates/interledger-rates/Cargo.toml
+++ b/crates/interledger-rates/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 [dependencies]
 interledger-errors = { path = "../interledger-errors", version = "1.0.0" }
 
-async-trait = "0.1.22"
 futures = { version = "0.3.7", default-features = false }
 tracing = { version = "0.1.12", default-features = false, features = ["log"] }
 once_cell = { version = "1.3.1", default-features = false }

--- a/crates/interledger-stream/Cargo.toml
+++ b/crates/interledger-stream/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 
 # Optional feature to log connection statistics using a CSV file
 [features]
-metrics_csv = ["csv"]
 strict = ["interledger-packet/strict"]
 
 [dependencies]
@@ -24,7 +23,6 @@ chrono = { version = "0.4.9", default-features = false, features = ["clock"] }
 futures = { version = "0.3.7", default-features = false, features = ["std"] }
 tracing = { version = "0.1.12", default-features = false, features = ["log"] }
 num = { version = "0.2.1" }
-parking_lot = { version = "0.10.0", default-features = false }
 ring = { version = "0.16.9", default-features = false }
 serde = { version = "1.0.101", default-features = false }
 tokio = { version = "^0.2.6", default-features = false, features = ["rt-core", "time", "macros"] }
@@ -33,13 +31,11 @@ async-trait = { version = "0.1.22", default-features = false }
 pin-project = { version = "0.4.7", default-features = false }
 thiserror = { version = "1.0.10", default-features = false }
 
-# metrics_csv feature
-csv = { version = "1.1.1", default-features = false, optional = true }
-
 [dev-dependencies]
 interledger-errors = { path = "../interledger-errors", version = "1.0.0", default-features = false }
 interledger-router = { path = "../interledger-router", version = "1.0.0", default-features = false }
 interledger-service-util = { path = "../interledger-service-util", version = "1.0.0", default-features = false }
 hex-literal = "0.3"
+parking_lot = { version = "0.10.0", default-features = false }
 
 once_cell = { version = "1.3.1", default-features = false }


### PR DESCRIPTION
This removes the csv dump functionality from `interledger-stream` which is enabled on all test runs thanks to `--all-features`. The 6e5b804 should be reverted if this dev feature is found being needed later on.

Removal of `async-trait` in `interledger-rates` is a drive-by cleanup motivated by `cargo udeps` finding it.