### PR TITLE
Stream fuzzing fixes

### DIFF
--- a/crates/interledger-stream/fuzz/Cargo.toml
+++ b/crates/interledger-stream/fuzz/Cargo.toml
@@ -14,6 +14,7 @@ libfuzzer-sys = "0.4"
 
 [dependencies.interledger-stream]
 path = ".."
+features = ["strict"]
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/crates/interledger-stream/src/packet.rs
+++ b/crates/interledger-stream/src/packet.rs
@@ -887,7 +887,6 @@ mod fuzzing {
     use bytes::{Buf, BytesMut};
 
     #[test]
-    #[cfg(feature = "strict")]
     fn fuzzed_0_extra_trailer_bytes() {
         // From the [RFC]'s it sounds like the at least trailer junk should be kept around,
         // but only under the condition that they are zero-bytes and MUST be ignored in parsing.

--- a/crates/interledger-stream/src/packet.rs
+++ b/crates/interledger-stream/src/packet.rs
@@ -183,6 +183,8 @@ impl StreamPacket {
         let junk_data_len = reader.len();
 
         if junk_data_len > 0 {
+            // trailing bytes are supported for future compatibility, see
+            // https://github.com/interledger/rfcs/blob/master/0029-stream/0029-stream.md#52-stream-packet
             let _ = buffer_unencrypted.split_off(buffer_unencrypted.len() - junk_data_len);
         }
 


### PR DESCRIPTION
cc: #705 

Focused on fuzzing `StreamPacket`

- when parsing of stream packet data into valid known frames errors, it is returned instead of ignored
- updated a fuzz test name for clarification of cause of failure
- added new test and code for removing trailer bytes for fuzzing

TODO: 
- add new test and handle Unknown frames for fuzzing