### PR TITLE
Clippy warnings in 1.53

### DIFF
--- a/crates/interledger-http/src/client.rs
+++ b/crates/interledger-http/src/client.rs
@@ -9,7 +9,7 @@ use reqwest::{
     Client, ClientBuilder, Response as HttpResponse,
 };
 use secrecy::{ExposeSecret, SecretString};
-use std::{convert::TryFrom, iter::FromIterator, marker::PhantomData, sync::Arc, time::Duration};
+use std::{convert::TryFrom, marker::PhantomData, sync::Arc, time::Duration};
 use tracing::{error, trace};
 
 /// The HttpClientService implements [OutgoingService](../../interledger_service/trait.OutgoingService)
@@ -158,7 +158,7 @@ async fn parse_packet_from_response(response: HttpResponse, ilp_address: Address
         })
         .await?;
 
-    let body = BytesMut::from_iter(body.into_iter());
+    let body = body.into_iter().collect::<BytesMut>();
     match Packet::try_from(body) {
         Ok(Packet::Fulfill(fulfill)) => Ok(fulfill),
         Ok(Packet::Reject(reject)) => Err(reject),

--- a/crates/interledger-http/src/lib.rs
+++ b/crates/interledger-http/src/lib.rs
@@ -101,69 +101,59 @@ mod tests {
         let body_incorrect = r#"{"other_key": 0}"#;
 
         // `content-type` should be provided.
-        assert_eq!(
-            request().body(body_correct).matches(&json_filter).await,
-            false
-        );
+        assert!(!request().body(body_correct).matches(&json_filter).await);
 
         // Should accept only "application/json" or "application/json; charset=utf-8"
-        assert_eq!(
-            request()
+        assert!(
+            !request()
                 .body(body_correct)
                 .header("content-type", "text/plain")
                 .matches(&json_filter)
-                .await,
-            false
+                .await
         );
-        assert_eq!(
+        assert!(
             request()
                 .body(body_correct)
                 .header("content-type", "application/json")
                 .matches(&json_filter)
-                .await,
-            true
+                .await
         );
-        assert_eq!(
-            request()
+        assert!(
+            !request()
                 .body(body_correct)
                 .header("content-type", "application/json; charset=ascii")
                 .matches(&json_filter)
-                .await,
-            false
+                .await
         );
-        assert_eq!(
+        assert!(
             request()
                 .body(body_correct)
                 .header("content-type", "application/json; charset=utf-8")
                 .matches(&json_filter)
-                .await,
-            true
+                .await
         );
-        assert_eq!(
+        assert!(
             request()
                 .body(body_correct)
                 .header("content-type", "application/json; charset=UTF-8")
                 .matches(&json_filter)
-                .await,
-            true
+                .await
         );
 
         // Should accept only bodies that can be deserialized
-        assert_eq!(
-            request()
+        assert!(
+            !request()
                 .body(body_incorrect)
                 .header("content-type", "application/json")
                 .matches(&json_filter)
-                .await,
-            false
+                .await
         );
-        assert_eq!(
-            request()
+        assert!(
+            !request()
                 .body(body_incorrect)
                 .header("content-type", "application/json; charset=utf-8")
                 .matches(&json_filter)
-                .await,
-            false
+                .await
         );
     }
 }

--- a/crates/interledger-service-util/src/balance_service.rs
+++ b/crates/interledger-service-util/src/balance_service.rs
@@ -660,8 +660,8 @@ mod tests {
 
         tokio::time::delay_for(Duration::from_millis(100u64)).await;
         mock.assert();
-        assert_eq!(*store.refunded_settlement.read(), false);
-        assert_eq!(*store.rejected_message.read(), false);
+        assert!(!*store.refunded_settlement.read());
+        assert!(!*store.rejected_message.read());
     }
 
     #[tokio::test]
@@ -683,8 +683,8 @@ mod tests {
 
         tokio::time::delay_for(Duration::from_millis(100u64)).await;
         mock.assert();
-        assert_eq!(*store.refunded_settlement.read(), false);
-        assert_eq!(*store.rejected_message.read(), false);
+        assert!(!*store.refunded_settlement.read());
+        assert!(!*store.rejected_message.read());
     }
 
     #[tokio::test]
@@ -706,8 +706,8 @@ mod tests {
 
         tokio::time::delay_for(Duration::from_millis(100u64)).await;
         mock.assert();
-        assert_eq!(*store.refunded_settlement.read(), true);
-        assert_eq!(*store.rejected_message.read(), false);
+        assert!(*store.refunded_settlement.read());
+        assert!(!*store.rejected_message.read());
     }
 
     #[tokio::test]
@@ -734,7 +734,7 @@ mod tests {
 
         tokio::time::delay_for(Duration::from_millis(100u64)).await;
         mock.assert();
-        assert_eq!(*store.rejected_message.read(), true);
+        assert!(*store.rejected_message.read());
     }
 
     #[derive(Debug, Clone)]

--- a/crates/interledger-service-util/src/rate_limit_service.rs
+++ b/crates/interledger-service-util/src/rate_limit_service.rs
@@ -187,7 +187,7 @@ mod tests {
         let mut service = RateLimitService::new(store.clone(), next);
         let fulfill = service.handle_request(TEST_REQUEST.clone()).await.unwrap();
         assert_eq!(fulfill.data(), b"test data");
-        assert_eq!(*store.was_refunded.read(), false);
+        assert!(!*store.was_refunded.read());
     }
 
     #[tokio::test]
@@ -208,7 +208,7 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(reject.code(), ErrorCode::T00_INTERNAL_ERROR);
-        assert_eq!(*store.was_refunded.read(), true);
+        assert!(*store.was_refunded.read());
     }
 
     #[tokio::test]
@@ -227,7 +227,7 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(reject.code(), ErrorCode::T05_RATE_LIMITED);
-        assert_eq!(*store.was_refunded.read(), false);
+        assert!(!*store.was_refunded.read());
     }
 
     #[tokio::test]
@@ -246,7 +246,7 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(reject.code(), ErrorCode::T04_INSUFFICIENT_LIQUIDITY);
-        assert_eq!(*store.was_refunded.read(), false);
+        assert!(!*store.was_refunded.read());
     }
 
     #[tokio::test]
@@ -265,7 +265,7 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(reject.code(), ErrorCode::T00_INTERNAL_ERROR);
-        assert_eq!(*store.was_refunded.read(), false);
+        assert!(!*store.was_refunded.read());
     }
 
     #[derive(Debug, Clone)]


### PR DESCRIPTION
fixed [bool_assert_comparison](https://rust-lang.github.io/rust-clippy/master/index.html#bool_assert_comparison) and [from_iter_instead_of_collect](https://rust-lang.github.io/rust-clippy/master/index.html#from_iter_instead_of_collect) clippy lint warnings.