### PR TITLE
stream: Allow fuzzing for Unknown Data (ErrorCode and FrameType)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
         run: |
           timeout 15m cargo test -p interledger-stream
           timeout 15m cargo test -p interledger-stream --features strict
+          timeout 15m cargo test -p interledger-stream --features roundtrip-only
 
   test-md:
     runs-on: ubuntu-latest

--- a/crates/interledger-stream/Cargo.toml
+++ b/crates/interledger-stream/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/interledger-rs/interledger-rs"
 # Optional feature to log connection statistics using a CSV file
 [features]
 strict = ["interledger-packet/strict"]
+# Only applicable for roundtripping in fuzzing
+# Deliberate error for valid replacement of data, such as `saturating_read_var_uint`.
+roundtrip-only = ["strict"] 
 
 [dependencies]
 interledger-packet = { path = "../interledger-packet", version = "1.0.0", default-features = false, features = ["serde"] }

--- a/crates/interledger-stream/fuzz/Cargo.toml
+++ b/crates/interledger-stream/fuzz/Cargo.toml
@@ -14,7 +14,8 @@ libfuzzer-sys = "0.4"
 
 [dependencies.interledger-stream]
 path = ".."
-features = ["strict"]
+# roundtrip enables strict features as well
+features = ["roundtrip-only"]
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/crates/interledger-stream/src/lib.rs
+++ b/crates/interledger-stream/src/lib.rs
@@ -27,11 +27,6 @@ pub use server::{
 pub fn fuzz_decrypted_stream_packet(data: &[u8]) {
     let b = bytes::BytesMut::from(data);
     if let Ok(pkt) = packet::StreamPacket::from_decrypted(b) {
-        if pkt.frames().any(|x| matches!(x, packet::Frame::Unknown)) {
-            // TODO: builder just skips over these, probably shouldn't
-            return;
-        }
-
         let other = packet::StreamPacketBuilder {
             sequence: pkt.sequence(),
             ilp_packet_type: pkt.ilp_packet_type(),

--- a/crates/interledger-stream/src/packet.rs
+++ b/crates/interledger-stream/src/packet.rs
@@ -488,7 +488,7 @@ impl From<ErrorCode> for u8 {
     }
 }
 
-fn check_frame_data_prefix_length(_reader: &[u8]) -> Result<(), ParseError> {
+fn ensure_no_inner_trailing_bytes(_reader: &[u8]) -> Result<(), ParseError> {
     // Content slice passed to the `read_contents` function should not
     // contain extra bytes.
     #[cfg(feature = "strict")]
@@ -521,7 +521,7 @@ impl<'a> SerializableFrame<'a> for ConnectionCloseFrame<'a> {
     fn read_contents(mut reader: &'a [u8]) -> Result<Self, ParseError> {
         let code = ErrorCode::from(reader.read_u8()?);
         let message_bytes = reader.read_var_octet_string()?;
-        check_frame_data_prefix_length(reader)?;
+        ensure_no_inner_trailing_bytes(reader)?;
         let message = str::from_utf8(message_bytes)?;
 
         Ok(ConnectionCloseFrame { code, message })
@@ -562,7 +562,7 @@ pub struct ConnectionNewAddressFrame {
 impl<'a> SerializableFrame<'a> for ConnectionNewAddressFrame {
     fn read_contents(mut reader: &'a [u8]) -> Result<Self, ParseError> {
         let source_account = reader.read_var_octet_string()?;
-        check_frame_data_prefix_length(reader)?;
+        ensure_no_inner_trailing_bytes(reader)?;
         let source_account = Address::try_from(source_account)?;
 
         Ok(ConnectionNewAddressFrame { source_account })
@@ -598,7 +598,7 @@ impl<'a> SerializableFrame<'a> for ConnectionAssetDetailsFrame<'a> {
     fn read_contents(mut reader: &'a [u8]) -> Result<Self, ParseError> {
         let source_asset_code = str::from_utf8(reader.read_var_octet_string()?)?;
         let source_asset_scale = reader.read_u8()?;
-        check_frame_data_prefix_length(reader)?;
+        ensure_no_inner_trailing_bytes(reader)?;
 
         Ok(ConnectionAssetDetailsFrame {
             source_asset_scale,
@@ -622,7 +622,7 @@ pub struct ConnectionMaxDataFrame {
 impl<'a> SerializableFrame<'a> for ConnectionMaxDataFrame {
     fn read_contents(mut reader: &[u8]) -> Result<Self, ParseError> {
         let max_offset = reader.read_var_uint()?;
-        check_frame_data_prefix_length(reader)?;
+        ensure_no_inner_trailing_bytes(reader)?;
 
         Ok(ConnectionMaxDataFrame { max_offset })
     }
@@ -642,7 +642,7 @@ pub struct ConnectionDataBlockedFrame {
 impl<'a> SerializableFrame<'a> for ConnectionDataBlockedFrame {
     fn read_contents(mut reader: &[u8]) -> Result<Self, ParseError> {
         let max_offset = reader.read_var_uint()?;
-        check_frame_data_prefix_length(reader)?;
+        ensure_no_inner_trailing_bytes(reader)?;
 
         Ok(ConnectionDataBlockedFrame { max_offset })
     }
@@ -662,7 +662,7 @@ pub struct ConnectionMaxStreamIdFrame {
 impl<'a> SerializableFrame<'a> for ConnectionMaxStreamIdFrame {
     fn read_contents(mut reader: &[u8]) -> Result<Self, ParseError> {
         let max_stream_id = reader.read_var_uint()?;
-        check_frame_data_prefix_length(reader)?;
+        ensure_no_inner_trailing_bytes(reader)?;
 
         Ok(ConnectionMaxStreamIdFrame { max_stream_id })
     }
@@ -682,7 +682,7 @@ pub struct ConnectionStreamIdBlockedFrame {
 impl<'a> SerializableFrame<'a> for ConnectionStreamIdBlockedFrame {
     fn read_contents(mut reader: &[u8]) -> Result<Self, ParseError> {
         let max_stream_id = reader.read_var_uint()?;
-        check_frame_data_prefix_length(reader)?;
+        ensure_no_inner_trailing_bytes(reader)?;
 
         Ok(ConnectionStreamIdBlockedFrame { max_stream_id })
     }
@@ -710,7 +710,7 @@ impl<'a> SerializableFrame<'a> for StreamCloseFrame<'a> {
         let stream_id = reader.read_var_uint()?;
         let code = ErrorCode::from(reader.read_u8()?);
         let message_bytes = reader.read_var_octet_string()?;
-        check_frame_data_prefix_length(reader)?;
+        ensure_no_inner_trailing_bytes(reader)?;
         let message = str::from_utf8(message_bytes)?;
 
         Ok(StreamCloseFrame {
@@ -753,7 +753,7 @@ impl<'a> SerializableFrame<'a> for StreamMoneyFrame {
     fn read_contents(mut reader: &[u8]) -> Result<Self, ParseError> {
         let stream_id = reader.read_var_uint()?;
         let shares = reader.read_var_uint()?;
-        check_frame_data_prefix_length(reader)?;
+        ensure_no_inner_trailing_bytes(reader)?;
 
         Ok(StreamMoneyFrame { stream_id, shares })
     }
@@ -787,7 +787,7 @@ impl<'a> SerializableFrame<'a> for StreamMaxMoneyFrame {
         let stream_id = reader.read_var_uint()?;
         let receive_max = saturating_read_var_uint(&mut reader)?;
         let total_received = reader.read_var_uint()?;
-        check_frame_data_prefix_length(reader)?;
+        ensure_no_inner_trailing_bytes(reader)?;
 
         Ok(StreamMaxMoneyFrame {
             stream_id,
@@ -821,7 +821,7 @@ impl<'a> SerializableFrame<'a> for StreamMoneyBlockedFrame {
         let stream_id = reader.read_var_uint()?;
         let send_max = saturating_read_var_uint(&mut reader)?;
         let total_sent = reader.read_var_uint()?;
-        check_frame_data_prefix_length(reader)?;
+        ensure_no_inner_trailing_bytes(reader)?;
 
         Ok(StreamMoneyBlockedFrame {
             stream_id,
@@ -868,7 +868,7 @@ impl<'a> SerializableFrame<'a> for StreamDataFrame<'a> {
         let stream_id = reader.read_var_uint()?;
         let offset = reader.read_var_uint()?;
         let data = reader.read_var_octet_string()?;
-        check_frame_data_prefix_length(reader)?;
+        ensure_no_inner_trailing_bytes(reader)?;
 
         Ok(StreamDataFrame {
             stream_id,
@@ -897,7 +897,7 @@ impl<'a> SerializableFrame<'a> for StreamMaxDataFrame {
     fn read_contents(mut reader: &[u8]) -> Result<Self, ParseError> {
         let stream_id = reader.read_var_uint()?;
         let max_offset = reader.read_var_uint()?;
-        check_frame_data_prefix_length(reader)?;
+        ensure_no_inner_trailing_bytes(reader)?;
 
         Ok(StreamMaxDataFrame {
             stream_id,
@@ -924,7 +924,7 @@ impl<'a> SerializableFrame<'a> for StreamDataBlockedFrame {
     fn read_contents(mut reader: &[u8]) -> Result<Self, ParseError> {
         let stream_id = reader.read_var_uint()?;
         let max_offset = reader.read_var_uint()?;
-        check_frame_data_prefix_length(reader)?;
+        ensure_no_inner_trailing_bytes(reader)?;
 
         Ok(StreamDataBlockedFrame {
             stream_id,

--- a/crates/interledger-stream/src/packet.rs
+++ b/crates/interledger-stream/src/packet.rs
@@ -1214,6 +1214,46 @@ mod serialization {
         )
     });
 
+    static UNKNOWN_FRAME_PACKET: Lazy<StreamPacket> = Lazy::new(|| {
+        StreamPacketBuilder {
+            sequence: 1,
+            ilp_packet_type: IlpPacketType::try_from(12).unwrap(),
+            prepare_amount: 99,
+            frames: &[Frame::Unknown(UnknownFrameData {
+                frame_type: 89,
+                content: &[1, 2, 3],
+            })],
+        }
+        .build()
+    });
+
+    static SERIALIZED_UNKNOWN_FRAME_PACKET: Lazy<BytesMut> = Lazy::new(|| {
+        BytesMut::from(
+            &vec![
+                1, 12, 1, 1, 1, 99, // Version, type, sequence amount
+                1, 1,  // num frames
+                89, // frame type - Unknown
+                3, 1, 2, 3, // frame data
+            ][..],
+        )
+    });
+
+    #[test]
+    fn it_serializes_unknown_frame_data() {
+        assert_eq!(
+            UNKNOWN_FRAME_PACKET.buffer_unencrypted,
+            *SERIALIZED_UNKNOWN_FRAME_PACKET
+        );
+    }
+
+    #[test]
+    fn it_deserializes_packets_with_unknown_frame_data() {
+        assert_eq!(
+            StreamPacket::from_bytes_unencrypted(SERIALIZED_UNKNOWN_FRAME_PACKET.clone()).unwrap(),
+            *UNKNOWN_FRAME_PACKET
+        );
+    }
+
     #[test]
     fn it_serializes_to_same_as_javascript() {
         assert_eq!(PACKET.buffer_unencrypted, *SERIALIZED);

--- a/crates/interledger-stream/src/packet.rs
+++ b/crates/interledger-stream/src/packet.rs
@@ -945,7 +945,7 @@ fn saturating_read_var_uint<'a>(reader: &mut impl BufOerExt<'a>) -> Result<u64, 
 
         if cfg!(feature = "roundtrip-only") {
             // This is needed because the returned value u64::MAX
-            // will make rounttrip fail, i.e. ByteMut::from(packet)
+            // will make roundtrip fail, i.e. BytesMut::from(packet)
             // will not equal to the original data.
             Err(ParseError::WrongType(
                 "Fuzzing roundtrip for var_uint larger than u64::MAX unavailable".to_string(),
@@ -1052,16 +1052,12 @@ mod fuzzing {
             1, 1, 4, 0, 255, 255, 255, 255, 255, 128, 255, 128
             ];
 
-        // roundtrip result
-        // [1, 14, 1, 14, 1, 14, 1, 1, 1, 2, 1, 0]
-        //                                ^ ----^
-        //                                Suspect due to content prefix length
         let b = BytesMut::from(input);
         let pkt = StreamPacket::from_decrypted(b);
 
         assert_eq!(
             "Invalid Packet: Incorrect number of frames or unable to parse all frames",
-            format!("{}", pkt.unwrap_err())
+            &pkt.unwrap_err().to_string()
         );
     }
 
@@ -1110,7 +1106,7 @@ mod fuzzing {
 
         assert_eq!(
             "Invalid Packet: Incorrect number of frames or unable to parse all frames",
-            format!("{}", pkt.unwrap_err())
+            &pkt.unwrap_err().to_string()
         );
     }
 
@@ -1229,7 +1225,7 @@ mod serialization {
 
     static SERIALIZED_UNKNOWN_FRAME_PACKET: Lazy<BytesMut> = Lazy::new(|| {
         BytesMut::from(
-            &vec![
+            &[
                 1, 12, 1, 1, 1, 99, // Version, type, sequence amount
                 1, 1,  // num frames
                 89, // frame type - Unknown


### PR DESCRIPTION
cc: #705 

This PR addresses:
- ensures no inner trailing bytes in frame data
- adds roundtrip-only feature for fuzzing in the case of saturated value replacement 
- stores and return Unknown ErrorCode and FrameTypes