### PR TITLE
CI speedup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,8 @@ name: CI
 
 # limit ci building to pushes to master not to get twice the notification email
 # from github.
-#
-# if you want to test your branch on your fork, just replace the 'branches'
-# filter below for 'push' with the one for 'pull_request' temporarily and drop
-# the commit when creating the PR.
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
           rust-version: stable
           components: clippy, rustfmt
 
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+
       - name: Build
         run: cargo build --all-features --all-targets
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,16 +130,69 @@ jobs:
       - name: Test --features strict
         run: timeout 15m cargo test -p interledger-btp --features strict
 
-  test-md:
+
+  settlement-engines:
+    # This job builds the ethereum-settlement-engine required by `test-md`.
+    # A separate job to enable dependency caching.
     runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          repository: interledger-rs/settlement-engines
+          ref: master
+
+      - name: Install rust toolchain
+        uses: hecrj/setup-rust-action@v1.3.4
+        with:
+          rust-version: stable
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Build
+        run: cargo build --bin ilp-settlement-ethereum
+
+      - name: Upload settlement-engine artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: settlement-engine
+          path: target/debug/ilp-settlement-ethereum
+
+  test-md:
+    env:
+      RUST_LOG: "interledger=trace"
+      RUST_BACKTRACE: "full"
+
+    needs: settlement-engines
+
+    runs-on: ubuntu-latest
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install node
-        uses: actions/setup-node@v2
+      - name: Install rust toolchain
+        uses: hecrj/setup-rust-action@v1.3.4
         with:
-          node-version: 'v12.18.4'
+          rust-version: stable
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Build binaries
+        run: |
+          mkdir -p ~/.interledger/bin
+          cargo build --bin ilp-node --bin ilp-cli
+          mv target/debug/ilp-node ~/.interledger/bin
+          mv target/debug/ilp-cli ~/.interledger/bin
+
+      - name: Download settlement engine artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: settlement-engine
+          path: ~/.interledger/bin
 
       - name: Install dependencies
         run: |
@@ -150,8 +203,7 @@ jobs:
           npm install -g ganache-cli ilp-settlement-xrp conventional-changelog-cli
 
       - name: Test
-        run: |
-          scripts/run-md-test.sh '^.*$' 1
+        run: scripts/run-md-test.sh '^.*$' 2
 
       - name: 'Store artifacts'
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,8 +207,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y redis-server redis-tools libssl-dev
 
-          # install components (ganache-cli ilp-settlement-xrp conventional-changelog-cli)
-          npm install -g ganache-cli ilp-settlement-xrp conventional-changelog-cli
+          # install components (ganache-cli ilp-settlement-xrp)
+          npm install -g ganache-cli ilp-settlement-xrp
 
       - name: Test
         run: scripts/run-md-test.sh '^.*$' 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,14 @@ jobs:
       - name: Test --features strict
         run: timeout 15m cargo test -p interledger-btp --features strict
 
+  build:
+    # Repo requires a `build` job to succeed in order to merge into master.
+    # A step and runs-on is required for a job to be valid.
+    needs: [interledger, interledger-packet, interledger-stream, interledger-btp]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Success
+        run: echo "Success"
 
   settlement-engines:
     # This job builds the ethereum-settlement-engine required by `test-md`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
     branches: '*'
 
 jobs:
-  build:
+  interledger:
     env:
       RUST_LOG: "interledger=trace"
       RUST_BACKTRACE: "full"
@@ -54,22 +54,81 @@ jobs:
       - name: Test
         run: timeout 15m cargo test --all --all-features
 
-      - name: Test with subset of features (interledger-packet)
-        run: |
-          timeout 15m cargo test -p interledger-packet
-          timeout 15m cargo test -p interledger-packet --features strict
-          timeout 15m cargo test -p interledger-packet --features roundtrip-only
+  interledger-packet:
+    env:
+      RUST_LOG: "interledger=trace"
+      RUST_BACKTRACE: "full"
 
-      - name: Test with subset of features (interledger-btp)
-        run: |
-          timeout 15m cargo test -p interledger-btp
-          timeout 15m cargo test -p interledger-btp --features strict
+    runs-on: ubuntu-latest
 
-      - name: Test with subset of features (interledger-stream)
-        run: |
-          timeout 15m cargo test -p interledger-stream
-          timeout 15m cargo test -p interledger-stream --features strict
-          timeout 15m cargo test -p interledger-stream --features roundtrip-only
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install rust toolchain
+        uses: hecrj/setup-rust-action@v1.3.4
+        with:
+          rust-version: stable
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Test
+        run: timeout 15m cargo test -p interledger-packet
+      - name: Test --features strict
+        run: timeout 15m cargo test -p interledger-packet --features strict
+      - name: Test --features roundtrip-only
+        run: timeout 15m cargo test -p interledger-packet --features roundtrip-only
+
+  interledger-stream:
+    env:
+      RUST_LOG: "interledger=trace"
+      RUST_BACKTRACE: "full"
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install rust toolchain
+        uses: hecrj/setup-rust-action@v1.3.4
+        with:
+          rust-version: stable
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Test
+        run: timeout 15m cargo test -p interledger-stream
+      - name: Test --features strict
+        run: timeout 15m cargo test -p interledger-stream --features strict
+      - name: Test --features roundtrip-only
+        run: timeout 15m cargo test -p interledger-stream --features roundtrip-only
+
+  interledger-btp:
+    env:
+      RUST_LOG: "interledger=trace"
+      RUST_BACKTRACE: "full"
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install rust toolchain
+        uses: hecrj/setup-rust-action@v1.3.4
+        with:
+          rust-version: stable
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Test
+        run: timeout 15m cargo test -p interledger-btp
+      - name: Test --features strict
+        run: timeout 15m cargo test -p interledger-btp --features strict
 
   test-md:
     runs-on: ubuntu-latest

--- a/scripts/run-md-test.sh
+++ b/scripts/run-md-test.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# Runs the examples listed in the READMEs from `examples/*/README.md`.
+#
+# Requires additional runtime dependencies as listed in those READMEs.
+#
+# The code snippets and comments are parsed by `parse-md.sh` and can
+# essentially be split into two sections:
+#   1: binary aquisition
+#   2: test execution
+#
+# (1) is controlled by the `SOURCE_MODE` parameter in the READMEs and
+# is set by the second flag passed to this script ($2).
+#
+# Note: although the README scripts check for the binaries existance
+#       before re-downloading (SOURCE_MODE != 1), this script deletes
+#       the binaries before each run.
+#
+# Has two parameters:
+#   $1 = test name filter
+#   $2 = source mode flag
+#      1: build binaries from source
+#      *: download binaries as releases
+
 
 function clear_environment() {
     clear_logs


### PR DESCRIPTION
This PR adds dependency caching to the CI workflow, dramatically speeding up builds (after the first one). Note: does not include the docker workflow -- may be of interest too (?) but I'm not sure how it could work.

Also adds `workflow_dispatch` trigger, which will let us manually trigger the workflow. Mainly useful for testing on forks without having to fiddle with the workflow file.

Uses the [rust-cache action](https://github.com/Swatinem/rust-cache). We could try manually figure out which parts of `/target` to cache, but I found it difficult and prone to error. This action seems to do the right thing and ends up caching about 2 GB total with the way I have it setup (multiple jobs, with independent caches).

It may be possible to further optimize the cache by sharing amongst the jobs, but I'm not quite certain how.

What I found surprising is that the `clippy` check is so slow -- it seems to be checking *all* depedencies. Might be worth investigating. I did a small search which turned up the `--no-deps` option but it didn't change anything for me. This is only for a non-cached run -- since the cache will include the dependency clippy checks for the next run.

Comparison between runs:
| Run  | Duration | Cumulative time |
| --- | --- | --- |
| [before](https://github.com/interledger-rs/interledger-rs/actions/runs/1093773784) | 17m 39s | 33m 37s |
| [no cache](https://github.com/Mirko-von-Leipzig/interledger-rs/actions/runs/1104556424) | 12m 51s | 30m 1s |
| [cache](https://github.com/Mirko-von-Leipzig/interledger-rs/actions/runs/1104557123) | 7m 54s | 15m 47s |

Cache size per job:
| Job | Cache |
| --- | --- |
| Interledger | ~440 MB |
| Interledger-packet | ~166 MB |
| Interledger-stream | ~251 MB |
| Interledger-btp | ~294 MB |
| Settlement-engines | ~364 MB |
| test-md | ~335 MB |
| **Total** | **~1.85 GB** |

Some restrictions on [github action caching](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy):
- maximum size of 5GB *total* per repo - replaces oldest cache automatically on overflow
- gets cleared automatically after 7 days of inactivity