### PR TITLE
fix(ilp-node): explicit use of uuid v4 feature

### DIFF
--- a/crates/ilp-node/Cargo.toml
+++ b/crates/ilp-node/Cargo.toml
@@ -56,7 +56,7 @@ url = { version = "2.1.1", default-features = false }
 libc = { version = "0.2.62", default-features = false }
 warp = { version = "0.2", default-features = false, features = ["websocket"] }
 secrecy = { version = "0.6.0", default-features = false, features = ["alloc", "serde"] }
-uuid = { version = "0.8.1", default-features = false}
+uuid = { version = "0.8.1", default-features = false, features = ["v4"] }
 
 # For google-pubsub
 base64 = { version = "0.11.0", default-features = false, optional = true }


### PR DESCRIPTION
This PR adds `features = ["v4"]` to `crates/ilp-node/Cargo.toml` to prevent a confusing error that might occur when trying to use i.e. `Uuid::new_v4` downstream.