### PR TITLE
ci: add commit checks for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,8 @@ jobs:
         # 1. spin: is no longer actively maintained
         # 2. sized-chunks: no safe upgrade.
         # 3. net2: has been removed from crates, still present as a dep to tokio
-        run: cargo audit --ignore RUSTSEC-2019-0031 --ignore RUSTSEC-2020-0041 --ignore RUSTSEC-2020-0016
+        # 4. hyper: requires 18 exabytes of data transfer, can be removed with tokio 1.0 upgrade
+        run: cargo audit --ignore RUSTSEC-2019-0031 --ignore RUSTSEC-2020-0041 --ignore RUSTSEC-2020-0016 --ignore RUSTSEC-2021-0078 --ignore RUSTSEC-2021-0079
 
       - name: Test
         run: timeout 15m cargo test --all --all-features

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -1,0 +1,69 @@
+# Checks all commits in a PR follow the repo rules:
+#
+#   1. conventional commit messages
+#   2. used `git commit --signoff`
+#   3. no extra merge commits
+name: Commits
+
+on:
+  workflow_dispatch:
+  # Perform these checks on PRs into *any* branch.
+  #
+  # Motivation:
+  #   Commits which are not --signoff but merged into other branches
+  #   will likely make their way into PRs for master. At which
+  #   point it will be difficult to get the original author to --signoff.
+  pull_request:
+
+jobs:
+  commit-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set commit range variables
+        # Finding the commit range is not as trivial as it may seem.
+        #
+        # At this stage git's HEAD does not refer to the latest commit in the PR,
+        # but rather to the merge commit inserted by the PR. So instead we have
+        # to get 'HEAD' from the PR event.
+        #
+        # One cannot use the number of commits (github.event.pull_request.commits)
+        # to find the start commit i.e. HEAD~N does not work, this breaks if there
+        # are merge commits.
+        run: |
+          echo "PR_HEAD=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+          echo "PR_BASE=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
+
+      - name: Install conventional-commit linter
+        run: |
+          # Intall the linter and the conventional commits config
+          npm install @commitlint/config-conventional @commitlint/cli
+
+          # Extend the conventional commits config with the `--signoff`
+          # requirement.
+          echo "module.exports = {
+            extends: ['@commitlint/config-conventional'],
+            rules: {
+              'signed-off-by': [2, 'always', 'Signed-off-by:'],
+            }
+          }" > commitlint.config.js
+
+      - name: Conventional commit check
+        run: |
+          npx commitlint --from $PR_BASE --to $PR_HEAD
+
+      - name: No merge commits
+        run: |
+          # This will list any merge commits in the PR commit path
+          MERGE=$(git log --merges --ancestry-path $PR_BASE..$PR_HEAD)
+
+          # The merge list should be empty
+          [[ ! -z "$MERGE" ]] && {
+            echo "PR contains merge commits:";
+            echo $MERGE;
+            exit 1;
+          }
+          exit 0;

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Before diving in to Interledger.rs, you may find it helpful to familiarize yours
 ## Pull Requests
 We welcome pull requests (PRs) that address reported issues. You can find appropriate issues by `bug` or `help-wanted` labels. To avoid multiple PRs for a single issue, please let us know that you are working on it by a comment for the issue. Also we recommend to make discussions on the issue of how to address the issue, methodology towards the resolution or the architecture of your code, in order to avoid writing inefficient or inappropriate code.
 
-Please follow the instruction below when making pull requests.
+Please follow the instruction below when making pull requests. These will be checked by our PR CI process where applicable, so don't worry about getting it wrong.
 
 - Make sure that your branch is forked from the latest `master` branch.
 - Make sure that you wrote tests, ran it and the results were all green (required to pass CI).
@@ -47,10 +47,10 @@ Please follow the instruction below when making pull requests.
     - To install clippy, run `rustup component add clippy`.
     - To run clippy, use `cargo clippy --all-targets --all-features -- -D warnings`.
     - If you would like to make your local setup reject unformatted commits, you can add the command as a pre-commit hook in the file `interledger-rs/.git/hooks/pre-commit`.
-- Make sure to commit using `-s` or `--signoff` option like `git cz -s`.
+- Make sure to commit using `-s` or `--signoff` option like `git cz -s` (required to pass CI).
     - `cz` means using the [commitizen](https://github.com/commitizen/cz-cli) explained below.
     - Why we use the option is explained later in the [Signing-off](#Signing-off) section.
-- Make sure that you committed using the [commitizen](https://github.com/commitizen/cz-cli) format (commit messages should start with `feat:`, `docs:`, `refactor:`, `chore:`, etc). PRs may contain multiple commits but they should generally be squashed into one or a small number of complete change sets (for example, a feature followed by multiple refactors and another commit to add tests and docs should be combined into a single commit for that feature).
+- Make sure that you committed using the [commitizen](https://github.com/commitizen/cz-cli) format (commit messages should start with `feat:`, `docs:`, `refactor:`, `chore:`, etc) (required to pass CI). PRs may contain multiple commits but they should generally be squashed into one or a small number of complete change sets (for example, a feature followed by multiple refactors and another commit to add tests and docs should be combined into a single commit for that feature).
     - If you would like to make your local setup reject improperly formatted commit headers, you can add the following code to `interledger-rs/.git/hooks/commit-msg`:
 ```bash
 if head -n 1 "$1" | grep -vqE "^(feat|fix|docs|style|refactor|perf|test|chore|ci|build)(\(.{1,30}\))?:[ ].{5,100}$"; then
@@ -58,6 +58,7 @@ if head -n 1 "$1" | grep -vqE "^(feat|fix|docs|style|refactor|perf|test|chore|ci
 fi
 ```
 - Make pull requests against `master` branch of this repository (interledger-rs/interledger-rs) from your repository.
+- The pull request should contain no merge commits (required to pass CI).
 - If reviewers request some changes, please follow the instruction or make discussions if you have any constructive opinions on the PRs you made.
     - Then if you want to make some changes on your PRs, `push -f` is allowed to renew your branch after squashing your new commits. You don't need to open new PRs.
 - For our [examples](../examples/README.md), we adopted a [literate programming](https://en.wikipedia.org/wiki/Literate_programming) approach. The examples are described in Markdown with shell commands included. The [`run-md.sh`](../scripts/run-md.sh) script parses the commands out of the Markdown file and runs them. If you want to add examples, please make sure your instruction file can be parsed and run by that script.


### PR DESCRIPTION
This PR introduces a new github workflow which ensures all commits in a PR conform to our requirements. It checks for the following:

1. conventional commit messages
2. used `git commit --signoff`
3. no extra merge commits

### Conventional commits and `--signoff`

The first two points are taken care of by the NPM [`commitlint`](https://github.com/conventional-changelog/commitlint) package. Unfortunately, they provide guides for CircleCI and TravisCI but not for Github Actions ([open issue](https://github.com/conventional-changelog/commitlint/issues/586)). I managed to get it working after some trial and error. 

There is a 3rd party Github Action which looks great, but unfortunately I ran into [this bug](https://github.com/wagoid/commitlint-github-action/issues/187). It also seemed like a lot of code to audit, considering we don't need much.

Another alternative could be to use [`git interpret-trailers`](https://git-scm.com/docs/git-interpret-trailers) to check for `--signoff`, but since this came bundled with `commitlint` I didn't explore further.

### no extra merge commits

This gets checked with some simple bash code walking the PR commits using `git log --merges --ancestry-path`. Luckily the Github PR event contains the `HEAD` and number of commits in the PR.

### Why a new workflow file?

It has different run `on` requirements and therefore requires its own file (I think?).

It made sense to me that it should only run on actual PRs. It would otherwise trigger (and probably fail) when wanting to test things quickly.

I also enabled it for PRs into any branch (and not just into master), since its likely the code would eventually make its way into a PR for `master`, but by that time it may be too late to get the commit requirements fixed.

### cargo audit

I've also added in the ignore for the two hyper RUSTSECs.