### PR TITLE
ci: add testing of without and with strict feats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,21 @@ jobs:
       - name: Test
         run: timeout 15m cargo test --all --all-features
 
+      - name: Test with subset of features (interledger-packet)
+        run: |
+          timeout 15m cargo test -p interledger-packet
+          timeout 15m cargo test -p interledger-packet --features strict
+
+      - name: Test with subset of features (interledger-btp)
+        run: |
+          timeout 15m cargo test -p interledger-btp
+          timeout 15m cargo test -p interledger-btp --features strict
+
+      - name: Test with subset of features (interledger-stream)
+        run: |
+          timeout 15m cargo test -p interledger-stream
+          timeout 15m cargo test -p interledger-stream --features strict
+
   test-md:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I had forgotten to do this a while ago, when introducing the `interledger-packet/strict` feature.