### PR TITLE
Require unicase >= 2.6 to ensure correct username comparison

### DIFF
--- a/crates/interledger-service/Cargo.toml
+++ b/crates/interledger-service/Cargo.toml
@@ -19,7 +19,7 @@ futures = { version = "0.3.7", default-features = false }
 serde = { version = "1.0.101", default-features = false, features = ["derive"] }
 regex = { version = "1.3.1", default-features = false, features = ["std", "unicode-perl"] }
 once_cell = { version = "1.3.1", default-features = false, features = ["std"] }
-unicase = { version = "2.5.1", default-features = false }
+unicase = { version = "2.6.0", default-features = false }
 unicode-normalization = { version = "0.1.8", default-features = false }
 uuid = { version = "0.8.1", default-features = false}
 async-trait = { version = "0.1.22", default-features = false }

--- a/crates/interledger-service/src/username.rs
+++ b/crates/interledger-service/src/username.rs
@@ -98,6 +98,14 @@ mod tests {
     }
 
     #[test]
+    fn comparison_works() {
+        assert_ne!(
+            Username::from_str("ẽfoobara").unwrap(),
+            Username::from_str("ẽFoObAr").unwrap()
+        );
+    }
+
+    #[test]
     fn too_long_name() {
         assert!(Username::from_str("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").is_err());
     }


### PR DESCRIPTION
When using unicase 2.5.1 the username comparison is not correct and substrings are considered equal due to https://github.com/seanmonstar/unicase/issues/38.

Requiring 2.6.0 (which is already used in the `Cargo.lock`) prevents the problem.