### PR TITLE
Continued interledger-packet fuzzability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           timeout 15m cargo test -p interledger-packet
           timeout 15m cargo test -p interledger-packet --features strict
+          timeout 15m cargo test -p interledger-packet --features roundtrip-only
 
       - name: Test with subset of features (interledger-btp)
         run: |

--- a/crates/interledger-packet/Cargo.toml
+++ b/crates/interledger-packet/Cargo.toml
@@ -8,8 +8,10 @@ edition = "2018"
 repository = "https://github.com/interledger-rs/interledger-rs"
 
 [features]
-# used when fuzzing; accepts only roundtripping input
+# strict adherence to the rfcs, but not taking any "roundtrip-only" shortcuts
 strict = []
+# used when fuzzing; accepts only roundtripping input
+roundtrip-only = ["strict"]
 
 [dependencies]
 byteorder = { version = "1.3.2" }

--- a/crates/interledger-packet/fuzz/Cargo.toml
+++ b/crates/interledger-packet/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ bytes = "0.5"
 
 [dependencies.interledger-packet]
 path = ".."
-features = ["strict"]
+features = ["roundtrip-only"]
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/crates/interledger-packet/fuzz/fuzz_targets/packet.rs
+++ b/crates/interledger-packet/fuzz/fuzz_targets/packet.rs
@@ -1,49 +1,6 @@
 #![no_main]
-use bytes::BytesMut;
 use libfuzzer_sys::fuzz_target;
-use std::convert::{TryFrom, TryInto};
 
 fuzz_target!(|data: &[u8]| {
-    use interledger_packet::{FulfillBuilder, Packet, PrepareBuilder, RejectBuilder};
-
-    if let Ok(pkt) = interledger_packet::Packet::try_from(BytesMut::from(data)) {
-        // try to create a corresponding builder and a new set of bytes
-        match pkt {
-            Packet::Prepare(p) => {
-                let other = PrepareBuilder {
-                    amount: p.amount(),
-                    expires_at: p.expires_at(),
-                    destination: p.destination(),
-                    execution_condition: p
-                        .execution_condition()
-                        .try_into()
-                        .expect("wrong length slice"),
-                    data: p.data(),
-                }
-                .build();
-
-                assert_eq!(p, other);
-            }
-            Packet::Fulfill(f) => {
-                let other = FulfillBuilder {
-                    fulfillment: f.fulfillment().try_into().expect("wrong length slice"),
-                    data: f.data(),
-                }
-                .build();
-
-                assert_eq!(f, other);
-            }
-            Packet::Reject(r) => {
-                let other = RejectBuilder {
-                    code: r.code(),
-                    message: r.message(),
-                    triggered_by: r.triggered_by().as_ref(),
-                    data: r.data(),
-                }
-                .build();
-
-                assert_eq!(r, other);
-            }
-        }
-    }
+    let _ = interledger_packet::lenient_packet_roundtrips(data);
 });

--- a/crates/interledger-packet/src/hex.rs
+++ b/crates/interledger-packet/src/hex.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 /// Slice as hex string debug formatter, doesn't require allocating a string.
+#[derive(PartialEq, Eq)]
 pub struct HexString<'a>(pub &'a [u8]);
 
 impl<'a> fmt::Debug for HexString<'a> {

--- a/crates/interledger-packet/src/lib.rs
+++ b/crates/interledger-packet/src/lib.rs
@@ -19,3 +19,93 @@ pub use self::errors::ParseError;
 pub use self::packet::MaxPacketAmountDetails;
 pub use self::packet::{Fulfill, Packet, PacketType, Prepare, Reject};
 pub use self::packet::{FulfillBuilder, PrepareBuilder, RejectBuilder};
+
+#[cfg(any(fuzzing, test))]
+pub fn lenient_packet_roundtrips(data: &[u8]) -> Result<(), ParseError> {
+    use bytes::BytesMut;
+    use std::convert::{TryFrom, TryInto};
+
+    let pkt = Packet::try_from(BytesMut::from(data))?;
+
+    // try to create a corresponding builder and a new set of bytes
+    match pkt {
+        Packet::Prepare(p) => {
+            let other = PrepareBuilder {
+                amount: p.amount(),
+                expires_at: p.expires_at(),
+                destination: p.destination(),
+                execution_condition: p
+                    .execution_condition()
+                    .try_into()
+                    .expect("wrong length slice"),
+                data: p.data(),
+            }
+            .build();
+
+            if p == other {
+                // if the packet roundtripped, great, we are done
+                return Ok(());
+            }
+
+            // doublecheck to see if this was because fuzzer added bytes in the trailer of the
+            // initial varlen field.
+            //
+            // bytes outside of the outermost varlen field are not accepted per specs.
+
+            assert_eq!(p.amount(), other.amount());
+            assert_eq!(p.expires_at(), other.expires_at());
+            assert_eq!(p.destination(), other.destination());
+            assert_eq!(p.execution_condition(), other.execution_condition());
+            assert_eq!(p.data(), other.data());
+
+            let p = BytesMut::from(p);
+            let other = BytesMut::from(other);
+
+            // since the components are equal, make sure that the only way the difference can
+            // be is with *extra* bytes
+            assert!(p.len() > other.len());
+        }
+        Packet::Fulfill(f) => {
+            let other = FulfillBuilder {
+                fulfillment: f.fulfillment().try_into().expect("wrong length slice"),
+                data: f.data(),
+            }
+            .build();
+
+            if f == other {
+                return Ok(());
+            }
+
+            assert_eq!(f.fulfillment(), other.fulfillment());
+            assert_eq!(f.data(), other.data());
+
+            let f = BytesMut::from(f);
+            let other = BytesMut::from(other);
+            assert!(f.len() > other.len());
+        }
+        Packet::Reject(r) => {
+            let other = RejectBuilder {
+                code: r.code(),
+                message: r.message(),
+                triggered_by: r.triggered_by().as_ref(),
+                data: r.data(),
+            }
+            .build();
+
+            if r == other {
+                return Ok(());
+            }
+
+            assert_eq!(r.code(), other.code());
+            assert_eq!(r.message(), other.message());
+            assert_eq!(r.triggered_by(), other.triggered_by());
+            assert_eq!(r.data(), other.data());
+
+            let r = BytesMut::from(r);
+            let other = BytesMut::from(other);
+            assert!(r.len() > other.len());
+        }
+    }
+
+    Ok(())
+}

--- a/crates/interledger-packet/src/lib.rs
+++ b/crates/interledger-packet/src/lib.rs
@@ -23,6 +23,7 @@ pub use self::packet::{FulfillBuilder, PrepareBuilder, RejectBuilder};
 #[cfg(any(fuzzing, test))]
 pub fn lenient_packet_roundtrips(data: &[u8]) -> Result<(), ParseError> {
     use bytes::BytesMut;
+    use hex::HexString;
     use std::convert::{TryFrom, TryInto};
 
     let pkt = Packet::try_from(BytesMut::from(data))?;
@@ -79,7 +80,7 @@ pub fn lenient_packet_roundtrips(data: &[u8]) -> Result<(), ParseError> {
         }
     };
 
-    assert_eq!(data, other);
+    assert_eq!(HexString(data), HexString(&other[..]));
 
     Ok(())
 }

--- a/crates/interledger-packet/src/packet.rs
+++ b/crates/interledger-packet/src/packet.rs
@@ -671,6 +671,88 @@ mod fuzzed {
             "Invalid Packet: Reject.ErrorCode was not IA5String"
         );
     }
+
+    #[test]
+    fn fuzzed_0_with_fixed_errorcode() {
+        #[rustfmt::skip]
+        let orig = [
+            // reject
+            14,
+            // varlen for the content
+            13,
+            // fixed error code
+            116, 119, 127,
+            // varlen address
+            6, 116, 101, 115, 116, 46, 116,
+            // varlen message
+            0,
+            // varlen data
+            0,
+            // extra byte in the end
+            42,
+        ];
+
+        roundtrip(&orig);
+    }
+
+    fn roundtrip(bytes: &[u8]) {
+        use super::{FulfillBuilder, Packet::*, PrepareBuilder, RejectBuilder};
+        use std::convert::TryInto;
+        match Packet::try_from(BytesMut::from(bytes)).unwrap() {
+            Prepare(p) => {
+                let other = PrepareBuilder {
+                    amount: p.amount(),
+                    expires_at: p.expires_at(),
+                    destination: p.destination(),
+                    execution_condition: p
+                        .execution_condition()
+                        .try_into()
+                        .expect("wrong length slice"),
+                    data: p.data(),
+                }
+                .build();
+
+                if p != other {
+                    assert_eq!(p.amount(), other.amount());
+                    assert_eq!(p.expires_at(), other.expires_at());
+                    assert_eq!(p.destination(), other.destination());
+                    assert_eq!(p.execution_condition(), other.execution_condition());
+                    assert_eq!(p.data(), other.data());
+                }
+            }
+            Fulfill(f) => {
+                let other = FulfillBuilder {
+                    fulfillment: f.fulfillment().try_into().expect("wrong length slice"),
+                    data: f.data(),
+                }
+                .build();
+
+                if f != other {
+                    assert_eq!(f.fulfillment(), other.fulfillment());
+                    assert_eq!(f.data(), other.data());
+                }
+            }
+            Reject(r) => {
+                let other = RejectBuilder {
+                    code: r.code(),
+                    message: r.message(),
+                    triggered_by: r.triggered_by().as_ref(),
+                    data: r.data(),
+                }
+                .build();
+
+                if r != other {
+                    // doublecheck to see if this was because fuzzer added bytes in the trailer of
+                    // the initial varlen field.
+
+                    assert_eq!(r.code(), other.code());
+                    assert_eq!(r.message(), other.message());
+                    assert_eq!(r.triggered_by(), other.triggered_by());
+                    assert_eq!(r.data(), other.data());
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/interledger-packet/src/packet.rs
+++ b/crates/interledger-packet/src/packet.rs
@@ -653,7 +653,7 @@ mod fuzzed {
     use std::convert::TryFrom;
 
     #[test]
-    fn fuzzed_0_non_utf8_error_code() {
+    fn fuzzed_0_non_ascii_error_code() {
         #[rustfmt::skip]
         let orig = [
             // reject

--- a/crates/interledger-packet/src/packet.rs
+++ b/crates/interledger-packet/src/packet.rs
@@ -682,8 +682,8 @@ mod fuzzed {
 
         let e = Packet::try_from(BytesMut::from(&orig[..])).unwrap_err();
         assert_eq!(
+            "Invalid Packet: Reject.ErrorCode was not IA5String",
             &e.to_string(),
-            "Invalid Packet: Reject.ErrorCode was not IA5String"
         );
     }
 
@@ -711,8 +711,8 @@ mod fuzzed {
 
         if cfg!(feature = "strict") {
             assert_eq!(
+                "Invalid Packet: Unexpected inner trailing bytes",
                 &res.unwrap_err().to_string(),
-                "Invalid Packet: Unexpected inner trailing bytes"
             );
         } else {
             res.unwrap();
@@ -736,7 +736,7 @@ mod test_packet_type {
     fn try_from_empty() {
         assert_eq!(
             "Invalid Packet: Unknown packet type: None",
-            format!("{}", PacketType::try_from(&[][..]).unwrap_err())
+            &PacketType::try_from(&[][..]).unwrap_err().to_string()
         );
     }
 }
@@ -835,7 +835,7 @@ mod test_prepare {
         {
             assert_eq!(
                 "Invalid Packet: Unexpected outer trailing bytes",
-                format!("{}", with_junk_data.unwrap_err())
+                &with_junk_data.unwrap_err().to_string()
             );
         }
 
@@ -935,16 +935,12 @@ mod test_fulfill {
 
         // feature = "strict" is used when fuzzing and is tested here to ensure
         // error is returned instead of roundtripping when junk data is added
-        #[cfg(feature = "strict")]
-        {
+        if cfg!(feature = "strict") {
             assert_eq!(
                 "Invalid Packet: Unexpected outer trailing bytes",
-                format!("{}", with_junk_data.unwrap_err())
+                &with_junk_data.unwrap_err().to_string()
             );
-        }
-
-        #[cfg(not(feature = "strict"))]
-        {
+        } else {
             let with_junk_data = with_junk_data.unwrap();
             assert_eq!(with_junk_data.fulfillment(), fixtures::FULFILLMENT);
             assert_eq!(with_junk_data.data(), fixtures::DATA);
@@ -990,7 +986,7 @@ mod test_fulfill {
         if cfg!(feature = "strict") {
             assert_eq!(
                 "Invalid Packet: Unexpected inner trailing bytes",
-                format!("{}", res.unwrap_err())
+                &res.unwrap_err().to_string()
             );
         } else {
             res.unwrap();
@@ -1039,16 +1035,12 @@ mod test_reject {
 
         // feature = "strict" is used when fuzzing and is tested here to ensure
         // error is returned instead of roundtripping when junk data is added
-        #[cfg(feature = "strict")]
-        {
+        if cfg!(feature = "strict") {
             assert_eq!(
                 "Invalid Packet: Unexpected outer trailing bytes",
-                format!("{}", with_junk_data.unwrap_err())
+                &with_junk_data.unwrap_err().to_string()
             );
-        }
-
-        #[cfg(not(feature = "strict"))]
-        {
+        } else {
             let with_junk_data = with_junk_data.unwrap();
             assert_eq!(with_junk_data.code(), REJECT_BUILDER.code);
             assert_eq!(with_junk_data.message(), REJECT_BUILDER.message);

--- a/crates/interledger-packet/src/packet.rs
+++ b/crates/interledger-packet/src/packet.rs
@@ -160,6 +160,12 @@ impl TryFrom<BytesMut> for Prepare {
         let data_offset = content_offset + content_len - content.len();
         content.skip_var_octet_string()?;
 
+        if !content.is_empty() {
+            return Err(ParseError::InvalidPacket(
+                "Packet contains trailing bytes".into(),
+            ));
+        }
+
         Ok(Prepare {
             buffer,
             content_offset,
@@ -433,6 +439,12 @@ impl TryFrom<BytesMut> for Reject {
         let data_offset = content_offset + content_len - content.len();
         content.skip_var_octet_string()?;
 
+        if !content.is_empty() {
+            return Err(ParseError::InvalidPacket(
+                "Packet contains trailing bytes".into(),
+            ));
+        }
+
         Ok(Reject {
             buffer,
             code,
@@ -692,7 +704,12 @@ mod fuzzed {
             42,
         ];
 
-        crate::lenient_packet_roundtrips(&orig[..]).unwrap();
+        let e = crate::lenient_packet_roundtrips(&orig[..]).unwrap_err();
+
+        assert_eq!(
+            &e.to_string(),
+            "Invalid Packet: Packet contains trailing bytes"
+        );
     }
 }
 

--- a/crates/interledger-packet/src/packet.rs
+++ b/crates/interledger-packet/src/packet.rs
@@ -692,66 +692,7 @@ mod fuzzed {
             42,
         ];
 
-        roundtrip(&orig);
-    }
-
-    fn roundtrip(bytes: &[u8]) {
-        use super::{FulfillBuilder, Packet::*, PrepareBuilder, RejectBuilder};
-        use std::convert::TryInto;
-        match Packet::try_from(BytesMut::from(bytes)).unwrap() {
-            Prepare(p) => {
-                let other = PrepareBuilder {
-                    amount: p.amount(),
-                    expires_at: p.expires_at(),
-                    destination: p.destination(),
-                    execution_condition: p
-                        .execution_condition()
-                        .try_into()
-                        .expect("wrong length slice"),
-                    data: p.data(),
-                }
-                .build();
-
-                if p != other {
-                    assert_eq!(p.amount(), other.amount());
-                    assert_eq!(p.expires_at(), other.expires_at());
-                    assert_eq!(p.destination(), other.destination());
-                    assert_eq!(p.execution_condition(), other.execution_condition());
-                    assert_eq!(p.data(), other.data());
-                }
-            }
-            Fulfill(f) => {
-                let other = FulfillBuilder {
-                    fulfillment: f.fulfillment().try_into().expect("wrong length slice"),
-                    data: f.data(),
-                }
-                .build();
-
-                if f != other {
-                    assert_eq!(f.fulfillment(), other.fulfillment());
-                    assert_eq!(f.data(), other.data());
-                }
-            }
-            Reject(r) => {
-                let other = RejectBuilder {
-                    code: r.code(),
-                    message: r.message(),
-                    triggered_by: r.triggered_by().as_ref(),
-                    data: r.data(),
-                }
-                .build();
-
-                if r != other {
-                    // doublecheck to see if this was because fuzzer added bytes in the trailer of
-                    // the initial varlen field.
-
-                    assert_eq!(r.code(), other.code());
-                    assert_eq!(r.message(), other.message());
-                    assert_eq!(r.triggered_by(), other.triggered_by());
-                    assert_eq!(r.data(), other.data());
-                }
-            }
-        }
+        crate::lenient_packet_roundtrips(&orig[..]).unwrap();
     }
 }
 

--- a/crates/interledger-packet/src/packet.rs
+++ b/crates/interledger-packet/src/packet.rs
@@ -707,7 +707,7 @@ mod fuzzed {
     }
 
     #[test]
-    fn fuzzed_0_with_fixed_errorcode() {
+    fn fuzzed_1_with_fixed_errorcode() {
         #[rustfmt::skip]
         let orig = [
             // reject
@@ -740,7 +740,7 @@ mod fuzzed {
 
     #[test]
     #[cfg(feature = "roundtrip-only")]
-    fn fuzzed_1_chrono_60s_rollover() {
+    fn fuzzed_2_chrono_60s_rollover() {
         // this has been reduced from the original
         #[rustfmt::skip]
         let orig = [


### PR DESCRIPTION
Cc: #705

This is a follow-up to #716 with:

- `interledger-packet/roundtrip-only` feature for denying ILP timestamps which don't roundtrip [^1]
- rejects trailing bytes on `interledger-packet/strict` for Prepare and Reject (continues #710 which did this for Fulfill) [^2]
- stylistic refactoring around unifying the style (assert_eq order, `.to_string()` calls, `if cfg!(...) { } else { }`)
- moves the fuzz target verification to `src/lib.rs` where it can be used with tests as well
- adds `PartialEq` derivation for `interledger-packet::hex::HexString` for use in `assert_eq!(HexString(...), HexString(...));`

[^1]: Unsure if this should be the default; it'd seem that the `60` as the `%S` field is accepted for every date, which might not match the idea in the RFCs. "Every date" as in best to my knowledge, 2000-05-31 was not any special day w.r.t. leap seconds.

[^2]: Changes include string changes for consistent "Unexpected {inner,outer} trailing bytes", where outer means outside the interledger-packet envelope and inner means inside the envelope.