### PR TITLE
fix: Clean up and decouple interledge-packet::ParseError in other crates 

### DIFF
--- a/crates/interledger-btp/src/errors.rs
+++ b/crates/interledger-btp/src/errors.rs
@@ -1,16 +1,21 @@
 use std::str::Utf8Error;
-use std::string::FromUtf8Error;
 
 #[derive(Debug, thiserror::Error)]
-pub enum ParseError {
+pub enum BtpPacketError {
     #[error("I/O Error: {0}")]
     IoErr(#[from] std::io::Error),
     #[error("UTF-8 Error: {0}")]
     Utf8Err(#[from] Utf8Error),
-    #[error("UTF-8 Conversion Error: {0}")]
-    FromUtf8Err(#[from] FromUtf8Error),
     #[error("Chrono Error: {0}")]
     ChronoErr(#[from] chrono::ParseError),
-    #[error("Invalid Packet: {0}")]
-    InvalidPacket(String),
+    #[error("PacketType Error: {0}")]
+    PacketTypeError(#[from] PacketTypeError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PacketTypeError {
+    #[error("PacketType {0} is not supported")]
+    Unknown(u8),
+    #[error("PacketType {1} expected, found {0}")]
+    Unexpected(u8, u8),
 }

--- a/crates/interledger-btp/src/errors.rs
+++ b/crates/interledger-btp/src/errors.rs
@@ -9,13 +9,13 @@ pub enum BtpPacketError {
     #[error("Chrono Error: {0}")]
     ChronoErr(#[from] chrono::ParseError),
     #[error("PacketType Error: {0}")]
-    PacketTypeError(#[from] PacketTypeError),
+    PacketType(#[from] PacketTypeError),
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum PacketTypeError {
     #[error("PacketType {0} is not supported")]
     Unknown(u8),
-    #[error("PacketType {1} expected, found {0}")]
+    #[error("Cannot parse Message from packet of type {0}, expected type {1}")]
     Unexpected(u8, u8),
 }

--- a/crates/interledger-packet/src/address.rs
+++ b/crates/interledger-packet/src/address.rs
@@ -18,9 +18,9 @@ const MAX_ADDRESS_LENGTH: usize = 1023;
 
 #[derive(thiserror::Error, Debug)]
 pub enum AddressError {
-    #[error("Invalid address length: {0}")]
+    #[error("Invalid Address: Invalid address length: {0}")]
     InvalidLength(usize),
-    #[error("Invalid address format")]
+    #[error("Invalid Address: Invalid address format")]
     InvalidFormat,
 }
 
@@ -278,13 +278,10 @@ mod test_address {
             &Address::try_from(Bytes::from("test.alice")).unwrap(),
             &[Token::BorrowedStr("test.alice")],
         );
-        // TODO: Why does it format it differently
-        // left: `Error { msg: "Invalid address format" }`,
-        // right: `"Invalid Address: Invalid address format"`
-        // assert_de_tokens_error::<Address>(
-        //     &[Token::BorrowedStr("test.alice ")],
-        //     "Invalid Address: Invalid address format",
-        // );
+        assert_de_tokens_error::<Address>(
+            &[Token::BorrowedStr("test.alice ")],
+            "Invalid Address: Invalid address format",
+        );
     }
 
     #[test]

--- a/crates/interledger-packet/src/errors.rs
+++ b/crates/interledger-packet/src/errors.rs
@@ -12,6 +12,7 @@ pub enum ParseError {
     PacketTypeError(#[from] PacketTypeError),
     #[error("Trailing Bytes Error: {0}")]
     TrailingBytesError(#[from] TrailingBytesError),
+    // TODO: use specific errors for timestamp etc
     #[error("Data Type Error: {0}")]
     DataTypeError(#[from] DataTypeError),
     #[error("Wrong Type: {0}")]

--- a/crates/interledger-packet/src/errors.rs
+++ b/crates/interledger-packet/src/errors.rs
@@ -1,24 +1,56 @@
+use super::AddressError;
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;
-
-use super::AddressError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ParseError {
     #[error("I/O Error: {0}")]
     IoErr(#[from] std::io::Error),
-    #[error("UTF-8 Error: {0}")]
-    Utf8Err(#[from] Utf8Error),
-    #[error("UTF-8 Conversion Error: {0}")]
-    FromUtf8Err(#[from] FromUtf8Error),
     #[error("Chrono Error: {0}")]
     ChronoErr(#[from] chrono::ParseError),
+    #[error("PacketType Error: {0}")]
+    PacketTypeError(#[from] PacketTypeError),
+    #[error("Trailing Bytes Error: {0}")]
+    TrailingBytesError(#[from] TrailingBytesError),
+    #[error("Data Type Error: {0}")]
+    DataTypeError(#[from] DataTypeError),
     #[error("Wrong Type: {0}")]
     WrongType(String),
     #[error("Invalid Address: {0}")]
     InvalidAddress(#[from] AddressError),
     #[error("Invalid Packet: {0}")]
     InvalidPacket(String),
-    #[error(transparent)]
-    OtherErr(Box<dyn std::error::Error + Send>),
+    #[error("Roundtrip(Fuzzing) Error")]
+    RoundtripError,
+    // TODO: move below to other crates
+    #[error("UTF-8 Error: {0}")]
+    Utf8Err(#[from] Utf8Error),
+    #[error("UTF-8 Conversion Error: {0}")]
+    FromUtf8Err(#[from] FromUtf8Error),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PacketTypeError {
+    #[error("PacketType data not found")]
+    EOF,
+    #[error("PacketType {0} is not supported")]
+    Unknown(u8),
+    #[error("PacketType {1} expected, found {0}")]
+    Unexpected(u8, u8),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TrailingBytesError {
+    #[error("Outer")]
+    Outer,
+    #[error("Inner")]
+    Inner,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DataTypeError {
+    #[error("Should be IA5String")]
+    IA5String,
+    #[error("Should be ASCII")]
+    ASCII,
 }

--- a/crates/interledger-packet/src/errors.rs
+++ b/crates/interledger-packet/src/errors.rs
@@ -1,6 +1,4 @@
 use super::AddressError;
-use std::str::Utf8Error;
-use std::string::FromUtf8Error;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ParseError {
@@ -9,31 +7,24 @@ pub enum ParseError {
     #[error("Chrono Error: {0}")]
     ChronoErr(#[from] chrono::ParseError),
     #[error("PacketType Error: {0}")]
-    PacketTypeError(#[from] PacketTypeError),
-    #[error("Trailing Bytes Error: {0}")]
-    TrailingBytesError(#[from] TrailingBytesError),
-    // TODO: use specific errors for timestamp etc
-    #[error("Data Type Error: {0}")]
-    DataTypeError(#[from] DataTypeError),
-    #[error("Wrong Type: {0}")]
-    WrongType(String),
+    PacketType(#[from] PacketTypeError),
+    #[error("Invalid Packet: Reject.ErrorCode was not IA5String")]
+    ErrorCodeConversion,
+    #[error("Invalid Packet: DateTime must be numeric")]
+    TimestampConversion,
     #[error("Invalid Address: {0}")]
     InvalidAddress(#[from] AddressError),
     #[error("Invalid Packet: {0}")]
-    InvalidPacket(String),
-    #[error("Roundtrip(Fuzzing) Error")]
-    RoundtripError,
-    // TODO: move below to other crates
-    #[error("UTF-8 Error: {0}")]
-    Utf8Err(#[from] Utf8Error),
-    #[error("UTF-8 Conversion Error: {0}")]
-    FromUtf8Err(#[from] FromUtf8Error),
+    TrailingBytes(#[from] TrailingBytesError),
+    #[cfg(feature = "roundtrip-only")]
+    #[cfg_attr(feature = "roundtrip-only", error("Timestamp not roundtrippable"))]
+    NonRoundtrippableTimestamp,
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum PacketTypeError {
-    #[error("PacketType data not found")]
-    EOF,
+    #[error("Invalid Packet: Unknown packet type")]
+    Eof,
     #[error("PacketType {0} is not supported")]
     Unknown(u8),
     #[error("PacketType {1} expected, found {0}")]
@@ -42,16 +33,8 @@ pub enum PacketTypeError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum TrailingBytesError {
-    #[error("Outer")]
+    #[error("Unexpected outer trailing bytes")]
     Outer,
-    #[error("Inner")]
+    #[error("Unexpected inner trailing bytes")]
     Inner,
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum DataTypeError {
-    #[error("Should be IA5String")]
-    IA5String,
-    #[error("Should be ASCII")]
-    ASCII,
 }

--- a/crates/interledger-packet/src/lib.rs
+++ b/crates/interledger-packet/src/lib.rs
@@ -14,7 +14,7 @@ mod packet;
 
 pub use self::address::{Address, AddressError};
 pub use self::error::{ErrorClass, ErrorCode};
-pub use self::errors::{DataTypeError, PacketTypeError, ParseError, TrailingBytesError};
+pub use self::errors::{PacketTypeError, ParseError, TrailingBytesError};
 
 pub use self::packet::MaxPacketAmountDetails;
 pub use self::packet::{Fulfill, Packet, PacketType, Prepare, Reject};

--- a/crates/interledger-packet/src/lib.rs
+++ b/crates/interledger-packet/src/lib.rs
@@ -14,7 +14,7 @@ mod packet;
 
 pub use self::address::{Address, AddressError};
 pub use self::error::{ErrorClass, ErrorCode};
-pub use self::errors::ParseError;
+pub use self::errors::{DataTypeError, PacketTypeError, ParseError, TrailingBytesError};
 
 pub use self::packet::MaxPacketAmountDetails;
 pub use self::packet::{Fulfill, Packet, PacketType, Prepare, Reject};

--- a/crates/interledger-packet/src/packet.rs
+++ b/crates/interledger-packet/src/packet.rs
@@ -431,7 +431,7 @@ impl TryFrom<BytesMut> for Reject {
         let mut code = [0; 3];
         content.read_exact(&mut code)?;
 
-        let code = ErrorCode::new(code).ok_or_else(|| DataTypeError::IA5String)?;
+        let code = ErrorCode::new(code).ok_or(DataTypeError::IA5String)?;
 
         let triggered_by_offset = content_offset + content_len - content.len();
         Address::try_from(content.read_var_octet_string()?)?;

--- a/crates/interledger-store/src/account.rs
+++ b/crates/interledger-store/src/account.rs
@@ -116,7 +116,7 @@ impl Account {
             Some(a) => a,
             None => node_ilp_address
                 .with_suffix(details.username.as_bytes())
-                .map_err(CreateAccountError::InvalidSuffix)?,
+                .map_err(|e| CreateAccountError::InvalidSuffix(e.into()))?,
         };
 
         let ilp_over_http_url = if let Some(ref url) = details.ilp_over_http_url {

--- a/crates/interledger-stream/src/error.rs
+++ b/crates/interledger-stream/src/error.rs
@@ -1,34 +1,41 @@
-use interledger_packet::{AddressError, PacketTypeError as IlpPacketTypeError};
+use interledger_packet::{AddressError, ErrorCode, PacketTypeError as IlpPacketTypeError};
 /// Stream Errors
 use std::str::Utf8Error;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    //TODO: can we remove these strings?
-    #[error("Error polling: {0}")]
-    SendMoneyError(String),
-    #[error("Error maximum time exceeded: {0}")]
-    TimeoutError(String),
+    #[error("Terminating payment since too many packets are rejected ({0} packets fulfilled, {1} packets rejected)")]
+    PaymentFailFast(u64, u64),
+    #[error("Packet was rejected with ErrorCode: {0} {1:?}")]
+    UnexpectedRejection(ErrorCode, String),
+    #[error(
+        "Error maximum time exceeded: Time since last fulfill exceeded the maximum time limit"
+    )]
+    Timeout,
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum StreamPacketError {
-    #[error("Unable to decrypt message")]
+    #[error("Unable to decrypt packet")]
     FailedToDecrypt,
-    #[error("Stream version not supported")]
-    UnsupportedVersion,
-    #[error("Frames Error: Not enough successfully parsed frames")]
+    #[error("Unsupported STREAM version: {0}")]
+    UnsupportedVersion(u8),
+    #[error("Invalid Packet: Incorrect number of frames or unable to parse all frames")]
     NotEnoughValidFrames,
     #[error("Trailing bytes error: Inner")]
     TrailingInnerBytes,
-    #[error("Roundtrip only: Error expected for roundtrip fuzzing")]
-    RoundtripError,
     #[error("I/O Error: {0}")]
     IoErr(#[from] std::io::Error),
     #[error("Ilp PacketType Error: {0}")]
-    IplPacketTypeError(#[from] IlpPacketTypeError),
+    IlpPacketType(#[from] IlpPacketTypeError),
     #[error("Address Error: {0}")]
-    AddressError(#[from] AddressError),
+    Address(#[from] AddressError),
     #[error("UTF-8 Error: {0}")]
     Utf8Err(#[from] Utf8Error),
+    #[cfg(feature = "roundtrip-only")]
+    #[cfg_attr(
+        feature = "roundtrip-only",
+        error("Roundtrip only: Error expected for roundtrip fuzzing")
+    )]
+    NonRoundtrippableSaturatingAmount,
 }

--- a/crates/interledger-stream/src/error.rs
+++ b/crates/interledger-stream/src/error.rs
@@ -1,12 +1,34 @@
+use interledger_packet::{AddressError, PacketTypeError as IlpPacketTypeError};
 /// Stream Errors
+use std::str::Utf8Error;
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Error connecting: {0}")]
-    ConnectionError(String),
-    #[error("Error polling: {0}")]
-    PollError(String),
+    //TODO: can we remove these strings?
     #[error("Error polling: {0}")]
     SendMoneyError(String),
     #[error("Error maximum time exceeded: {0}")]
     TimeoutError(String),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum StreamPacketError {
+    #[error("Unable to decrypt message")]
+    FailedToDecrypt,
+    #[error("Stream version not supported")]
+    UnsupportedVersion,
+    #[error("Frames Error: Not enough successfully parsed frames")]
+    NotEnoughValidFrames,
+    #[error("Trailing bytes error: Inner")]
+    TrailingInnerBytes,
+    #[error("Roundtrip only: Error expected for roundtrip fuzzing")]
+    RoundtripError,
+    #[error("I/O Error: {0}")]
+    IoErr(#[from] std::io::Error),
+    #[error("Ilp PacketType Error: {0}")]
+    IplPacketTypeError(#[from] IlpPacketTypeError),
+    #[error("Address Error: {0}")]
+    AddressError(#[from] AddressError),
+    #[error("UTF-8 Error: {0}")]
+    Utf8Err(#[from] Utf8Error),
 }

--- a/crates/interledger-stream/src/lib.rs
+++ b/crates/interledger-stream/src/lib.rs
@@ -338,7 +338,7 @@ mod send_money_to_receiver {
 
         // Connector takes 2% spread, but we're only willing to tolerate 1.4%
         match result {
-            Err(Error::SendMoneyError(_)) => {}
+            Err(Error::PaymentFailFast(_, _)) => {}
             _ => panic!("Payment should fail fast due to poor exchange rates"),
         }
     }

--- a/crates/interledger-stream/src/lib.rs
+++ b/crates/interledger-stream/src/lib.rs
@@ -18,7 +18,7 @@ mod packet;
 mod server;
 
 pub use client::{send_money, StreamDelivery};
-pub use error::Error;
+pub use error::{Error, StreamPacketError};
 pub use server::{
     ConnectionGenerator, PaymentNotification, StreamNotificationsStore, StreamReceiverService,
 };


### PR DESCRIPTION
cc #708 

This attempts to decouple the error type `ParseError` in interledger-packet with other crates. 
The idea is to have more explicit errors that are more efficient. 