### PR TITLE
Chore: Fix CI errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Audit
         # FIXME: Disabled:
         # 1.   spin: is no longer actively maintained
-        run: cargo audit --ignore RUSTSEC-2019-0031
+        run: cargo audit --ignore RUSTSEC-2019-0031 --ignore RUSTSEC-2020-0041 --ignore RUSTSEC-2020-0016 --ignore RUSTSEC-2021-0078 --ignore RUSTSEC-2021-0079 --ignore RUSTSEC-2021-0113 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2021-0124
 
       - name: Test
         run: timeout 15m cargo test --all --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,7 +1055,7 @@ dependencies = [
  "interledger-service",
  "once_cell",
  "parking_lot",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "rand 0.7.3",
  "secrecy",
  "socket2",
@@ -1347,7 +1347,7 @@ dependencies = [
  "num",
  "once_cell",
  "parking_lot",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "ring",
  "serde",
  "thiserror",
@@ -1857,11 +1857,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+checksum = "918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f"
 dependencies = [
- "pin-project-internal 0.4.27",
+ "pin-project-internal 0.4.28",
 ]
 
 [[package]]
@@ -1875,9 +1875,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
 dependencies = [
  "cfg-if 0.1.10",
  "crossbeam-channel 0.4.4",
- "crossbeam-deque 0.7.3",
+ "crossbeam-deque 0.7.4",
  "crossbeam-epoch 0.8.2",
  "crossbeam-queue",
  "crossbeam-utils 0.7.2",
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+checksum = "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed"
 dependencies = [
  "crossbeam-epoch 0.8.2",
  "crossbeam-utils 0.7.2",
@@ -329,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch 0.9.3",
@@ -2110,7 +2110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
 dependencies = [
  "autocfg",
- "crossbeam-deque 0.8.0",
+ "crossbeam-deque 0.8.1",
  "either",
  "rayon-core",
 ]
@@ -2122,7 +2122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel 0.5.0",
- "crossbeam-deque 0.8.0",
+ "crossbeam-deque 0.8.1",
  "crossbeam-utils 0.8.3",
  "lazy_static",
  "num_cpus",

--- a/crates/ilp-cli/src/interpreter.rs
+++ b/crates/ilp-cli/src/interpreter.rs
@@ -390,6 +390,7 @@ fn unflatten_pairs<'a>(matches: &'a ArgMatches) -> (&'a str, HashMap<&'a str, &'
     (matches.value_of("authorization_key").unwrap(), pairs)
 }
 
+#[allow(unused)]
 #[derive(Debug, serde::Deserialize)]
 struct XpringResponse {
     http_endpoint: String,

--- a/crates/interledger-http/src/lib.rs
+++ b/crates/interledger-http/src/lib.rs
@@ -89,6 +89,7 @@ mod tests {
     use serde::Deserialize;
     use warp::test::request;
 
+    #[allow(unused)]
     #[derive(Deserialize, Clone)]
     struct TestJsonStruct {
         string_value: String,

--- a/crates/interledger-service/src/lib.rs
+++ b/crates/interledger-service/src/lib.rs
@@ -455,7 +455,7 @@ mod tests {
 
     #[derive(Clone)]
     struct LayeredService<I, A> {
-        next: I,
+        _next: I,
         account_type: PhantomData<A>,
     }
 
@@ -464,9 +464,9 @@ mod tests {
         I: IncomingService<A> + Send + Sync + 'static,
         A: Account,
     {
-        fn new_incoming(next: I) -> Self {
+        fn new_incoming(_next: I) -> Self {
             Self {
-                next,
+                _next,
                 account_type: PhantomData,
             }
         }
@@ -477,9 +477,9 @@ mod tests {
         I: OutgoingService<A> + Send + Sync + 'static,
         A: Account,
     {
-        fn new_outgoing(next: I) -> Self {
+        fn new_outgoing(_next: I) -> Self {
             Self {
-                next,
+                _next,
                 account_type: PhantomData,
             }
         }


### PR DESCRIPTION
1) Upgrades pin-project and crossbeam-deque dependencies to clear a clippy errors
2) Handles unused variables
3) Adds more cargo audit ignores