### PR TITLE
Fix interledger-packet::ErrorCode too lenient parsing

### DIFF
--- a/crates/interledger-packet/src/packet.rs
+++ b/crates/interledger-packet/src/packet.rs
@@ -671,49 +671,6 @@ mod fuzzed {
             "Invalid Packet: Reject.ErrorCode was not IA5String"
         );
     }
-
-    #[allow(unused)]
-    fn roundtrip(bytes: &[u8]) {
-        use super::{FulfillBuilder, Packet::*, PrepareBuilder, RejectBuilder};
-        use std::convert::TryInto;
-        match Packet::try_from(BytesMut::from(bytes)).unwrap() {
-            Prepare(p) => {
-                let other = PrepareBuilder {
-                    amount: p.amount(),
-                    expires_at: p.expires_at(),
-                    destination: p.destination(),
-                    execution_condition: p
-                        .execution_condition()
-                        .try_into()
-                        .expect("wrong length slice"),
-                    data: p.data(),
-                }
-                .build();
-
-                assert_eq!(p, other);
-            }
-            Fulfill(f) => {
-                let other = FulfillBuilder {
-                    fulfillment: f.fulfillment().try_into().expect("wrong length slice"),
-                    data: f.data(),
-                }
-                .build();
-
-                assert_eq!(f, other);
-            }
-            Reject(r) => {
-                let other = RejectBuilder {
-                    code: r.code(),
-                    message: r.message(),
-                    triggered_by: r.triggered_by().as_ref(),
-                    data: r.data(),
-                }
-                .build();
-
-                assert_eq!(r, other);
-            }
-        }
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Found this crash stashed away, which wasn't because of ErrorCode or parsing, but because of too strict fuzz_target. This PR fixes:

- allow only IA5String (ascii) error codes as is in the ASN.1 definition
- handle debug and display output for the error codes with control characters gracefully
- remove string allocation in ErrorCode's Debug impl

There's some churn related to the roundtrip test fn being added and removed, but I'll follow up with a better `fuzz/fuzz_targets/packet.rs` after this PR.

Cc: #705